### PR TITLE
Plan 02 — Task 10: Star billboard layer

### DIFF
--- a/src/scene/stars.test.ts
+++ b/src/scene/stars.test.ts
@@ -1,0 +1,162 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { describe, expect, it, vi, beforeEach, beforeAll } from "vitest";
+import { createStarLayer, generateStarSprite } from "./stars";
+import type { AltAzStar } from "../astro";
+
+// jsdom does not implement HTMLCanvasElement.prototype.getContext; stub it out
+// so tests run without noisy "not implemented" errors. Default: returns null
+// (fallback path). Individual tests can override to exercise the drawing path.
+const mockGetContext = vi.fn().mockReturnValue(null);
+beforeAll(() => {
+  HTMLCanvasElement.prototype.getContext =
+    mockGetContext as typeof HTMLCanvasElement.prototype.getContext;
+});
+
+const mockAdd = vi.fn().mockReturnValue({ show: true, position: null, scale: 1, color: null });
+const mockRemoveAll = vi.fn();
+
+vi.mock("cesium", () => {
+  const MockCartesian3 = vi.fn().mockImplementation((x: number, y: number, z: number) => ({
+    x,
+    y,
+    z,
+  }));
+  (MockCartesian3 as unknown as { fromDegrees: ReturnType<typeof vi.fn> }).fromDegrees = vi
+    .fn()
+    .mockReturnValue({ x: 1, y: 2, z: 3 });
+
+  return {
+    BillboardCollection: vi.fn().mockImplementation(() => ({
+      add: mockAdd,
+      removeAll: mockRemoveAll,
+      length: 0,
+    })),
+    Cartesian3: MockCartesian3,
+    Color: {
+      WHITE: { withAlpha: (a: number) => ({ red: 1, green: 1, blue: 1, alpha: a }) },
+    },
+    HorizontalOrigin: { CENTER: 0 },
+    VerticalOrigin: { CENTER: 0 },
+    Math: { toRadians: (d: number) => (d * Math.PI) / 180 },
+  };
+});
+
+function makeMockScene() {
+  return {
+    primitives: { add: vi.fn() },
+  };
+}
+
+const STARS: AltAzStar[] = [
+  { hip: 32349, alt: 45, az: 180, mag: -1.46, name: "Sirius", size: 16, opacity: 1.0 },
+  { hip: 69673, alt: 70, az: 90, mag: 0.03, name: "Vega", size: 14, opacity: 0.95 },
+  { hip: 99999, alt: 10, az: 270, mag: 5.8, size: 3, opacity: 0.42 },
+];
+
+beforeEach(() => {
+  mockAdd.mockClear();
+  mockRemoveAll.mockClear();
+});
+
+describe("generateStarSprite", () => {
+  it("returns a canvas element when getContext returns null (fallback path)", () => {
+    mockGetContext.mockReturnValueOnce(null);
+    const canvas = generateStarSprite();
+    expect(canvas).toBeInstanceOf(HTMLCanvasElement);
+    expect(canvas.width).toBe(32);
+    expect(canvas.height).toBe(32);
+  });
+
+  it("draws a radial gradient when getContext returns a 2d context", () => {
+    const mockGradient = {
+      addColorStop: vi.fn(),
+    };
+    const mockCtx = {
+      createRadialGradient: vi.fn().mockReturnValue(mockGradient),
+      fillRect: vi.fn(),
+      fillStyle: null as unknown,
+    };
+    mockGetContext.mockReturnValueOnce(mockCtx);
+    const canvas = generateStarSprite();
+    expect(canvas).toBeInstanceOf(HTMLCanvasElement);
+    expect(mockCtx.createRadialGradient).toHaveBeenCalledOnce();
+    expect(mockGradient.addColorStop).toHaveBeenCalledTimes(3);
+    expect(mockCtx.fillRect).toHaveBeenCalledOnce();
+  });
+});
+
+describe("createStarLayer", () => {
+  it("returns an object with an update method", () => {
+    const scene = makeMockScene();
+    const layer = createStarLayer(scene as never);
+    expect(layer).toBeDefined();
+    expect(layer).toHaveProperty("update");
+    expect(typeof layer.update).toBe("function");
+  });
+
+  it("registers a BillboardCollection with scene.primitives", () => {
+    const scene = makeMockScene();
+    createStarLayer(scene as never);
+    expect(scene.primitives.add).toHaveBeenCalledOnce();
+  });
+});
+
+describe("StarLayer.update", () => {
+  it("adds a billboard for each visible star", () => {
+    const scene = makeMockScene();
+    const layer = createStarLayer(scene as never);
+    layer.update(STARS, 33, -117);
+    expect(mockRemoveAll).toHaveBeenCalledOnce();
+    expect(mockAdd).toHaveBeenCalledTimes(3);
+  });
+
+  it("clears existing billboards before adding new ones", () => {
+    const scene = makeMockScene();
+    const layer = createStarLayer(scene as never);
+    layer.update(STARS, 33, -117);
+    mockAdd.mockClear();
+    mockRemoveAll.mockClear();
+    layer.update(STARS.slice(0, 1), 33, -117);
+    expect(mockRemoveAll).toHaveBeenCalledOnce();
+    expect(mockAdd).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes scale derived from star size", () => {
+    const scene = makeMockScene();
+    const layer = createStarLayer(scene as never);
+    layer.update(STARS, 33, -117);
+    const firstCall = mockAdd.mock.calls[0];
+    expect(firstCall).toBeDefined();
+    const callArgs = firstCall![0] as { scale: number };
+    // Sirius has size 16 → scale = 16/16 = 1.0
+    expect(callArgs.scale).toBeCloseTo(1.0);
+  });
+
+  it("passes color with star's opacity", () => {
+    const scene = makeMockScene();
+    const layer = createStarLayer(scene as never);
+    layer.update(STARS, 33, -117);
+    const firstCall = mockAdd.mock.calls[0];
+    expect(firstCall).toBeDefined();
+    const callArgs = firstCall![0] as { color: { alpha: number } };
+    expect(callArgs.color.alpha).toBeCloseTo(1.0);
+  });
+
+  it("works with empty star list (no billboards added)", () => {
+    const scene = makeMockScene();
+    const layer = createStarLayer(scene as never);
+    layer.update([], 0, 0);
+    expect(mockRemoveAll).toHaveBeenCalledOnce();
+    expect(mockAdd).not.toHaveBeenCalled();
+  });
+
+  it("passes position to each billboard", () => {
+    const scene = makeMockScene();
+    const layer = createStarLayer(scene as never);
+    layer.update(STARS, 33, -117);
+    const firstCall = mockAdd.mock.calls[0];
+    expect(firstCall).toBeDefined();
+    const callArgs = firstCall![0] as { position: unknown };
+    expect(callArgs.position).toBeDefined();
+  });
+});

