### PR TITLE
Plan 02 — Task 7: Astro barrel export

### DIFF
--- a/src/astro/index.ts
+++ b/src/astro/index.ts
@@ -1,0 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+export { type StarRecord, type CatalogLoadError, parseCatalog } from "./catalog";
+export { type HorizontalCoord, raDecToAltAz } from "./coords";
+export { type StarVisual, magToVisual } from "./magnitude";
+export { type AltAzStar, filterVisibleStars } from "./visibility";


### PR DESCRIPTION
Closes #35

Barrel export for src/astro/ — re-exports all public types and functions.