### PR TITLE
Plan 03 — Task 1: Moon illumination (TDD)

### DIFF
--- a/src/astro/moon-phase.test.ts
+++ b/src/astro/moon-phase.test.ts
@@ -1,0 +1,30 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { describe, expect, it } from "vitest";
+import { getMoonIllumination } from "./moon-phase";
+
+describe("getMoonIllumination", () => {
+  it("returns near-full illumination on a known full moon date", () => {
+    // Full moon: 2026-04-02T02:12Z
+    const result = getMoonIllumination(new Date("2026-04-02T02:00:00Z"));
+    expect(result.fraction).toBeGreaterThan(0.95);
+  });
+
+  it("returns near-zero illumination on a known new moon date", () => {
+    // New moon: 2026-04-17T11:52Z
+    const result = getMoonIllumination(new Date("2026-04-17T12:00:00Z"));
+    expect(result.fraction).toBeLessThan(0.05);
+  });
+
+  it("returns approximately half illumination near first quarter", () => {
+    // First quarter: ~2026-04-24T02:32Z
+    const result = getMoonIllumination(new Date("2026-04-24T02:00:00Z"));
+    expect(result.fraction).toBeGreaterThan(0.35);
+    expect(result.fraction).toBeLessThan(0.65);
+  });
+
+  it("phase angle is between 0 and 360", () => {
+    const result = getMoonIllumination(new Date("2026-06-15T00:00:00Z"));
+    expect(result.phaseAngle).toBeGreaterThanOrEqual(0);
+    expect(result.phaseAngle).toBeLessThanOrEqual(360);
+  });
+});

--- a/src/astro/moon-phase.ts
+++ b/src/astro/moon-phase.ts
@@ -1,0 +1,16 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { Body, Illumination, MakeTime } from "astronomy-engine";
+
+export type MoonIllumination = {
+  readonly fraction: number;
+  readonly phaseAngle: number;
+};
+
+export function getMoonIllumination(time: Date): MoonIllumination {
+  const astroTime = MakeTime(time);
+  const illum = Illumination(Body.Moon, astroTime);
+  return {
+    fraction: illum.phase_fraction,
+    phaseAngle: illum.phase_angle,
+  };
+}


### PR DESCRIPTION
Closes #60

Implements `getMoonIllumination(date: Date)` in `src/astro/moon-phase.ts` wrapping Astronomy Engine's `Illumination(Body.Moon, ...)`. Returns `{ fraction: number, phaseAngle: number }`.

**TDD:** Tests written first (failing with module-not-found), then implementation added — all 4 tests green.

**Note on test dates:** The plan's dates (2026-03-29 full moon, 2026-04-12 new moon, 2026-04-20 first quarter) did not match actual lunar phases for this cycle. Actual phases verified via `SearchMoonPhase`: full moon 2026-04-02, new moon 2026-04-17, first quarter 2026-04-24. Tests use the corrected dates.

**Astronomy Engine API:** `phase_fraction` and `phase_angle` property names match the plan exactly (verified at runtime).