### PR TITLE
Plan 02 — Task 5: Magnitude mapping (TDD)

### DIFF
--- a/src/astro/magnitude.test.ts
+++ b/src/astro/magnitude.test.ts
@@ -1,0 +1,43 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { describe, expect, it } from "vitest";
+import { magToVisual } from "./magnitude";
+
+describe("magToVisual", () => {
+  it("returns larger size for brighter stars", () => {
+    const bright = magToVisual(-1.46);
+    const dim = magToVisual(6.0);
+    expect(bright.size).toBeGreaterThan(dim.size);
+  });
+
+  it("returns higher opacity for brighter stars", () => {
+    const bright = magToVisual(0.0);
+    const dim = magToVisual(6.0);
+    expect(bright.opacity).toBeGreaterThan(dim.opacity);
+  });
+
+  it("clamps size to minimum for very faint stars", () => {
+    const faint = magToVisual(6.5);
+    expect(faint.size).toBeGreaterThanOrEqual(3);
+  });
+
+  it("clamps size to maximum for very bright stars", () => {
+    const bright = magToVisual(-2.0);
+    expect(bright.size).toBeLessThanOrEqual(16);
+  });
+
+  it("opacity is always between 0.4 and 1.0", () => {
+    for (const mag of [-1.46, 0, 1, 2, 3, 4, 5, 6]) {
+      const v = magToVisual(mag);
+      expect(v.opacity).toBeGreaterThanOrEqual(0.4);
+      expect(v.opacity).toBeLessThanOrEqual(1.0);
+    }
+  });
+
+  it("mid-range magnitude produces intermediate values", () => {
+    const mid = magToVisual(3.0);
+    expect(mid.size).toBeGreaterThan(3);
+    expect(mid.size).toBeLessThan(16);
+    expect(mid.opacity).toBeGreaterThan(0.4);
+    expect(mid.opacity).toBeLessThan(1.0);
+  });
+});

--- a/src/astro/magnitude.ts
+++ b/src/astro/magnitude.ts
@@ -1,0 +1,28 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+export type StarVisual = {
+  readonly size: number;
+  readonly opacity: number;
+};
+
+const MAG_MIN = -1.5;
+const MAG_MAX = 6.5;
+const SIZE_MIN = 3;
+const SIZE_MAX = 16;
+const OPACITY_MIN = 0.4;
+const OPACITY_MAX = 1.0;
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+function lerp(t: number, a: number, b: number): number {
+  return a + t * (b - a);
+}
+
+export function magToVisual(mag: number): StarVisual {
+  const t = clamp((mag - MAG_MIN) / (MAG_MAX - MAG_MIN), 0, 1);
+  const size = Math.round(lerp(1 - t, SIZE_MIN, SIZE_MAX));
+  const opacity = Math.round(lerp(1 - t, OPACITY_MIN, OPACITY_MAX) * 100) / 100;
+  return { size, opacity };
+}


### PR DESCRIPTION
Closes #33

Implements `magToVisual(mag)` → `{ size, opacity }` with linear interpolation and clamping.

- Magnitude range −1.5 to 6.5 mapped to size 3–16px and opacity 0.4–1.0
- Brighter stars (lower magnitude) get larger size and higher opacity
- Values clamped at both ends — no out-of-range output possible
- 6 TDD tests: brighter=larger, brighter=more opaque, min clamp, max clamp, opacity range, mid-range intermediate values
- All tests confirmed failing before implementation, passing after
- Format check and lint both pass