### PR TITLE
Plan 03 — Task 2: Body positions (TDD)

### DIFF
--- a/src/astro/bodies.test.ts
+++ b/src/astro/bodies.test.ts
@@ -1,0 +1,63 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { describe, expect, it } from "vitest";
+import { computeBodyPositions } from "./bodies";
+
+describe("computeBodyPositions", () => {
+  it("returns 7 bodies total (some may be below horizon)", () => {
+    const all = computeBodyPositions(33, -117, new Date("2026-06-15T12:00:00Z"), false);
+    expect(all).toHaveLength(7);
+  });
+
+  it("filters to above-horizon when requested", () => {
+    const visible = computeBodyPositions(33, -117, new Date("2026-06-15T12:00:00Z"), true);
+    for (const body of visible) {
+      expect(body.alt).toBeGreaterThan(0);
+    }
+  });
+
+  it("Sun is above horizon at local noon", () => {
+    // Noon UTC for lon=-117 is roughly 19:00 UTC
+    const all = computeBodyPositions(33, -117, new Date("2026-06-15T19:00:00Z"), false);
+    const sun = all.find((b) => b.id === "Sun");
+    expect(sun).toBeDefined();
+    expect(sun!.alt).toBeGreaterThan(0);
+  });
+
+  it("Sun is below horizon at local midnight", () => {
+    // Midnight for lon=-117 is roughly 07:00 UTC
+    const all = computeBodyPositions(33, -117, new Date("2026-06-15T07:00:00Z"), false);
+    const sun = all.find((b) => b.id === "Sun");
+    expect(sun).toBeDefined();
+    expect(sun!.alt).toBeLessThan(0);
+  });
+
+  it("every body has required fields", () => {
+    const all = computeBodyPositions(40, -74, new Date("2026-03-15T22:00:00Z"), false);
+    for (const body of all) {
+      expect(body).toHaveProperty("id");
+      expect(body).toHaveProperty("alt");
+      expect(body).toHaveProperty("az");
+      expect(body).toHaveProperty("ra");
+      expect(body).toHaveProperty("dec");
+      expect(body).toHaveProperty("mag");
+      expect(body).toHaveProperty("size");
+      expect(body).toHaveProperty("color");
+    }
+  });
+
+  it("Moon has illumination and phaseAngle", () => {
+    const all = computeBodyPositions(33, -117, new Date("2026-03-29T02:00:00Z"), false);
+    const moon = all.find((b) => b.id === "Moon");
+    expect(moon).toBeDefined();
+    expect(moon!.illumination).toBeDefined();
+    expect(moon!.phaseAngle).toBeDefined();
+  });
+
+  it("Sun has the largest size", () => {
+    const all = computeBodyPositions(33, -117, new Date("2026-06-15T19:00:00Z"), false);
+    const sun = all.find((b) => b.id === "Sun")!;
+    for (const body of all) {
+      expect(sun.size).toBeGreaterThanOrEqual(body.size);
+    }
+  });
+});

--- a/src/astro/bodies.ts
+++ b/src/astro/bodies.ts
@@ -1,0 +1,80 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { Body, Equator, MakeTime, Observer } from "astronomy-engine";
+import { raDecToAltAz } from "./coords";
+import { getMoonIllumination } from "./moon-phase";
+
+export type CelestialBody = {
+  readonly id: string;
+  readonly alt: number;
+  readonly az: number;
+  readonly ra: number;
+  readonly dec: number;
+  readonly mag: number;
+  readonly size: number;
+  readonly color: string;
+  readonly illumination?: number;
+  readonly phaseAngle?: number;
+};
+
+type BodyConfig = {
+  body: Body;
+  id: string;
+  color: string;
+  size: number;
+  mag: number;
+};
+
+const BODY_CONFIGS: BodyConfig[] = [
+  { body: Body.Sun, id: "Sun", color: "#FDB813", size: 24, mag: -26.74 },
+  { body: Body.Moon, id: "Moon", color: "#E8E8E0", size: 20, mag: -12.7 },
+  { body: Body.Mercury, id: "Mercury", color: "#B5A7A7", size: 6, mag: 0.0 },
+  { body: Body.Venus, id: "Venus", color: "#FFFFCC", size: 10, mag: -4.0 },
+  { body: Body.Mars, id: "Mars", color: "#CC4422", size: 8, mag: 1.0 },
+  { body: Body.Jupiter, id: "Jupiter", color: "#D4A96A", size: 9, mag: -2.0 },
+  { body: Body.Saturn, id: "Saturn", color: "#C8B07A", size: 7, mag: 0.5 },
+];
+
+export function computeBodyPositions(
+  lat: number,
+  lon: number,
+  time: Date,
+  filterVisible: boolean,
+): CelestialBody[] {
+  const astroTime = MakeTime(time);
+  const observer = new Observer(lat, lon, 0);
+  const result: CelestialBody[] = [];
+
+  for (const config of BODY_CONFIGS) {
+    const eq = Equator(config.body, astroTime, observer, true, true);
+    const raDeg = eq.ra * 15;
+    const decDeg = eq.dec;
+    const { alt, az } = raDecToAltAz(raDeg, decDeg, lat, lon, time);
+
+    if (filterVisible && alt <= 0) continue;
+
+    const entry: CelestialBody = {
+      id: config.id,
+      alt,
+      az,
+      ra: raDeg,
+      dec: decDeg,
+      mag: config.mag,
+      size: config.size,
+      color: config.color,
+    };
+
+    if (config.id === "Moon") {
+      const moonIllum = getMoonIllumination(time);
+      const withMoon: CelestialBody = {
+        ...entry,
+        illumination: moonIllum.fraction,
+        phaseAngle: moonIllum.phaseAngle,
+      };
+      result.push(withMoon);
+    } else {
+      result.push(entry);
+    }
+  }
+
+  return result;
+}


### PR DESCRIPTION
Closes #61

Implements `computeBodyPositions(lat, lon, time, filterVisible)` in `src/astro/bodies.ts`, returning a `CelestialBody[]` for the Sun, Moon, and five naked-eye planets (Mercury, Venus, Mars, Jupiter, Saturn). Moon entries include `illumination` and `phaseAngle` from `getMoonIllumination`. Positions use `Equator` from Astronomy Engine (RA converted to degrees) fed through the existing `raDecToAltAz` helper.

TDD: 7 failing tests written first (module-not-found), then implementation made them pass. All 78 tests across 13 files pass with no lint/type/format issues.