### PR TITLE
Plan 02 — Task 12: Wire astro + scene into app

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,9 +5,33 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <title>Planisphere</title>
+    <style>
+      html,
+      body,
+      #app {
+        margin: 0;
+        padding: 0;
+        width: 100%;
+        height: 100%;
+        overflow: hidden;
+        background: #000;
+      }
+      #cesium-container {
+        width: 100%;
+        height: 100%;
+      }
+      #error {
+        color: #ff6b6b;
+        font-family: monospace;
+        padding: 2rem;
+      }
+    </style>
   </head>
   <body>
-    <main id="app">Loading…</main>
+    <main id="app">
+      <div id="cesium-container"></div>
+      <div id="error" style="display: none"></div>
+    </main>
     <script type="module" src="/src/main.ts"></script>
   </body>
 </html>

--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -1,35 +1,117 @@
 /* SPDX-License-Identifier: Apache-2.0 */
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("cesium", () => ({
+  Viewer: vi.fn().mockImplementation(() => ({
+    scene: {
+      skyBox: undefined,
+      skyAtmosphere: undefined,
+      sun: { show: true },
+      moon: { show: true },
+      backgroundColor: { red: 0, green: 0, blue: 0, alpha: 1 },
+      globe: { show: true },
+      primitives: { add: vi.fn() },
+    },
+    imageryLayers: { removeAll: vi.fn() },
+    camera: { setView: vi.fn() },
+    destroy: vi.fn(),
+  })),
+  BillboardCollection: vi.fn().mockImplementation(() => ({
+    add: vi.fn(),
+    removeAll: vi.fn(),
+    length: 0,
+  })),
+  Cartesian3: { fromDegrees: vi.fn().mockReturnValue({ x: 0, y: 0, z: 0 }) },
+  Color: {
+    BLACK: { clone: () => ({ red: 0, green: 0, blue: 0, alpha: 1 }) },
+    WHITE: { withAlpha: (a: number) => ({ red: 1, green: 1, blue: 1, alpha: a }) },
+  },
+  Ion: { defaultAccessToken: "" },
+  Math: { toRadians: (d: number) => (d * Math.PI) / 180 },
+  HorizontalOrigin: { CENTER: 0 },
+  VerticalOrigin: { CENTER: 0 },
+}));
+
+vi.mock("../data/stars.json", () => ({
+  default: [
+    { hip: 11767, ra: 37.9546, dec: 89.2641, mag: 2.02, name: "Polaris" },
+    { hip: 32349, ra: 101.2872, dec: -16.7161, mag: -1.46, name: "Sirius" },
+  ],
+}));
+
 import { bootstrap } from "./app";
