### PR TITLE
Plan 01 — Task 6: URL-synced AppState via TDD

### DIFF
--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -1,0 +1,9 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+export {
+  type AppState,
+  type Observer,
+  type StateParseError,
+  DEFAULT_STATE,
+  parseStateFromSearchParams,
+  serializeStateToSearchParams,
+} from "./state";

--- a/src/state/state.test.ts
+++ b/src/state/state.test.ts
@@ -1,0 +1,75 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { describe, expect, it } from "vitest";
+import { expectOk, isErr, isOk } from "../result";
+import { DEFAULT_STATE, parseStateFromSearchParams, serializeStateToSearchParams } from "./state";
+
+describe("AppState — defaults", () => {
+  it("has observer at (0, 0) and a valid timeUtc", () => {
+    expect(DEFAULT_STATE.observer.lat).toBe(0);
+    expect(DEFAULT_STATE.observer.lon).toBe(0);
+    expect(DEFAULT_STATE.timeUtc).toBeInstanceOf(Date);
+    expect(Number.isFinite(DEFAULT_STATE.timeUtc.getTime())).toBe(true);
+  });
+});
+
+describe("AppState — parse from URLSearchParams", () => {
+  it("returns defaults when all params are absent", () => {
+    const r = parseStateFromSearchParams(new URLSearchParams());
+    expect(isOk(r)).toBe(true);
+    const s = expectOk(r);
+    expect(s.observer.lat).toBe(DEFAULT_STATE.observer.lat);
+    expect(s.observer.lon).toBe(DEFAULT_STATE.observer.lon);
+  });
+
+  it("parses valid lat/lon/t", () => {
+    const params = new URLSearchParams({
+      lat: "37.7749",
+      lon: "-122.4194",
+      t: "2026-04-15T12:00:00.000Z",
+    });
+    const s = expectOk(parseStateFromSearchParams(params));
+    expect(s.observer.lat).toBeCloseTo(37.7749, 4);
+    expect(s.observer.lon).toBeCloseTo(-122.4194, 4);
+    expect(s.timeUtc.toISOString()).toBe("2026-04-15T12:00:00.000Z");
+  });
+
+  it("returns Err for out-of-range latitude", () => {
+    const r = parseStateFromSearchParams(new URLSearchParams({ lat: "95" }));
+    expect(isErr(r)).toBe(true);
+    if (isErr(r)) expect(r.error.kind).toBe("lat-out-of-range");
+  });
+
+  it("returns Err for out-of-range longitude", () => {
+    const r = parseStateFromSearchParams(new URLSearchParams({ lon: "-200" }));
+    expect(isErr(r)).toBe(true);
+    if (isErr(r)) expect(r.error.kind).toBe("lon-out-of-range");
+  });
+
+  it("returns Err for non-numeric latitude", () => {
+    const r = parseStateFromSearchParams(new URLSearchParams({ lat: "abc" }));
+    expect(isErr(r)).toBe(true);
+    if (isErr(r)) expect(r.error.kind).toBe("lat-not-a-number");
+  });
+
+  it("returns Err for invalid ISO timestamp", () => {
+    const r = parseStateFromSearchParams(new URLSearchParams({ t: "not-a-date" }));
+    expect(isErr(r)).toBe(true);
+    if (isErr(r)) expect(r.error.kind).toBe("time-invalid");
+  });
+});
+
+describe("AppState — serialize", () => {
+  it("round-trips a known state", () => {
+    const params = new URLSearchParams({
+      lat: "10",
+      lon: "20",
+      t: "2030-01-01T00:00:00.000Z",
+    });
+    const s = expectOk(parseStateFromSearchParams(params));
+    const out = serializeStateToSearchParams(s);
+    const s2 = expectOk(parseStateFromSearchParams(out));
+    expect(s2.observer.lat).toBe(s.observer.lat);
+    expect(s2.observer.lon).toBe(s.observer.lon);
+    expect(s2.timeUtc.toISOString()).toBe(s.timeUtc.toISOString());
+  });
+});

--- a/src/state/state.ts
+++ b/src/state/state.ts
@@ -1,0 +1,80 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { err, ok, type Result } from "../result";
+
+export type Observer = { readonly lat: number; readonly lon: number };
+
+export type AppState = {
+  readonly observer: Observer;
+  readonly timeUtc: Date;
+};
+
+export type StateParseError =
+  | { kind: "lat-not-a-number"; raw: string }
+  | { kind: "lat-out-of-range"; value: number }
+  | { kind: "lon-not-a-number"; raw: string }
+  | { kind: "lon-out-of-range"; value: number }
+  | { kind: "time-invalid"; raw: string };
+
+export const DEFAULT_STATE: AppState = {
+  observer: { lat: 0, lon: 0 },
+  timeUtc: new Date("2026-04-15T00:00:00.000Z"),
+};
+
+function parseLat(raw: string): Result<number, StateParseError> {
+  const n = Number(raw);
+  if (!Number.isFinite(n)) return err({ kind: "lat-not-a-number", raw });
+  if (n < -90 || n > 90) return err({ kind: "lat-out-of-range", value: n });
+  return ok(n);
+}
+
+function parseLon(raw: string): Result<number, StateParseError> {
+  const n = Number(raw);
+  if (!Number.isFinite(n)) return err({ kind: "lon-not-a-number", raw });
+  if (n < -180 || n > 180) return err({ kind: "lon-out-of-range", value: n });
+  return ok(n);
+}
+
+function parseTime(raw: string): Result<Date, StateParseError> {
+  const d = new Date(raw);
+  if (Number.isNaN(d.getTime())) return err({ kind: "time-invalid", raw });
+  return ok(d);
+}
+
+export function parseStateFromSearchParams(
+  params: URLSearchParams,
+): Result<AppState, StateParseError> {
+  let lat = DEFAULT_STATE.observer.lat;
+  let lon = DEFAULT_STATE.observer.lon;
+  let timeUtc = DEFAULT_STATE.timeUtc;
+
+  const rawLat = params.get("lat");
+  if (rawLat !== null) {
+    const r = parseLat(rawLat);
+    if (!r.ok) return r;
+    lat = r.value;
+  }
+
+  const rawLon = params.get("lon");
+  if (rawLon !== null) {
+    const r = parseLon(rawLon);
+    if (!r.ok) return r;
+    lon = r.value;
+  }
+
+  const rawT = params.get("t");
+  if (rawT !== null) {
+    const r = parseTime(rawT);
+    if (!r.ok) return r;
+    timeUtc = r.value;
+  }
+
+  return ok({ observer: { lat, lon }, timeUtc });
+}
+
+export function serializeStateToSearchParams(state: AppState): URLSearchParams {
+  const params = new URLSearchParams();
+  params.set("lat", String(state.observer.lat));
+  params.set("lon", String(state.observer.lon));
+  params.set("t", state.timeUtc.toISOString());
+  return params;
+}


### PR DESCRIPTION
Closes #7

Implements URL-synced `AppState` (observer lat/lon + timeUtc) with a `Result`-based parser and serializer. All 8 new tests pass; total project tests: 22 (13 result + 8 state + 1 smoke). `src/state/` coverage: 100% statements/lines/functions, 96.15% branches — above the 90%/85% thresholds. `pnpm typecheck` and `pnpm lint` both clean.