### PR TITLE
Plan 01 — Task 7: Wire app.ts to state + delete smoke test

### DIFF
--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -1,0 +1,35 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { describe, expect, it } from "vitest";
+import { bootstrap } from "./app";
+
+describe("bootstrap", () => {
+  it("renders observer + time text into the root element", () => {
+    const root = document.createElement("main");
+    const params = new URLSearchParams({
+      lat: "34.05",
+      lon: "-118.25",
+      t: "2026-04-15T03:30:00.000Z",
+    });
+    bootstrap(root, params);
+    expect(root.textContent).toContain("34.05");
+    expect(root.textContent).toContain("-118.25");
+    expect(root.textContent).toContain("2026-04-15T03:30:00.000Z");
+  });
+
+  it("renders an error message when params are invalid", () => {
+    const root = document.createElement("main");
+    bootstrap(root, new URLSearchParams({ lat: "999" }));
+    expect(root.textContent).toMatch(/lat-out-of-range/);
+  });
+
+  it("does nothing when root is null", () => {
+    expect(() => bootstrap(null, new URLSearchParams())).not.toThrow();
+  });
+
+  it("uses default URLSearchParams when params arg is omitted", () => {
+    const root = document.createElement("main");
+    // In jsdom, location.search is "" by default, so it parses as default state
+    bootstrap(root);
+    expect(root.textContent).toContain("Planisphere");
+  });
+});

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,6 +1,16 @@
 /* SPDX-License-Identifier: Apache-2.0 */
+import { parseStateFromSearchParams } from "./state";
 
-export function bootstrap(root: HTMLElement | null): void {
+export function bootstrap(
+  root: HTMLElement | null,
+  params: URLSearchParams = new URLSearchParams(globalThis.location?.search ?? ""),
+): void {
   if (!root) return;
-  root.textContent = "Planisphere — foundation online.";
+  const r = parseStateFromSearchParams(params);
+  if (!r.ok) {
+    root.textContent = `Planisphere — state error: ${r.error.kind}`;
+    return;
+  }
+  const { observer, timeUtc } = r.value;
+  root.textContent = `Planisphere — observer (${observer.lat}, ${observer.lon}) @ ${timeUtc.toISOString()}`;
 }

--- a/src/smoke.test.ts
+++ b/src/smoke.test.ts
@@ -1,8 +1,0 @@
-/* SPDX-License-Identifier: Apache-2.0 */
-import { describe, expect, it } from "vitest";
-
-describe("smoke", () => {
-  it("runs the test runner", () => {
-    expect(1 + 1).toBe(2);
-  });
-});


### PR DESCRIPTION
Closes #8

## Summary

- Replaced `src/app.ts` placeholder with a real `bootstrap` function that parses `URLSearchParams` via `parseStateFromSearchParams` and renders observer + time text (or an error message) into the root element.
- Created `src/app.test.ts` with 4 tests covering the happy path, error path, null-root guard, and default-params branch.
- Deleted `src/smoke.test.ts` (temporary scaffold from Task 4).

## TDD confirmation

Tests were written first and failed correctly (2/3 failed) before `app.ts` was updated. After the implementation, all tests went green.

An additional 4th test was required: the initial 3 tests left the `params` default-expression branch (line 6) uncovered at 66.66%, below the 70% threshold. Adding a test that calls `bootstrap(root)` without the second argument (exercising the `globalThis.location?.search` default) brought branch coverage to 85.71%.

## `pnpm test:cov` final output

```
 RUN  v2.1.9 /Users/sartin/code/planisphere/.worktrees/task-01-07-app-wire
      Coverage enabled with v8

 ✓ src/result/result.test.ts (13 tests) 3ms
 ✓ src/app.test.ts (4 tests) 3ms
 ✓ src/state/state.test.ts (8 tests) 3ms

 Test Files  3 passed (3)
      Tests  25 passed (25)
   Start at  20:54:24
   Duration  506ms (transform 35ms, setup 0ms, collect 55ms, tests 9ms, environment 539ms, prepare 112ms)

 % Coverage report from v8
------------|---------|----------|---------|---------|-------------------
File        | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
------------|---------|----------|---------|---------|-------------------
All files   |     100 |    96.42 |     100 |     100 |                   
 src        |     100 |    85.71 |     100 |     100 |                   
  app.ts    |     100 |    85.71 |     100 |     100 | 6                 
 src/result |     100 |      100 |     100 |     100 |                   
  result.ts |     100 |      100 |     100 |     100 |                   
 src/state  |     100 |    96.66 |     100 |     100 |                   
  state.ts  |     100 |    96.66 |     100 |     100 | 32                
------------|---------|----------|---------|---------|-------------------
```

No threshold failures. Exit code 0. First time `pnpm test:cov` passes.

## Test plan
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm format:check` — All matched files use Prettier code style!
- [x] `pnpm test:cov` — 25 tests pass, all thresholds green
- [x] `pnpm build` — dist built successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)