### PR TITLE
Plan 01 — Task 11: Branch-protection script + runbook

### DIFF
--- a/docs/ops/branch-protection.md
+++ b/docs/ops/branch-protection.md
@@ -1,0 +1,35 @@
+# Branch Protection — `main`
+
+`main` must be locked once Plan 01 lands so the remaining plans land via PR.
+
+## Required protections
+
+- Require a pull request before merging.
+- Require approvals: **1**.
+- Dismiss stale approvals when new commits are pushed.
+- Require status checks to pass before merging:
+  - `typecheck`
+  - `lint`
+  - `test`
+  - `build`
+  - `deploy`
+- Require branches to be up to date before merging.
+- Require linear history.
+- Do not allow force pushes.
+- Do not allow deletions.
+
+## Apply via gh
+
+The script below is idempotent; run it from the repo root:
+
+    bash scripts/protect-main.sh <owner>/<repo>
+
+Requires:
+- `gh` CLI authenticated with admin rights on the repo.
+- CI has already run on `main` at least once so the check names exist.
+
+> **Note:** `deploy` is included in the required status checks. If the deploy
+> workflow (`.github/workflows/deploy.yml`) has not been set up yet, remove
+> `"deploy"` from the `contexts` array in `scripts/protect-main.sh` before
+> running — otherwise branch protection will block all merges because the
+> deploy check will never be reported.

--- a/docs/ops/branch-protection.md
+++ b/docs/ops/branch-protection.md
@@ -25,6 +25,7 @@ The script below is idempotent; run it from the repo root:
     bash scripts/protect-main.sh <owner>/<repo>
 
 Requires:
+
 - `gh` CLI authenticated with admin rights on the repo.
 - CI has already run on `main` at least once so the check names exist.
 

--- a/scripts/protect-main.sh
+++ b/scripts/protect-main.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+set -euo pipefail
+
+REPO="${1:-}"
+if [[ -z "$REPO" ]]; then
+  echo "Usage: $0 <owner>/<repo>" >&2
+  exit 2
+fi
+
+payload=$(cat <<'JSON'
+{
+  "required_status_checks": {
+    "strict": true,
+    "contexts": ["typecheck", "lint", "test", "build", "deploy"]
+  },
+  "enforce_admins": true,
+  "required_pull_request_reviews": {
+    "required_approving_review_count": 1,
+    "dismiss_stale_reviews": true,
+    "require_code_owner_reviews": false
+  },
+  "restrictions": null,
+  "required_linear_history": true,
+  "allow_force_pushes": false,
+  "allow_deletions": false,
+  "required_conversation_resolution": true,
+  "lock_branch": false,
+  "allow_fork_syncing": true
+}
+JSON
+)
+
+echo "$payload" | gh api \
+  --method PUT \
+  -H "Accept: application/vnd.github+json" \
+  "repos/${REPO}/branches/main/protection" \
+  --input -
+
+echo "Branch protection applied to ${REPO}@main."


### PR DESCRIPTION
Closes #12

Adds the branch-protection runbook and idempotent `gh`-backed script that locks `main` once Plan 01 lands.

## Changes

- `docs/ops/branch-protection.md` — runbook listing all required protections, apply instructions, and a note about the `deploy` check (remove it from contexts if Task 10 / deploy workflow hasn't landed yet).
- `scripts/protect-main.sh` — executable shell script that calls the GitHub API via `gh api PUT` to apply the protection rules; includes `deploy` in required status checks per spec.

## Verification

- `bash -n scripts/protect-main.sh` passes (syntax OK).
- `scripts/protect-main.sh` is executable (`-rwxr-xr-x`).
- Single commit with exact message `docs(ops): add branch-protection runbook + gh script`.