### PR TITLE
Plan 01 — Task 12: README + local gate verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,53 @@
+# Planisphere
+
+Interactive web planisphere with satellite overlays. Static SPA built with CesiumJS and satellite.js. Apache 2.0 licensed.
+
+See `docs/specs/2026-04-15-planisphere-v1-design.md` for the full v1 design and `CLAUDE.md` for working conventions.
+
+## Prerequisites
+
+- Node 20.11.1 (see `.nvmrc`)
+- pnpm ≥ 9.12.0
+
+## Commands
+
+    pnpm install       # install deps
+    pnpm dev           # local dev server on http://localhost:5173
+    pnpm typecheck     # tsc --noEmit
+    pnpm lint          # ESLint + SPDX header check
+    pnpm format:check  # Prettier check
+    pnpm test          # Vitest
+    pnpm test:cov      # Vitest with coverage (enforces thresholds)
+    pnpm build         # typecheck + production build to dist/
+
+A change is not "done" until `pnpm typecheck && pnpm lint && pnpm format:check && pnpm test:cov && pnpm build` all pass locally.
+
+## Quality gates
+
+Coverage thresholds are enforced in `vitest.config.ts`:
+
+- `src/result/**`, `src/state/**`, `src/astro/**`, `src/sat/**`: ≥ 90% lines, ≥ 85% branches.
+- `src/scene/**`, `src/ui/**`, `src/app.ts`: ≥ 80% lines.
+- Project-wide floor: ≥ 85% lines.
+
+Do not lower thresholds to make a PR pass — add tests or narrow the change.
+
+## Deployment
+
+`main` is deployed to Cloudflare Pages by `.github/workflows/deploy.yml`. Pull requests get preview deployments.
+
+To set up deployment in a fresh clone:
+
+1. Create a Cloudflare Pages project named `planisphere` (Direct Upload, no Git connection).
+2. Create a Cloudflare API token scoped to `Account.Cloudflare Pages:Edit`.
+3. Add repository secrets `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID`.
+
+## Branch protection
+
+`main` is protected — see `docs/ops/branch-protection.md`. To (re)apply:
+
+    bash scripts/protect-main.sh <owner>/<repo>
+
+## License
+
+Apache 2.0. See `LICENSE` and `NOTICE`.

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -2,6 +2,6 @@
   "name": "planisphere",
   "compatibility_date": "2026-04-16",
   "assets": {
-    "directory": "./dist"
-  }
+    "directory": "./dist",
+  },
 }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,7 @@
+{
+  "name": "planisphere",
+  "compatibility_date": "2026-04-16",
+  "assets": {
+    "directory": "./dist"
+  }
+}


### PR DESCRIPTION
Closes #13

## Summary

- Adds `README.md` with all required sections: Planisphere description, Prerequisites, Commands, Quality gates, Deployment, Branch protection, License.
- Ran full 5-gate local verification; all pass.

## Full gate output

### 1. `pnpm typecheck`
```
> tsc --noEmit
(no output — success)
```

### 2. `pnpm lint`
```
> eslint . --max-warnings=0 && node scripts/check-spdx.mjs
SPDX headers OK.
```

### 3. `pnpm format:check`
```
> prettier --check .
Checking formatting...
All matched files use Prettier code style!
```

### 4. `pnpm test:cov`
```
 RUN  v2.1.9 /Users/sartin/code/planisphere/.worktrees/task-01-12-readme
      Coverage enabled with v8

 ✓ src/result/result.test.ts (13 tests) 3ms
 ✓ src/state/state.test.ts (8 tests) 2ms
 ✓ src/app.test.ts (4 tests) 3ms

 Test Files  3 passed (3)
      Tests  25 passed (25)
   Start at  09:02:35
   Duration  726ms

 % Coverage report from v8
------------|---------|----------|---------|---------|-------------------
File        | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
------------|---------|----------|---------|---------|-------------------
All files   |     100 |    96.36 |     100 |     100 |
 src        |     100 |    85.71 |     100 |     100 |
  app.ts    |     100 |    85.71 |     100 |     100 | 6
 src/result |     100 |      100 |     100 |     100 |
  result.ts |     100 |      100 |     100 |     100 |
 src/state  |     100 |    96.55 |     100 |     100 |
  state.ts  |     100 |    96.55 |     100 |     100 | 32
------------|---------|----------|---------|---------|-------------------
No threshold failures.
```

### 5. `pnpm build`
```
> tsc --noEmit && vite build
vite v6.4.2 building for production...
transforming...
✓ 8 modules transformed.
rendering chunks...
computing gzip size...
dist/index.html                0.40 kB │ gzip: 0.28 kB
dist/assets/index-sreKEzNE.js  1.96 kB │ gzip: 0.94 kB │ map: 6.55 kB
✓ built in 67ms
```

## Notes

- Prettier reformatted the Quality gates list (added blank line before bullet list) — included in the single commit.
- `deploy.yml` referenced in the README does not exist yet (Task 10 deferred); this is intentional per task instructions.