### PR TITLE
Plan 02 — Task 6: Star visibility filter (TDD)

### DIFF
--- a/src/astro/visibility.test.ts
+++ b/src/astro/visibility.test.ts
@@ -1,0 +1,55 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { describe, expect, it } from "vitest";
+import { filterVisibleStars } from "./visibility";
+import type { StarRecord } from "./catalog";
+
+const CATALOG: StarRecord[] = [
+  { hip: 11767, ra: 37.9546, dec: 89.2641, mag: 2.02, name: "Polaris" },
+  { hip: 32349, ra: 101.2872, dec: -16.7161, mag: -1.46, name: "Sirius" },
+  { hip: 7588, ra: 24.4285, dec: -57.2367, mag: 0.46, name: "Achernar" },
+];
+
+describe("filterVisibleStars", () => {
+  it("includes Polaris for a northern observer", () => {
+    const result = filterVisibleStars(CATALOG, 60, 0, new Date("2026-01-15T22:00:00Z"));
+    const polaris = result.find((s) => s.name === "Polaris");
+    expect(polaris).toBeDefined();
+    expect(polaris!.alt).toBeGreaterThan(0);
+  });
+
+  it("excludes stars below the horizon", () => {
+    const result = filterVisibleStars(CATALOG, 60, 0, new Date("2026-01-15T22:00:00Z"));
+    for (const star of result) {
+      expect(star.alt).toBeGreaterThan(0);
+    }
+  });
+
+  it("each result has size and opacity from magnitude mapping", () => {
+    const result = filterVisibleStars(CATALOG, 33, -117, new Date("2026-01-15T04:00:00Z"));
+    for (const star of result) {
+      expect(star.size).toBeGreaterThanOrEqual(3);
+      expect(star.size).toBeLessThanOrEqual(16);
+      expect(star.opacity).toBeGreaterThanOrEqual(0.4);
+      expect(star.opacity).toBeLessThanOrEqual(1.0);
+    }
+  });
+
+  it("returns AltAzStar with required fields", () => {
+    const result = filterVisibleStars(CATALOG, 33, -117, new Date("2026-01-15T04:00:00Z"));
+    if (result.length > 0) {
+      const s = result[0];
+      expect(s).toHaveProperty("hip");
+      expect(s).toHaveProperty("alt");
+      expect(s).toHaveProperty("az");
+      expect(s).toHaveProperty("mag");
+      expect(s).toHaveProperty("size");
+      expect(s).toHaveProperty("opacity");
+    }
+  });
+
+  it("excludes deeply southern stars from far-north observer", () => {
+    const result = filterVisibleStars(CATALOG, 80, 0, new Date("2026-06-15T00:00:00Z"));
+    const achernar = result.find((s) => s.name === "Achernar");
+    expect(achernar).toBeUndefined();
+  });
+});

--- a/src/astro/visibility.ts
+++ b/src/astro/visibility.ts
@@ -1,0 +1,38 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import type { StarRecord } from "./catalog";
+import { raDecToAltAz } from "./coords";
+import { magToVisual } from "./magnitude";
+
+export type AltAzStar = {
+  readonly hip: number;
+  readonly alt: number;
+  readonly az: number;
+  readonly mag: number;
+  readonly name?: string;
+  readonly size: number;
+  readonly opacity: number;
+};
+
+export function filterVisibleStars(
+  catalog: StarRecord[],
+  lat: number,
+  lon: number,
+  time: Date,
+): AltAzStar[] {
+  const result: AltAzStar[] = [];
+  for (const star of catalog) {
+    const { alt, az } = raDecToAltAz(star.ra, star.dec, lat, lon, time);
+    if (alt <= 0) continue;
+    const { size, opacity } = magToVisual(star.mag);
+    result.push({
+      hip: star.hip,
+      alt,
+      az,
+      mag: star.mag,
+      name: star.name,
+      size,
+      opacity,
+    });
+  }
+  return result;
+}

--- a/src/astro/visibility.ts
+++ b/src/astro/visibility.ts
@@ -29,7 +29,7 @@ export function filterVisibleStars(
       alt,
       az,
       mag: star.mag,
-      name: star.name,
+      ...(star.name !== undefined ? { name: star.name } : {}),
       size,
       opacity,
     });


### PR DESCRIPTION
Closes #34

Implements `filterVisibleStars(catalog, lat, lon, time) → AltAzStar[]` — the full pipeline that converts RA/Dec star records into above-horizon stars with visual properties attached.

## What shipped

- `src/astro/visibility.ts`: `AltAzStar` type + `filterVisibleStars` function. Calls `raDecToAltAz` from `coords.ts` to compute altitude/azimuth, filters out stars at or below the horizon (`alt <= 0`), then attaches `size` and `opacity` from `magToVisual` in `magnitude.ts`.
- `src/astro/visibility.test.ts`: 5 TDD tests covering Polaris visible from north, all results above horizon, size/opacity range validity, required fields present, and southern star (Achernar) excluded from lat 80°N.

## TDD note

Tests were written first and confirmed failing (module not found), then implementation was added, all 5 tests pass.

## Lint/format fix

The plan's test template included an `import type { AltAzStar }` that was never used in the test body. Removed the unused import to satisfy the `@typescript-eslint/no-unused-vars` rule (zero-warning policy).

## Verification

- `pnpm vitest run src/astro/visibility.test.ts`: 5/5 pass
- `pnpm format:check`: clean
- `pnpm lint`: clean (SPDX headers OK, no ESLint warnings)