--- a/src/scene/stars.ts
+++ b/src/scene/stars.ts
@@ -1,0 +1,80 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import {
+  BillboardCollection,
+  Cartesian3,
+  Color,
+  Math as CesiumMath,
+  HorizontalOrigin,
+  VerticalOrigin,
+} from "cesium";
+import type { Scene } from "cesium";
+import type { AltAzStar } from "../astro";
+
+const SKY_RADIUS = 1e7;
+
+export type StarLayer = {
+  update: (stars: AltAzStar[], lat: number, lon: number) => void;
+};
+
+export function generateStarSprite(): HTMLCanvasElement {
+  const size = 32;
+  const canvas = document.createElement("canvas");
+  canvas.width = size;
+  canvas.height = size;
+  let ctx: CanvasRenderingContext2D | null;
+  try {
+    ctx = canvas.getContext("2d");
+  } catch {
+    // jsdom / test environment: getContext throws if canvas package absent
+    ctx = null;
+  }
+  if (ctx === null) {
+    // Context unavailable — return a blank canvas as fallback
+    return canvas;
+  }
+  const center = size / 2;
+  const gradient = ctx.createRadialGradient(center, center, 0, center, center, center);
+  gradient.addColorStop(0, "rgba(255, 255, 255, 1)");
+  gradient.addColorStop(0.3, "rgba(255, 255, 255, 0.6)");
+  gradient.addColorStop(1, "rgba(255, 255, 255, 0)");
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, size, size);
+  return canvas;
+}
+
+export function altAzToCartesian(alt: number, az: number, lat: number, lon: number): Cartesian3 {
+  const altRad = CesiumMath.toRadians(alt);
+  const azRad = CesiumMath.toRadians(az);
+  const cosAlt = Math.cos(altRad);
+  const dx = -cosAlt * Math.sin(azRad);
+  const dy = cosAlt * Math.cos(azRad);
+  const dz = Math.sin(altRad);
+  const observerPos = Cartesian3.fromDegrees(lon, lat, 0);
+  return new Cartesian3(
+    observerPos.x + dx * SKY_RADIUS,
+    observerPos.y + dy * SKY_RADIUS,
+    observerPos.z + dz * SKY_RADIUS,
+  );
+}
+
+export function createStarLayer(scene: Scene): StarLayer {
+  const billboards = new BillboardCollection({ scene });
+  scene.primitives.add(billboards);
+  const spriteImage = generateStarSprite();
+
+  function update(stars: AltAzStar[], lat: number, lon: number): void {
+    billboards.removeAll();
+    for (const star of stars) {
+      billboards.add({
+        position: altAzToCartesian(star.alt, star.az, lat, lon),
+        image: spriteImage,
+        scale: star.size / 16,
+        color: Color.WHITE.withAlpha(star.opacity),
+        horizontalOrigin: HorizontalOrigin.CENTER,
+        verticalOrigin: VerticalOrigin.CENTER,
+      });
+    }
+  }
+
+  return { update };
+}


### PR DESCRIPTION
Closes #38

## Summary

- Adds `src/scene/stars.ts` with `createStarLayer(scene)`, `generateStarSprite()`, and `altAzToCartesian()` — all exported for testing
- `createStarLayer` creates a `BillboardCollection`, registers it with `scene.primitives`, generates a 32×32 Gaussian-glow sprite via canvas, and returns a `StarLayer` object with an `update(stars, lat, lon)` method
- `update` clears existing billboards then adds one per `AltAzStar` with position (Alt/Az → Cartesian3), scale (size/16), color (WHITE.withAlpha(opacity)), and centered origin
- `altAzToCartesian` converts horizontal coords to ECEF Cartesian3 by offsetting the observer's ground position by SKY_RADIUS=1e7m in the local ENU frame
- `generateStarSprite` uses a radial gradient (white center → transparent edge); guards against null/throwing canvas context (jsdom compatibility)

## Test plan

- 10 tests in `src/scene/stars.test.ts` covering: layer creation, primitive registration, billboard count per update, clear-before-add, scale mapping, color opacity, empty star list, position presence, sprite null-context fallback, sprite gradient drawing path
- `vi.mock("cesium")` with constructor-capable `Cartesian3` mock; `HTMLCanvasElement.prototype.getContext` stubbed via `beforeAll` to suppress jsdom warnings
- All gates pass: `pnpm typecheck && pnpm format:check && pnpm lint && pnpm test:cov`
- Coverage `src/scene/**`: 98.21% lines / 92.3% branches / 100% functions (thresholds: ≥80% lines, ≥70% branches)