### PR TITLE
Fix star rendering: reduce SKY_RADIUS + disable depth test

### DIFF
--- a/src/scene/stars.ts
+++ b/src/scene/stars.ts
@@ -12,7 +12,7 @@ import {
 import type { Scene } from "cesium";
 import type { AltAzStar } from "../astro";
 
-const SKY_RADIUS = 1e7;
+const SKY_RADIUS = 1e5;
 
 export type StarLayer = {
   update: (stars: AltAzStar[], lat: number, lon: number) => void;
@@ -77,6 +77,7 @@ export function createStarLayer(scene: Scene): StarLayer {
         color: Color.WHITE.withAlpha(star.opacity),
         horizontalOrigin: HorizontalOrigin.CENTER,
         verticalOrigin: VerticalOrigin.CENTER,
+        disableDepthTestDistance: Number.POSITIVE_INFINITY,
       });
     }
   }


### PR DESCRIPTION
Closes #41

Stars were invisible due to two issues:
- `SKY_RADIUS` at 1e7m (10,000km) exceeded Cesium's far clip plane → reduced to 1e5m (100km)
- Billboard depth test against hidden globe → added `disableDepthTestDistance: Infinity`

Visually verified: stars render correctly at `?lat=33&lon=-117&t=2026-01-15T04:00:00Z`.