### PR TITLE
Plan 02 — Task 9: Camera setup

### DIFF
--- a/src/scene/camera.test.ts
+++ b/src/scene/camera.test.ts
@@ -1,0 +1,33 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { describe, expect, it, vi } from "vitest";
+import type { Camera } from "cesium";
+import { initCamera } from "./camera";
+
+vi.mock("cesium", () => ({
+  Cartesian3: { fromDegrees: vi.fn().mockReturnValue({ x: 0, y: 0, z: 0 }) },
+  Math: { toRadians: (deg: number) => (deg * Math.PI) / 180 },
+}));
+
+function makeCamera(): { mock: Camera; setView: ReturnType<typeof vi.fn> } {
+  const setView = vi.fn();
+  const mock = { setView } as unknown as Camera;
+  return { mock, setView };
+}
+
+describe("initCamera", () => {
+  it("calls setView with the observer's position looking up", () => {
+    const { mock, setView } = makeCamera();
+    initCamera(mock, 33.0, -117.0);
+    expect(setView).toHaveBeenCalledOnce();
+    const [args] = setView.mock.calls[0] as [Record<string, unknown>];
+    expect(args).toHaveProperty("destination");
+    expect(args).toHaveProperty("orientation");
+  });
+
+  it("orientation pitch points upward (negative = looking up in Cesium)", () => {
+    const { mock, setView } = makeCamera();
+    initCamera(mock, 40.0, -74.0);
+    const [args] = setView.mock.calls[0] as [{ orientation: { pitch: number } }];
+    expect(args.orientation.pitch).toBeLessThan(0);
+  });
+});

--- a/src/scene/camera.ts
+++ b/src/scene/camera.ts
@@ -1,0 +1,15 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { Cartesian3, Math as CesiumMath } from "cesium";
+import type { Camera } from "cesium";
+
+export function initCamera(camera: Camera, lat: number, lon: number): void {
+  const height = 1.7;
+  camera.setView({
+    destination: Cartesian3.fromDegrees(lon, lat, height),
+    orientation: {
+      heading: CesiumMath.toRadians(0),
+      pitch: CesiumMath.toRadians(-90),
+      roll: 0,
+    },
+  });
+}


### PR DESCRIPTION
Closes #37

Implements `initCamera(camera, lat, lon)` in `src/scene/camera.ts`, which positions the Cesium camera at the observer's lat/lon looking straight up (zenith view) using `Cartesian3.fromDegrees` and `CesiumMath.toRadians(-90)` for pitch.

## What shipped

- `src/scene/camera.ts` — `initCamera` function using `Cartesian3.fromDegrees` and `CesiumMath.toRadians`, placing the camera 1.7 m above ground pointing at zenith (pitch = −90°)
- `src/scene/camera.test.ts` — 2 tests verifying `setView` is called with `destination` + `orientation`, and that pitch < 0 (looking up)

## Coverage (src/scene/**)

```
src/scene   |     100 |      100 |     100 |     100 |
  camera.ts |     100 |      100 |     100 |     100 |
  viewer.ts |     100 |      100 |     100 |     100 |
```

## All gates

- `pnpm typecheck` ✓
- `pnpm format:check` ✓
- `pnpm lint` ✓
- `pnpm test:cov` ✓ — 51 tests, 100% lines/branches on scene/**