### PR TITLE
Plan 02 — Task 4: Coordinate transforms (TDD)

### DIFF
--- a/src/astro/coords.test.ts
+++ b/src/astro/coords.test.ts
@@ -1,0 +1,40 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { describe, expect, it } from "vitest";
+import { raDecToAltAz } from "./coords";
+
+describe("raDecToAltAz", () => {
+  it("places Polaris near zenith from the North Pole", () => {
+    const polaris = { ra: 37.9546, dec: 89.2641 };
+    const northPole = { lat: 89.99, lon: 0 };
+    const time = new Date("2026-06-15T00:00:00Z");
+    const result = raDecToAltAz(polaris.ra, polaris.dec, northPole.lat, northPole.lon, time);
+    expect(result.alt).toBeGreaterThan(85);
+    expect(result.alt).toBeLessThanOrEqual(90);
+  });
+
+  it("places a star at the horizon or below for wrong hemisphere", () => {
+    const acrux = { ra: 186.6496, dec: -63.099 };
+    const northernObs = { lat: 60, lon: 0 };
+    const time = new Date("2026-06-15T00:00:00Z");
+    const result = raDecToAltAz(acrux.ra, acrux.dec, northernObs.lat, northernObs.lon, time);
+    expect(result.alt).toBeLessThan(0);
+  });
+
+  it("returns azimuth in 0-360 range", () => {
+    const sirius = { ra: 101.2872, dec: -16.7161 };
+    const obs = { lat: 33, lon: -117 };
+    const time = new Date("2026-01-15T04:00:00Z");
+    const result = raDecToAltAz(sirius.ra, sirius.dec, obs.lat, obs.lon, time);
+    expect(result.az).toBeGreaterThanOrEqual(0);
+    expect(result.az).toBeLessThan(360);
+  });
+
+  it("altitude is between -90 and +90", () => {
+    const vega = { ra: 279.2347, dec: 38.7837 };
+    const obs = { lat: 40, lon: -74 };
+    const time = new Date("2026-08-01T02:00:00Z");
+    const result = raDecToAltAz(vega.ra, vega.dec, obs.lat, obs.lon, time);
+    expect(result.alt).toBeGreaterThanOrEqual(-90);
+    expect(result.alt).toBeLessThanOrEqual(90);
+  });
+});

--- a/src/astro/coords.ts
+++ b/src/astro/coords.ts
@@ -1,0 +1,21 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { MakeTime, Observer, Horizon } from "astronomy-engine";
+
+export type HorizontalCoord = {
+  readonly alt: number;
+  readonly az: number;
+};
+
+export function raDecToAltAz(
+  raDeg: number,
+  decDeg: number,
+  lat: number,
+  lon: number,
+  time: Date,
+): HorizontalCoord {
+  const astroTime = MakeTime(time);
+  const observer = new Observer(lat, lon, 0);
+  const raHours = raDeg / 15;
+  const result = Horizon(astroTime, observer, raHours, decDeg, "normal");
+  return { alt: result.altitude, az: result.azimuth };
+}


### PR DESCRIPTION
Closes #32

Implements `raDecToAltAz` in `src/astro/coords.ts`, wrapping Astronomy Engine's `Horizon` function to convert RA/Dec (degrees) + observer lat/lon + time into horizontal Alt/Az coordinates.

**Key detail:** RA is stored in degrees in our catalog but Astronomy Engine expects hours; the conversion (`raDeg / 15`) happens at the boundary in `coords.ts`.

**TDD flow:**
1. Wrote `coords.test.ts` with 4 known-answer tests — confirmed they all failed (module not found).
2. Implemented `coords.ts` — discovered `MakeObserver` does not exist in astronomy-engine 2.1.19; the correct API is `new Observer(lat, lon, height)`.
3. All 4 tests pass after fix.

**Tests (4 passing):**
- Polaris altitude >85° from near-North-Pole observer
- Southern star (Acrux) below horizon from lat 60°N
- Azimuth result is in [0, 360)
- Altitude result is in [-90, 90]

`pnpm format:check`, `pnpm lint` — both pass.