+import * as astro from "./astro";
+import { err } from "./result";
 
 describe("bootstrap", () => {
-  it("renders observer + time text into the root element", () => {
+  it("creates a cesium-container div when root exists", () => {
     const root = document.createElement("main");
-    const params = new URLSearchParams({
-      lat: "34.05",
-      lon: "-118.25",
-      t: "2026-04-15T03:30:00.000Z",
-    });
-    bootstrap(root, params);
-    expect(root.textContent).toContain("34.05");
-    expect(root.textContent).toContain("-118.25");
-    expect(root.textContent).toContain("2026-04-15T03:30:00.000Z");
-  });
+    root.id = "app";
+    const cesiumDiv = document.createElement("div");
+    cesiumDiv.id = "cesium-container";
+    root.appendChild(cesiumDiv);
+    const errorDiv = document.createElement("div");
+    errorDiv.id = "error";
+    root.appendChild(errorDiv);
+    document.body.appendChild(root);
 
-  it("renders an error message when params are invalid", () => {
-    const root = document.createElement("main");
-    bootstrap(root, new URLSearchParams({ lat: "999" }));
-    expect(root.textContent).toMatch(/lat-out-of-range/);
+    bootstrap(root);
+
+    expect(document.getElementById("cesium-container")).toBeTruthy();
+    document.body.removeChild(root);
   });
 
   it("does nothing when root is null", () => {
-    expect(() => bootstrap(null, new URLSearchParams())).not.toThrow();
+    expect(() => bootstrap(null)).not.toThrow();
   });
 
-  it("uses default URLSearchParams when params arg is omitted", () => {
+  it("shows error text when state parsing fails", () => {
     const root = document.createElement("main");
-    // In jsdom, location.search is "" by default, so it parses as default state
-    bootstrap(root);
-    expect(root.textContent).toContain("Planisphere");
+    root.id = "app";
+    const errorDiv = document.createElement("div");
+    errorDiv.id = "error";
+    root.appendChild(errorDiv);
+    document.body.appendChild(root);
+
+    bootstrap(root, new URLSearchParams({ lat: "999" }));
+
+    expect(errorDiv.style.display).not.toBe("none");
+    expect(errorDiv.textContent).toMatch(/lat-out-of-range/);
+    document.body.removeChild(root);
+  });
+
+  it("shows error text when catalog parsing fails", () => {
+    const spy = vi
+      .spyOn(astro, "parseCatalog")
+      .mockReturnValueOnce(err({ kind: "catalog-load-failed", message: "empty catalog" }));
+    const root = document.createElement("main");
+    root.id = "app";
+    const errorDiv = document.createElement("div");
+    errorDiv.id = "error";
+    root.appendChild(errorDiv);
+    document.body.appendChild(root);
+
+    bootstrap(root, new URLSearchParams({ lat: "34", lon: "-118", t: "2026-01-15T04:00:00Z" }));
+
+    expect(errorDiv.style.display).not.toBe("none");
+    expect(errorDiv.textContent).toMatch(/Catalog error/);
+    document.body.removeChild(root);
+    spy.mockRestore();
+  });
+
+  it("shows error text when viewer creation fails", () => {
+    const root = document.createElement("main");
+    root.id = "app";
+    const errorDiv = document.createElement("div");
+    errorDiv.id = "error";
+    root.appendChild(errorDiv);
+    // No #cesium-container in DOM → createViewer returns Err
+    document.body.appendChild(root);
+
+    bootstrap(root, new URLSearchParams({ lat: "34", lon: "-118", t: "2026-01-15T04:00:00Z" }));
+
+    expect(errorDiv.style.display).not.toBe("none");
+    expect(errorDiv.textContent).toMatch(/Scene error/);
+    document.body.removeChild(root);
   });
 });

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,16 +1,46 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 import { parseStateFromSearchParams } from "./state";
+import { parseCatalog, filterVisibleStars } from "./astro";
+import { createViewer, initCamera, createStarLayer } from "./scene";
+import rawStars from "../data/stars.json";
 
 export function bootstrap(
   root: HTMLElement | null,
   params: URLSearchParams = new URLSearchParams(globalThis.location?.search ?? ""),
 ): void {
   if (!root) return;
-  const r = parseStateFromSearchParams(params);
-  if (!r.ok) {
-    root.textContent = `Planisphere — state error: ${r.error.kind}`;
+
+  const errorDiv = root.querySelector<HTMLElement>("#error");
+
+  const stateResult = parseStateFromSearchParams(params);
+  if (!stateResult.ok) {
+    showError(errorDiv, `State error: ${stateResult.error.kind}`);
     return;
   }
-  const { observer, timeUtc } = r.value;
-  root.textContent = `Planisphere — observer (${observer.lat}, ${observer.lon}) @ ${timeUtc.toISOString()}`;
+  const { observer, timeUtc } = stateResult.value;
+
+  const catalogResult = parseCatalog(rawStars);
+  if (!catalogResult.ok) {
+    showError(errorDiv, `Catalog error: ${catalogResult.error.message}`);
+    return;
+  }
+
+  const viewerResult = createViewer("cesium-container");
+  if (!viewerResult.ok) {
+    showError(errorDiv, `Scene error: ${viewerResult.error.message}`);
+    return;
+  }
+  const viewer = viewerResult.value;
+
+  initCamera(viewer.camera, observer.lat, observer.lon);
+
+  const visibleStars = filterVisibleStars(catalogResult.value, observer.lat, observer.lon, timeUtc);
+  const starLayer = createStarLayer(viewer.scene);
+  starLayer.update(visibleStars, observer.lat, observer.lon);
+}
+
+function showError(el: HTMLElement | null, message: string): void {
+  if (!el) return;
+  el.textContent = message;
+  el.style.display = "block";
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,5 @@
 /* SPDX-License-Identifier: Apache-2.0 */
+import "cesium/Build/Cesium/Widgets/widgets.css";
 import { bootstrap } from "./app";
 
 bootstrap(document.getElementById("app"));


### PR DESCRIPTION
Closes #40

## Summary

- Replaces placeholder `app.ts` with full Cesium bootstrap: parse state → parse catalog → create viewer → init camera → compute visible stars → render star layer
- Updates `index.html` to full-viewport layout with `#cesium-container` and hidden `#error` div
- Adds `cesium/Build/Cesium/Widgets/widgets.css` import to `main.ts`
- Rewrites `app.test.ts` with comprehensive Cesium mock + stars.json mock; 5 tests covering happy path, null-root guard, state-error, catalog-error, and viewer-error branches

## Gate output

```
pnpm typecheck  ✓
pnpm format:check  ✓
pnpm lint  ✓
pnpm test:cov  ✓  (62 tests, 10 files)
pnpm build  ✓
```

## Coverage (src/app.ts)

```
app.ts  | 100% stmts | 83.33% branch | 100% funcs | 100% lines
```
Branch threshold: 70% — passed.

Project-wide: 98.72% stmts, 93.2% branch, 100% funcs, 98.72% lines.

## Notes

- The happy-path test produces a harmless jsdom stderr warning (`HTMLCanvasElement.prototype.getContext not implemented`) from `generateStarSprite()` in `stars.ts` — not a test failure; all 5 tests pass green.
- Catalog-error branch tested by spying on `parseCatalog` via `vi.spyOn`; viewer-error branch tested by omitting `#cesium-container` from the DOM.
- Both `cesium/Build/Cesium/Widgets/widgets.css` and `cesium/Source/Widgets/widgets.css` exist in the installed package; used the Build path per the plan.