### PR TITLE
Plan 02 — Task 8: CesiumJS viewer

### DIFF
--- a/src/scene/viewer.test.ts
+++ b/src/scene/viewer.test.ts
@@ -1,0 +1,42 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { describe, expect, it, vi } from "vitest";
+import { isOk, isErr } from "../result";
+import { createViewer } from "./viewer";
+
+vi.mock("cesium", () => {
+  const MockViewer = vi.fn().mockImplementation(() => ({
+    scene: {
+      skyBox: undefined,
+      skyAtmosphere: undefined,
+      sun: { show: true },
+      moon: { show: true },
+      backgroundColor: { red: 0, green: 0, blue: 0, alpha: 1 },
+      globe: { show: true },
+    },
+    imageryLayers: { removeAll: vi.fn() },
+    destroy: vi.fn(),
+  }));
+
+  return {
+    Viewer: MockViewer,
+    Color: { BLACK: { clone: () => ({ red: 0, green: 0, blue: 0, alpha: 1 }) } },
+    Ion: { defaultAccessToken: "" },
+  };
+});
+
+describe("createViewer", () => {
+  it("returns Ok with a viewer when container exists", () => {
+    const container = document.createElement("div");
+    container.id = "cesium-container";
+    document.body.appendChild(container);
+    const r = createViewer("cesium-container");
+    expect(isOk(r)).toBe(true);
+    document.body.removeChild(container);
+  });
+
+  it("returns Err when container does not exist", () => {
+    const r = createViewer("nonexistent");
+    expect(isErr(r)).toBe(true);
+    if (isErr(r)) expect(r.error.kind).toBe("scene-init-failed");
+  });
+});

--- a/src/scene/viewer.test.ts
+++ b/src/scene/viewer.test.ts
@@ -39,4 +39,19 @@ describe("createViewer", () => {
     expect(isErr(r)).toBe(true);
     if (isErr(r)) expect(r.error.kind).toBe("scene-init-failed");
   });
+
+  it("returns Err when Viewer constructor throws", async () => {
+    const { Viewer } = await import("cesium");
+    const mock = vi.mocked(Viewer);
+    mock.mockImplementationOnce(() => {
+      throw new Error("WebGL not available");
+    });
+    const container = document.createElement("div");
+    container.id = "cesium-throw";
+    document.body.appendChild(container);
+    const r = createViewer("cesium-throw");
+    expect(isErr(r)).toBe(true);
+    if (isErr(r)) expect(r.error.message).toContain("WebGL not available");
+    document.body.removeChild(container);
+  });
 });

--- a/src/scene/viewer.ts
+++ b/src/scene/viewer.ts
@@ -1,0 +1,51 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { Viewer, Color, Ion } from "cesium";
+import { err, ok, type Result } from "../result";
+
+export type SceneInitError = { kind: "scene-init-failed"; message: string };
+
+Ion.defaultAccessToken = "";
+
+export function createViewer(containerId: string): Result<Viewer, SceneInitError> {
+  const container = document.getElementById(containerId);
+  if (!container) {
+    return err({
+      kind: "scene-init-failed",
+      message: `Container element #${containerId} not found`,
+    });
+  }
+
+  try {
+    const viewer = new Viewer(containerId, {
+      animation: false,
+      baseLayerPicker: false,
+      fullscreenButton: false,
+      geocoder: false,
+      homeButton: false,
+      infoBox: false,
+      navigationHelpButton: false,
+      sceneModePicker: false,
+      selectionIndicator: false,
+      timeline: false,
+      skyBox: false,
+      skyAtmosphere: false,
+      orderIndependentTranslucency: false,
+      contextOptions: {
+        webgl: { alpha: false },
+      },
+    });
+
+    viewer.scene.backgroundColor = Color.BLACK.clone();
+    if (viewer.scene.sun) viewer.scene.sun.show = false;
+    if (viewer.scene.moon) viewer.scene.moon.show = false;
+    viewer.scene.globe.show = false;
+    viewer.imageryLayers.removeAll();
+
+    return ok(viewer);
+  } catch (e) {
+    return err({
+      kind: "scene-init-failed",
+      message: `Cesium Viewer creation failed: ${String(e)}`,
+    });
+  }
+}


### PR DESCRIPTION
Closes #36

Implements `createViewer()` in `src/scene/viewer.ts`, which:
- Returns `Result<Viewer, SceneInitError>` — no throws for domain errors
- Disables all UI chrome (timeline, geocoder, home button, etc.)
- Configures a dark sky-dome: black background, sun/moon/globe hidden, imagery layers cleared
- Sets `Ion.defaultAccessToken = ""` (no Ion services used)
- Returns `Err({ kind: "scene-init-failed" })` when the container element is not found

2 tests pass (container exists → Ok, container missing → Err). The plan's mock was adjusted to add `.show` properties to `sun` and `moon` (the plan's original mock had them as `undefined`, but the implementation accesses `.show` to set it to `false`; TypeScript requires a null-guard, which was added). All 48 tests in the suite pass; typecheck, lint, and format:check all clean.