### PR TITLE
feat(astro): export moon-phase and bodies modules

### DIFF
--- a/src/astro/index.ts
+++ b/src/astro/index.ts
@@ -3,3 +3,5 @@ export { type StarRecord, type CatalogLoadError, parseCatalog } from "./catalog"
 export { type HorizontalCoord, raDecToAltAz } from "./coords";
 export { type StarVisual, magToVisual } from "./magnitude";
 export { type AltAzStar, filterVisibleStars } from "./visibility";
+export { type MoonIllumination, getMoonIllumination } from "./moon-phase";
+export { type CelestialBody, computeBodyPositions } from "./bodies";


### PR DESCRIPTION
Exports the moon-phase and bodies modules from the astro barrel, making their public APIs available to consumers.

Closes #62