### PR TITLE
Fix star billboard positions (ENU-to-ECEF transform)

### DIFF
--- a/src/scene/camera.test.ts
+++ b/src/scene/camera.test.ts
@@ -24,10 +24,10 @@ describe("initCamera", () => {
     expect(args).toHaveProperty("orientation");
   });
 
-  it("orientation pitch points upward (negative = looking up in Cesium)", () => {
+  it("orientation pitch points upward (positive = looking up in Cesium)", () => {
     const { mock, setView } = makeCamera();
     initCamera(mock, 40.0, -74.0);
     const [args] = setView.mock.calls[0] as [{ orientation: { pitch: number } }];
-    expect(args.orientation.pitch).toBeLessThan(0);
+    expect(args.orientation.pitch).toBeGreaterThan(0);
   });
 });

--- a/src/scene/camera.ts
+++ b/src/scene/camera.ts
@@ -8,7 +8,7 @@ export function initCamera(camera: Camera, lat: number, lon: number): void {
     destination: Cartesian3.fromDegrees(lon, lat, height),
     orientation: {
       heading: CesiumMath.toRadians(0),
-      pitch: CesiumMath.toRadians(-90),
+      pitch: CesiumMath.toRadians(89.9),
       roll: 0,
     },
   });

--- a/src/scene/stars.test.ts
+++ b/src/scene/stars.test.ts
@@ -38,6 +38,14 @@ vi.mock("cesium", () => {
     HorizontalOrigin: { CENTER: 0 },
     VerticalOrigin: { CENTER: 0 },
     Math: { toRadians: (d: number) => (d * Math.PI) / 180 },
+    Transforms: {
+      eastNorthUpToFixedFrame: vi
+        .fn()
+        .mockReturnValue([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]),
+    },
+    Matrix4: {
+      multiplyByPoint: vi.fn().mockReturnValue({ x: 10, y: 20, z: 30 }),
+    },
   };
 });
 

--- a/src/scene/stars.ts
+++ b/src/scene/stars.ts
@@ -4,6 +4,8 @@ import {
   Cartesian3,
   Color,
   Math as CesiumMath,
+  Matrix4,
+  Transforms,
   HorizontalOrigin,
   VerticalOrigin,
 } from "cesium";
@@ -46,15 +48,18 @@ export function altAzToCartesian(alt: number, az: number, lat: number, lon: numb
   const altRad = CesiumMath.toRadians(alt);
   const azRad = CesiumMath.toRadians(az);
   const cosAlt = Math.cos(altRad);
-  const dx = -cosAlt * Math.sin(azRad);
-  const dy = cosAlt * Math.cos(azRad);
-  const dz = Math.sin(altRad);
+
+  // Direction in local ENU (East-North-Up) frame
+  const east = cosAlt * Math.sin(azRad);
+  const north = cosAlt * Math.cos(azRad);
+  const up = Math.sin(altRad);
+
+  const localDir = new Cartesian3(east * SKY_RADIUS, north * SKY_RADIUS, up * SKY_RADIUS);
+
+  // Transform local ENU direction to ECEF via the observer's reference frame
   const observerPos = Cartesian3.fromDegrees(lon, lat, 0);
-  return new Cartesian3(
-    observerPos.x + dx * SKY_RADIUS,
-    observerPos.y + dy * SKY_RADIUS,
-    observerPos.z + dz * SKY_RADIUS,
-  );
+  const enuToFixed = Transforms.eastNorthUpToFixedFrame(observerPos);
+  return Matrix4.multiplyByPoint(enuToFixed, localDir, new Cartesian3());
 }
 
 export function createStarLayer(scene: Scene): StarLayer {


### PR DESCRIPTION
Closes #41

Stars were invisible because `altAzToCartesian` added local ENU direction
vectors directly to ECEF coordinates. Fixed by using Cesium's
`Transforms.eastNorthUpToFixedFrame` to properly rotate the local direction
into the ECEF frame.

Also updates .gitignore to exclude `.claude/`.