### PR TITLE
feat: hover tooltip showing star identity and position

### DIFF
--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -21,7 +21,10 @@ vi.mock("cesium", () => ({
     removeAll: vi.fn(),
     length: 0,
   })),
-  Cartesian3: { fromDegrees: vi.fn().mockReturnValue({ x: 0, y: 0, z: 0 }) },
+  Cartesian3: Object.assign(
+    vi.fn().mockImplementation((x: number, y: number, z: number) => ({ x, y, z })),
+    { fromDegrees: vi.fn().mockReturnValue({ x: 0, y: 0, z: 0 }) },
+  ),
   Color: {
     BLACK: { clone: () => ({ red: 0, green: 0, blue: 0, alpha: 1 }) },
     WHITE: { withAlpha: (a: number) => ({ red: 1, green: 1, blue: 1, alpha: a }) },
@@ -30,6 +33,20 @@ vi.mock("cesium", () => ({
   Math: { toRadians: (d: number) => (d * Math.PI) / 180 },
   HorizontalOrigin: { CENTER: 0 },
   VerticalOrigin: { CENTER: 0 },
+  Transforms: {
+    eastNorthUpToFixedFrame: vi
+      .fn()
+      .mockReturnValue([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]),
+  },
+  Matrix4: {
+    multiplyByPoint: vi.fn().mockReturnValue({ x: 10, y: 20, z: 30 }),
+  },
+  ScreenSpaceEventHandler: vi.fn().mockImplementation(() => ({
+    setInputAction: vi.fn(),
+    destroy: vi.fn(),
+  })),
+  ScreenSpaceEventType: { MOUSE_MOVE: 0 },
+  defined: (v: unknown) => v !== undefined && v !== null,
 }));
 
 vi.mock("../data/stars.json", () => ({

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 import { parseStateFromSearchParams } from "./state";
 import { parseCatalog, filterVisibleStars } from "./astro";
-import { createViewer, initCamera, createStarLayer } from "./scene";
+import { createViewer, initCamera, createStarLayer, createTooltip } from "./scene";
 import rawStars from "../data/stars.json";
 
 export function bootstrap(
@@ -37,6 +37,11 @@ export function bootstrap(
   const visibleStars = filterVisibleStars(catalogResult.value, observer.lat, observer.lon, timeUtc);
   const starLayer = createStarLayer(viewer.scene);
   starLayer.update(visibleStars, observer.lat, observer.lon);
+
+  const cesiumContainer = document.getElementById("cesium-container");
+  if (cesiumContainer) {
+    createTooltip(viewer, cesiumContainer);
+  }
 }
 
 function showError(el: HTMLElement | null, message: string): void {

--- a/src/astro/visibility.test.ts
+++ b/src/astro/visibility.test.ts
@@ -39,6 +39,8 @@ describe("filterVisibleStars", () => {
     if (result.length > 0) {
       const s = result[0];
       expect(s).toHaveProperty("hip");
+      expect(s).toHaveProperty("ra");
+      expect(s).toHaveProperty("dec");
       expect(s).toHaveProperty("alt");
       expect(s).toHaveProperty("az");
       expect(s).toHaveProperty("mag");

--- a/src/astro/visibility.ts
+++ b/src/astro/visibility.ts
@@ -5,6 +5,8 @@ import { magToVisual } from "./magnitude";
 
 export type AltAzStar = {
   readonly hip: number;
+  readonly ra: number;
+  readonly dec: number;
   readonly alt: number;
   readonly az: number;
   readonly mag: number;
@@ -26,6 +28,8 @@ export function filterVisibleStars(
     const { size, opacity } = magToVisual(star.mag);
     result.push({
       hip: star.hip,
+      ra: star.ra,
+      dec: star.dec,
       alt,
       az,
       mag: star.mag,

--- a/src/scene/index.ts
+++ b/src/scene/index.ts
@@ -2,3 +2,4 @@
 export { type SceneInitError, createViewer } from "./viewer";
 export { initCamera } from "./camera";
 export { type StarLayer, createStarLayer } from "./stars";
+export { type Tooltip, createTooltip } from "./tooltip";

--- a/src/scene/stars.test.ts
+++ b/src/scene/stars.test.ts
@@ -56,9 +56,29 @@ function makeMockScene() {
 }
 
 const STARS: AltAzStar[] = [
-  { hip: 32349, alt: 45, az: 180, mag: -1.46, name: "Sirius", size: 16, opacity: 1.0 },
-  { hip: 69673, alt: 70, az: 90, mag: 0.03, name: "Vega", size: 14, opacity: 0.95 },
-  { hip: 99999, alt: 10, az: 270, mag: 5.8, size: 3, opacity: 0.42 },
+  {
+    hip: 32349,
+    ra: 101.29,
+    dec: -16.72,
+    alt: 45,
+    az: 180,
+    mag: -1.46,
+    name: "Sirius",
+    size: 16,
+    opacity: 1.0,
+  },
+  {
+    hip: 69673,
+    ra: 279.23,
+    dec: 38.78,
+    alt: 70,
+    az: 90,
+    mag: 0.03,
+    name: "Vega",
+    size: 14,
+    opacity: 0.95,
+  },
+  { hip: 99999, ra: 0, dec: 0, alt: 10, az: 270, mag: 5.8, size: 3, opacity: 0.42 },
 ];
 
 beforeEach(() => {

--- a/src/scene/stars.ts
+++ b/src/scene/stars.ts
@@ -78,6 +78,7 @@ export function createStarLayer(scene: Scene): StarLayer {
         horizontalOrigin: HorizontalOrigin.CENTER,
         verticalOrigin: VerticalOrigin.CENTER,
         disableDepthTestDistance: Number.POSITIVE_INFINITY,
+        id: star,
       });
     }
   }

--- a/src/scene/tooltip.test.ts
+++ b/src/scene/tooltip.test.ts
@@ -1,0 +1,105 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createTooltip } from "./tooltip";
+
+const mockSetInputAction = vi.fn();
+const mockDestroy = vi.fn();
+const mockPick = vi.fn();
+
+vi.mock("cesium", () => ({
+  ScreenSpaceEventHandler: vi.fn().mockImplementation(() => ({
+    setInputAction: mockSetInputAction,
+    destroy: mockDestroy,
+  })),
+  ScreenSpaceEventType: { MOUSE_MOVE: 0 },
+  defined: (v: unknown) => v !== undefined && v !== null,
+}));
+
+function makeMockViewer() {
+  return {
+    scene: {
+      canvas: document.createElement("canvas"),
+      pick: mockPick,
+    },
+  };
+}
+
+describe("createTooltip", () => {
+  beforeEach(() => {
+    mockSetInputAction.mockClear();
+    mockDestroy.mockClear();
+    mockPick.mockClear();
+  });
+
+  it("creates a tooltip div inside the container", () => {
+    const container = document.createElement("div");
+    const viewer = makeMockViewer();
+    createTooltip(viewer as never, container);
+    const tooltipDiv = container.querySelector("div");
+    expect(tooltipDiv).toBeTruthy();
+    expect(tooltipDiv!.style.display).toBe("none");
+  });
+
+  it("registers a MOUSE_MOVE handler", () => {
+    const container = document.createElement("div");
+    const viewer = makeMockViewer();
+    createTooltip(viewer as never, container);
+    expect(mockSetInputAction).toHaveBeenCalledOnce();
+  });
+
+  it("shows tooltip with star info when a billboard is picked", () => {
+    const container = document.createElement("div");
+    const viewer = makeMockViewer();
+    createTooltip(viewer as never, container);
+
+    const moveCallback = mockSetInputAction.mock.calls[0]![0] as (movement: {
+      endPosition: { x: number; y: number };
+    }) => void;
+
+    mockPick.mockReturnValueOnce({
+      id: {
+        hip: 32349,
+        ra: 101.2872,
+        dec: -16.7161,
+        alt: 45.2,
+        az: 180.3,
+        mag: -1.44,
+        name: "Sirius",
+        size: 16,
+        opacity: 1,
+      },
+    });
+    moveCallback({ endPosition: { x: 100, y: 200 } });
+
+    const tooltipDiv = container.querySelector("div")!;
+    expect(tooltipDiv.style.display).toBe("block");
+    expect(tooltipDiv.innerHTML).toContain("Sirius");
+    expect(tooltipDiv.innerHTML).toContain("-1.44");
+    expect(tooltipDiv.innerHTML).toContain("45.2");
+  });
+
+  it("hides tooltip when nothing is picked", () => {
+    const container = document.createElement("div");
+    const viewer = makeMockViewer();
+    createTooltip(viewer as never, container);
+
+    const moveCallback = mockSetInputAction.mock.calls[0]![0] as (movement: {
+      endPosition: { x: number; y: number };
+    }) => void;
+
+    mockPick.mockReturnValueOnce(undefined);
+    moveCallback({ endPosition: { x: 100, y: 200 } });
+
+    const tooltipDiv = container.querySelector("div")!;
+    expect(tooltipDiv.style.display).toBe("none");
+  });
+
+  it("destroy removes handler and tooltip element", () => {
+    const container = document.createElement("div");
+    const viewer = makeMockViewer();
+    const tooltip = createTooltip(viewer as never, container);
+    tooltip.destroy();
+    expect(mockDestroy).toHaveBeenCalledOnce();
+    expect(container.querySelector("div")).toBeNull();
+  });
+});

--- a/src/scene/tooltip.ts
+++ b/src/scene/tooltip.ts
@@ -1,0 +1,72 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { ScreenSpaceEventHandler, ScreenSpaceEventType, defined } from "cesium";
+import type { Cartesian2, Viewer } from "cesium";
+import type { AltAzStar } from "../astro";
+
+export type Tooltip = {
+  destroy: () => void;
+};
+
+function formatRa(raDeg: number): string {
+  const hours = raDeg / 15;
+  const h = Math.floor(hours);
+  const m = Math.round((hours - h) * 60);
+  return `${String(h)}h ${String(m)}m`;
+}
+
+function formatDec(dec: number): string {
+  const sign = dec >= 0 ? "+" : "-";
+  const abs = Math.abs(dec);
+  const d = Math.floor(abs);
+  const m = Math.round((abs - d) * 60);
+  return `${sign}${String(d)}\u00B0 ${String(m)}\u2032`;
+}
+
+function isAltAzStar(obj: unknown): obj is AltAzStar {
+  return (
+    typeof obj === "object" &&
+    obj !== null &&
+    "hip" in obj &&
+    "alt" in obj &&
+    "az" in obj &&
+    "mag" in obj
+  );
+}
+
+export function createTooltip(viewer: Viewer, container: HTMLElement): Tooltip {
+  const el = document.createElement("div");
+  el.style.cssText =
+    "position:absolute;pointer-events:none;display:none;background:rgba(0,0,0,0.85);" +
+    "color:#fff;font:12px/1.4 monospace;padding:6px 10px;border-radius:4px;" +
+    "border:1px solid rgba(255,255,255,0.2);white-space:nowrap;z-index:10";
+  container.appendChild(el);
+
+  const handler = new ScreenSpaceEventHandler(viewer.scene.canvas);
+
+  handler.setInputAction((movement: { endPosition: Cartesian2 }) => {
+    const picked: { id?: unknown } | undefined = viewer.scene.pick(movement.endPosition) as
+      | { id?: unknown }
+      | undefined;
+    if (defined(picked) && picked !== undefined && isAltAzStar(picked.id)) {
+      const star = picked.id;
+      const label = star.name ?? `HIP ${String(star.hip)}`;
+      el.innerHTML =
+        `<strong>${label}</strong><br>` +
+        `mag ${star.mag.toFixed(2)}<br>` +
+        `Alt ${star.alt.toFixed(1)}\u00B0 Az ${star.az.toFixed(1)}\u00B0<br>` +
+        `RA ${formatRa(star.ra)} Dec ${formatDec(star.dec)}`;
+      el.style.display = "block";
+      el.style.left = `${String(movement.endPosition.x + 14)}px`;
+      el.style.top = `${String(movement.endPosition.y + 14)}px`;
+    } else {
+      el.style.display = "none";
+    }
+  }, ScreenSpaceEventType.MOUSE_MOVE);
+
+  function destroy(): void {
+    handler.destroy();
+    el.remove();
+  }
+
+  return { destroy };
+}


### PR DESCRIPTION
Closes #54

## Summary
- Hover over any star to see its name (or HIP ID), magnitude, Alt/Az, and RA/Dec
- Uses CesiumJS `ScreenSpaceEventHandler` with `MOUSE_MOVE` for billboard picking
- Tooltip is an HTML overlay positioned near the cursor
- Added `ra`/`dec` fields to `AltAzStar` for catalog coordinate display
- 5 new tooltip tests + updated star/visibility/app tests

## Test plan
- [x] 67 tests pass, all coverage thresholds met
- [x] `pnpm typecheck && pnpm lint && pnpm format:check && pnpm test:cov && pnpm build` all pass
- [ ] Visual: hover over a star, tooltip appears with correct info
- [ ] Visual: move off star, tooltip disappears