### PR TITLE
Plan 01 — Task 5: Result<T,E> via TDD

### DIFF
--- a/src/result/index.ts
+++ b/src/result/index.ts
@@ -1,0 +1,15 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+export {
+  type Result,
+  type Ok,
+  type Err,
+  ok,
+  err,
+  isOk,
+  isErr,
+  map,
+  mapErr,
+  flatMap,
+  unwrapOr,
+  expectOk,
+} from "./result";

--- a/src/result/result.test.ts
+++ b/src/result/result.test.ts
@@ -1,0 +1,90 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { describe, expect, it } from "vitest";
+import { err, isErr, isOk, ok } from "./result";
+import { map } from "./result";
+import { flatMap, mapErr, unwrapOr } from "./result";
+import { expectOk } from "./result";
+
+describe("Result — construction and narrowing", () => {
+  it("ok() wraps a value and isOk narrows it", () => {
+    const r = ok(42);
+    expect(isOk(r)).toBe(true);
+    expect(isErr(r)).toBe(false);
+    if (isOk(r)) {
+      expect(r.value).toBe(42);
+    }
+  });
+
+  it("err() wraps an error and isErr narrows it", () => {
+    const r = err({ kind: "boom" } as const);
+    expect(isErr(r)).toBe(true);
+    expect(isOk(r)).toBe(false);
+    if (isErr(r)) {
+      expect(r.error.kind).toBe("boom");
+    }
+  });
+});
+
+describe("Result — map", () => {
+  it("transforms an Ok value", () => {
+    const r = map(ok(2), (n) => n * 3);
+    expect(r).toEqual({ ok: true, value: 6 });
+  });
+
+  it("passes Err through unchanged", () => {
+    const r = map(err("bad" as const), (n: number) => n * 3);
+    expect(r).toEqual({ ok: false, error: "bad" });
+  });
+});
+
+describe("Result — mapErr", () => {
+  it("transforms an Err", () => {
+    const r = mapErr(err("low" as const), (s) => s.toUpperCase());
+    expect(r).toEqual({ ok: false, error: "LOW" });
+  });
+
+  it("passes Ok through unchanged", () => {
+    const r = mapErr(ok(5), (s: string) => s.toUpperCase());
+    expect(r).toEqual({ ok: true, value: 5 });
+  });
+});
+
+describe("Result — flatMap", () => {
+  it("chains Ok into another Result", () => {
+    const parse = (s: string) => (/^\d+$/.test(s) ? ok(Number(s)) : err("nope" as const));
+    const r = flatMap(ok("42"), parse);
+    expect(r).toEqual({ ok: true, value: 42 });
+  });
+
+  it("short-circuits on Err", () => {
+    const parse = (s: string) => ok(Number(s));
+    const r = flatMap(err("bad" as const), parse);
+    expect(r).toEqual({ ok: false, error: "bad" });
+  });
+
+  it("propagates downstream Err", () => {
+    const parse = (_: string) => err("downstream" as const);
+    const r = flatMap(ok("x"), parse);
+    expect(r).toEqual({ ok: false, error: "downstream" });
+  });
+});
+
+describe("Result — unwrapOr", () => {
+  it("returns value for Ok", () => {
+    expect(unwrapOr(ok(7), 0)).toBe(7);
+  });
+
+  it("returns fallback for Err", () => {
+    expect(unwrapOr(err("bad"), 0)).toBe(0);
+  });
+});
+
+describe("Result — expectOk", () => {
+  it("returns value when Ok", () => {
+    expect(expectOk(ok(9))).toBe(9);
+  });
+
+  it("throws a descriptive error when Err", () => {
+    expect(() => expectOk(err({ kind: "nope" }))).toThrow(/expectOk/);
+  });
+});

--- a/src/result/result.ts
+++ b/src/result/result.ts
@@ -1,0 +1,45 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+export type Ok<T> = { readonly ok: true; readonly value: T };
+export type Err<E> = { readonly ok: false; readonly error: E };
+export type Result<T, E> = Ok<T> | Err<E>;
+
+export function ok<T>(value: T): Ok<T> {
+  return { ok: true, value };
+}
+
+export function err<E>(error: E): Err<E> {
+  return { ok: false, error };
+}
+
+export function isOk<T, E>(r: Result<T, E>): r is Ok<T> {
+  return r.ok;
+}
+
+export function isErr<T, E>(r: Result<T, E>): r is Err<E> {
+  return !r.ok;
+}
+
+export function map<T, U, E>(r: Result<T, E>, fn: (value: T) => U): Result<U, E> {
+  return r.ok ? ok(fn(r.value)) : r;
+}
+
+export function mapErr<T, E, F>(r: Result<T, E>, fn: (error: E) => F): Result<T, F> {
+  return r.ok ? r : err(fn(r.error));
+}
+
+export function flatMap<T, U, E, F>(
+  r: Result<T, E>,
+  fn: (value: T) => Result<U, F>,
+): Result<U, E | F> {
+  return r.ok ? fn(r.value) : r;
+}
+
+export function unwrapOr<T, E>(r: Result<T, E>, fallback: T): T {
+  return r.ok ? r.value : fallback;
+}
+
+export function expectOk<T, E>(r: Result<T, E>): T {
+  if (r.ok) return r.value;
+  throw new Error(`expectOk: received Err(${JSON.stringify(r.error)})`);
+}


### PR DESCRIPTION
Closes #6

Implements `Result<T,E>` using strict TDD: four red-green cycles, each test written and confirmed failing before implementation.

- **13 tests** across 4 cycles: construction/narrowing, `map`, `mapErr`/`flatMap`/`unwrapOr`, and `expectOk`
- `src/result/**` coverage: 100% lines, 100% branches (thresholds: 90% lines / 85% branches)
- `pnpm typecheck`, `pnpm lint`, and `pnpm test` all clean