### PR TITLE
Plan 02 — Task 2: Star catalog type + parser (TDD)

### DIFF
--- a/src/astro/catalog.test.ts
+++ b/src/astro/catalog.test.ts
@@ -1,0 +1,57 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { describe, expect, it } from "vitest";
+import { isErr, isOk, expectOk } from "../result";
+import { parseCatalog } from "./catalog";
+
+const VALID_STARS = [
+  { hip: 32349, ra: 101.2872, dec: -16.7161, mag: -1.46, name: "Sirius" },
+  { hip: 69673, ra: 279.2347, dec: 38.7837, mag: 0.03, name: "Vega" },
+  { hip: 11767, ra: 37.9546, dec: 89.2641, mag: 2.02, name: "Polaris" },
+];
+
+describe("parseCatalog", () => {
+  it("parses a valid star array", () => {
+    const r = parseCatalog(VALID_STARS);
+    expect(isOk(r)).toBe(true);
+    const stars = expectOk(r);
+    expect(stars).toHaveLength(3);
+    expect(stars[0]!.hip).toBe(32349);
+    expect(stars[0]!.name).toBe("Sirius");
+  });
+
+  it("accepts stars without a name field", () => {
+    const data = [{ hip: 1, ra: 0, dec: 0, mag: 5.5 }];
+    const stars = expectOk(parseCatalog(data));
+    expect(stars[0]!.name).toBeUndefined();
+  });
+
+  it("returns Err for non-array input", () => {
+    const r = parseCatalog("not an array");
+    expect(isErr(r)).toBe(true);
+    if (isErr(r)) expect(r.error.kind).toBe("catalog-load-failed");
+  });
+
+  it("returns Err for empty array", () => {
+    const r = parseCatalog([]);
+    expect(isErr(r)).toBe(true);
+    if (isErr(r)) expect(r.error.kind).toBe("catalog-load-failed");
+  });
+
+  it("skips entries with missing hip", () => {
+    const data = [
+      { hip: 32349, ra: 101.2872, dec: -16.7161, mag: -1.46 },
+      { ra: 0, dec: 0, mag: 5.0 },
+    ];
+    const stars = expectOk(parseCatalog(data));
+    expect(stars).toHaveLength(1);
+  });
+
+  it("skips entries with non-numeric mag", () => {
+    const data = [
+      { hip: 32349, ra: 101.2872, dec: -16.7161, mag: -1.46 },
+      { hip: 2, ra: 0, dec: 0, mag: "bright" },
+    ];
+    const stars = expectOk(parseCatalog(data));
+    expect(stars).toHaveLength(1);
+  });
+});

--- a/src/astro/catalog.ts
+++ b/src/astro/catalog.ts
@@ -1,0 +1,40 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { err, ok, type Result } from "../result";
+
+export type StarRecord = {
+  readonly hip: number;
+  readonly ra: number;
+  readonly dec: number;
+  readonly mag: number;
+  readonly name?: string;
+};
+
+export type CatalogLoadError = { kind: "catalog-load-failed"; message: string };
+
+export function parseCatalog(raw: unknown): Result<StarRecord[], CatalogLoadError> {
+  if (!Array.isArray(raw)) {
+    return err({ kind: "catalog-load-failed", message: "Star catalog is not an array" });
+  }
+  if (raw.length === 0) {
+    return err({ kind: "catalog-load-failed", message: "Star catalog is empty" });
+  }
+
+  const stars: StarRecord[] = [];
+  for (const entry of raw) {
+    if (typeof entry !== "object" || entry === null) continue;
+    const e = entry as Record<string, unknown>;
+    const hip = Number(e.hip);
+    const ra = Number(e.ra);
+    const dec = Number(e.dec);
+    const mag = Number(e.mag);
+    if (!Number.isFinite(hip) || hip <= 0) continue;
+    if (!Number.isFinite(ra) || !Number.isFinite(dec) || !Number.isFinite(mag)) continue;
+    const name = typeof e.name === "string" && e.name.length > 0 ? e.name : undefined;
+    stars.push({ hip, ra, dec, mag, ...(name !== undefined ? { name } : {}) });
+  }
+
+  if (stars.length === 0) {
+    return err({ kind: "catalog-load-failed", message: "No valid stars after parsing" });
+  }
+  return ok(stars);
+}


### PR DESCRIPTION
Closes #30

Adds `StarRecord` type and `parseCatalog` function following strict TDD — tests were written and confirmed failing before implementation.

## What shipped

- `src/astro/catalog.ts`: `StarRecord` type, `CatalogLoadError` type, `parseCatalog(raw: unknown): Result<StarRecord[], CatalogLoadError>` — validates unknown input, skips invalid entries, returns typed `Result`
- `src/astro/catalog.test.ts`: 6 tests covering valid parse, optional name field, non-array input, empty array, missing hip, non-numeric mag

## TDD confirmation

Tests were written first and confirmed to fail with `Error: Failed to resolve import "./catalog"` before implementation was added.

## Test results

6/6 tests pass. `pnpm typecheck` and `pnpm lint` pass.

## Strict-mode fixes

Two deviations from plan required by the repo's strict TS config (`exactOptionalPropertyTypes: true`, `noUncheckedIndexedAccess: true`):
- Used conditional spread `...(name !== undefined ? { name } : {})` instead of `name: undefined` to satisfy `exactOptionalPropertyTypes`
- Added `!` non-null assertions on array index access in tests to satisfy `noUncheckedIndexedAccess`
- Removed the unused `StarRecord` type import from the test file (lint: `no-unused-vars`)