### PR TITLE
Plan 03 — Task 4: Body billboard layer with custom sprites

### DIFF
--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -28,6 +28,9 @@ vi.mock("cesium", () => ({
   Color: {
     BLACK: { clone: () => ({ red: 0, green: 0, blue: 0, alpha: 1 }) },
     WHITE: { withAlpha: (a: number) => ({ red: 1, green: 1, blue: 1, alpha: a }) },
+    fromCssColorString: vi.fn().mockReturnValue({
+      withAlpha: (a: number) => ({ alpha: a }),
+    }),
   },
   Ion: { defaultAccessToken: "" },
   Math: { toRadians: (d: number) => (d * Math.PI) / 180 },

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 import { parseStateFromSearchParams } from "./state";
-import { parseCatalog, filterVisibleStars } from "./astro";
-import { createViewer, initCamera, createStarLayer, createTooltip } from "./scene";
+import { parseCatalog, filterVisibleStars, computeBodyPositions } from "./astro";
+import { createViewer, initCamera, createStarLayer, createBodyLayer, createTooltip } from "./scene";
 import rawStars from "../data/stars.json";
 
 export function bootstrap(
@@ -37,6 +37,10 @@ export function bootstrap(
   const visibleStars = filterVisibleStars(catalogResult.value, observer.lat, observer.lon, timeUtc);
   const starLayer = createStarLayer(viewer.scene);
   starLayer.update(visibleStars, observer.lat, observer.lon);
+
+  const bodies = computeBodyPositions(observer.lat, observer.lon, timeUtc, true);
+  const bodyLayer = createBodyLayer(viewer.scene);
+  bodyLayer.update(bodies, observer.lat, observer.lon);
 
   const cesiumContainer = document.getElementById("cesium-container");
   if (cesiumContainer) {

--- a/src/scene/bodies.test.ts
+++ b/src/scene/bodies.test.ts
@@ -1,0 +1,195 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createBodyLayer,
+  generateSunSprite,
+  generateMoonSprite,
+  generatePlanetSprite,
+} from "./bodies";
+import type { CelestialBody } from "../astro";
+
+const mockGetContext = vi.fn().mockReturnValue(null);
+beforeAll(() => {
+  HTMLCanvasElement.prototype.getContext =
+    mockGetContext as typeof HTMLCanvasElement.prototype.getContext;
+});
+
+const mockAdd = vi.fn().mockReturnValue({ show: true });
+const mockRemoveAll = vi.fn();
+
+vi.mock("cesium", () => {
+  const MockCartesian3 = vi.fn().mockImplementation((x: number, y: number, z: number) => ({
+    x,
+    y,
+    z,
+  }));
+  (MockCartesian3 as unknown as { fromDegrees: ReturnType<typeof vi.fn> }).fromDegrees = vi
+    .fn()
+    .mockReturnValue({ x: 1, y: 2, z: 3 });
+
+  return {
+    BillboardCollection: vi.fn().mockImplementation(() => ({
+      add: mockAdd,
+      removeAll: mockRemoveAll,
+      length: 0,
+    })),
+    Cartesian3: MockCartesian3,
+    Color: {
+      fromCssColorString: vi.fn().mockReturnValue({
+        withAlpha: (a: number) => ({ alpha: a }),
+      }),
+    },
+    HorizontalOrigin: { CENTER: 0 },
+    VerticalOrigin: { CENTER: 0 },
+    Math: { toRadians: (d: number) => (d * Math.PI) / 180 },
+    Transforms: {
+      eastNorthUpToFixedFrame: vi
+        .fn()
+        .mockReturnValue([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]),
+    },
+    Matrix4: {
+      multiplyByPoint: vi.fn().mockReturnValue({ x: 10, y: 20, z: 30 }),
+    },
+  };
+});
+
+function makeMockScene() {
+  return { primitives: { add: vi.fn() } };
+}
+
+const BODIES: CelestialBody[] = [
+  { id: "Sun", alt: 45, az: 180, ra: 80, dec: 20, mag: -26.74, size: 24, color: "#FDB813" },
+  {
+    id: "Moon",
+    alt: 60,
+    az: 120,
+    ra: 100,
+    dec: -5,
+    mag: -12.7,
+    size: 20,
+    color: "#E8E8E0",
+    illumination: 0.75,
+    phaseAngle: 90,
+  },
+  { id: "Venus", alt: 20, az: 260, ra: 300, dec: -20, mag: -4.0, size: 10, color: "#FFFFCC" },
+];
+
+function makeMockCtx() {
+  const mockGradient = { addColorStop: vi.fn() };
+  return {
+    createRadialGradient: vi.fn().mockReturnValue(mockGradient),
+    fillRect: vi.fn(),
+    beginPath: vi.fn(),
+    arc: vi.fn(),
+    ellipse: vi.fn(),
+    fill: vi.fn(),
+    fillStyle: null as unknown,
+    globalCompositeOperation: null as unknown,
+    gradient: mockGradient,
+  };
+}
+
+beforeEach(() => {
+  mockAdd.mockClear();
+  mockRemoveAll.mockClear();
+});
+
+describe("sprite generators (with 2d context)", () => {
+  it("generateSunSprite draws a radial gradient when context available", () => {
+    const ctx = makeMockCtx();
+    mockGetContext.mockReturnValueOnce(ctx);
+    const canvas = generateSunSprite();
+    expect(canvas).toBeInstanceOf(HTMLCanvasElement);
+    expect(canvas.width).toBe(48);
+    expect(ctx.createRadialGradient).toHaveBeenCalledOnce();
+    expect(ctx.gradient.addColorStop).toHaveBeenCalledTimes(4);
+    expect(ctx.fillRect).toHaveBeenCalledOnce();
+  });
+
+  it("generateMoonSprite draws crescent (waxing) when context available", () => {
+    const ctx = makeMockCtx();
+    mockGetContext.mockReturnValueOnce(ctx);
+    // phaseAngle < 180 → waxing path
+    const canvas = generateMoonSprite(0.75, 90);
+    expect(canvas).toBeInstanceOf(HTMLCanvasElement);
+    expect(canvas.width).toBe(48);
+    expect(ctx.arc).toHaveBeenCalled();
+    expect(ctx.ellipse).toHaveBeenCalled();
+    expect(ctx.fill).toHaveBeenCalled();
+  });
+
+  it("generateMoonSprite draws crescent (waning) when context available", () => {
+    const ctx = makeMockCtx();
+    mockGetContext.mockReturnValueOnce(ctx);
+    // phaseAngle >= 180 → waning path
+    const canvas = generateMoonSprite(0.25, 270);
+    expect(canvas).toBeInstanceOf(HTMLCanvasElement);
+    expect(ctx.ellipse).toHaveBeenCalled();
+    expect(ctx.fill).toHaveBeenCalled();
+  });
+
+  it("generatePlanetSprite draws a radial gradient when context available", () => {
+    const ctx = makeMockCtx();
+    mockGetContext.mockReturnValueOnce(ctx);
+    const canvas = generatePlanetSprite("#CC4422");
+    expect(canvas).toBeInstanceOf(HTMLCanvasElement);
+    expect(canvas.width).toBe(32);
+    expect(ctx.createRadialGradient).toHaveBeenCalledOnce();
+    expect(ctx.gradient.addColorStop).toHaveBeenCalledTimes(3);
+    expect(ctx.fillRect).toHaveBeenCalledOnce();
+  });
+
+  it("all sprite functions return blank canvas when getContext returns null", () => {
+    mockGetContext.mockReturnValue(null);
+    expect(generateSunSprite()).toBeInstanceOf(HTMLCanvasElement);
+    expect(generateMoonSprite(0.5, 90)).toBeInstanceOf(HTMLCanvasElement);
+    expect(generatePlanetSprite("#fff")).toBeInstanceOf(HTMLCanvasElement);
+  });
+});
+
+describe("createBodyLayer", () => {
+  it("returns an object with an update method", () => {
+    const layer = createBodyLayer(makeMockScene() as never);
+    expect(layer).toHaveProperty("update");
+  });
+
+  it("registers a BillboardCollection with scene.primitives", () => {
+    const scene = makeMockScene();
+    createBodyLayer(scene as never);
+    expect(scene.primitives.add).toHaveBeenCalledOnce();
+  });
+});
+
+describe("BodyLayer.update", () => {
+  it("adds a billboard for each body", () => {
+    const layer = createBodyLayer(makeMockScene() as never);
+    layer.update(BODIES, 33, -117);
+    expect(mockRemoveAll).toHaveBeenCalledOnce();
+    expect(mockAdd).toHaveBeenCalledTimes(3);
+  });
+
+  it("Sun billboard has the largest scale", () => {
+    const layer = createBodyLayer(makeMockScene() as never);
+    layer.update(BODIES, 33, -117);
+    const sunCall = mockAdd.mock.calls[0]![0] as { scale: number };
+    const venusCall = mockAdd.mock.calls[2]![0] as { scale: number };
+    expect(sunCall.scale).toBeGreaterThan(venusCall.scale);
+  });
+
+  it("works with empty body list", () => {
+    const layer = createBodyLayer(makeMockScene() as never);
+    layer.update([], 0, 0);
+    expect(mockRemoveAll).toHaveBeenCalledOnce();
+    expect(mockAdd).not.toHaveBeenCalled();
+  });
+
+  it("clears previous billboards before adding new ones", () => {
+    const layer = createBodyLayer(makeMockScene() as never);
+    layer.update(BODIES, 33, -117);
+    mockAdd.mockClear();
+    mockRemoveAll.mockClear();
+    layer.update(BODIES.slice(0, 1), 33, -117);
+    expect(mockRemoveAll).toHaveBeenCalledOnce();
+    expect(mockAdd).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/scene/bodies.ts
+++ b/src/scene/bodies.ts
@@ -1,0 +1,117 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { BillboardCollection, Color, HorizontalOrigin, VerticalOrigin } from "cesium";
+import type { Scene } from "cesium";
+import type { CelestialBody } from "../astro";
+import { altAzToCartesian } from "./stars";
+
+export type BodyLayer = {
+  update: (bodies: CelestialBody[], lat: number, lon: number) => void;
+};
+
+function getContext(canvas: HTMLCanvasElement): CanvasRenderingContext2D | null {
+  try {
+    return canvas.getContext("2d");
+  } catch {
+    // jsdom / test environment: getContext throws if canvas package absent
+    return null;
+  }
+}
+
+export function generateSunSprite(): HTMLCanvasElement {
+  const size = 48;
+  const canvas = document.createElement("canvas");
+  canvas.width = size;
+  canvas.height = size;
+  const ctx = getContext(canvas);
+  if (!ctx) return canvas;
+  const center = size / 2;
+  const gradient = ctx.createRadialGradient(center, center, 0, center, center, center);
+  gradient.addColorStop(0, "rgba(253, 184, 19, 1)");
+  gradient.addColorStop(0.2, "rgba(253, 184, 19, 0.8)");
+  gradient.addColorStop(0.5, "rgba(253, 150, 19, 0.3)");
+  gradient.addColorStop(1, "rgba(253, 150, 19, 0)");
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, size, size);
+  return canvas;
+}
+
+export function generateMoonSprite(illumination: number, phaseAngle: number): HTMLCanvasElement {
+  const size = 48;
+  const canvas = document.createElement("canvas");
+  canvas.width = size;
+  canvas.height = size;
+  const ctx = getContext(canvas);
+  if (!ctx) return canvas;
+  const center = size / 2;
+  const radius = center - 2;
+
+  ctx.fillStyle = "#E8E8E0";
+  ctx.beginPath();
+  ctx.arc(center, center, radius, 0, Math.PI * 2);
+  ctx.fill();
+
+  ctx.globalCompositeOperation = "destination-out";
+  ctx.fillStyle = "rgba(0,0,0,1)";
+
+  const shadowWidth = radius * (1 - illumination * 2);
+  const waxing = phaseAngle < 180;
+
+  ctx.beginPath();
+  if (waxing) {
+    ctx.ellipse(center, center, Math.abs(shadowWidth), radius, 0, -Math.PI / 2, Math.PI / 2);
+    ctx.arc(center, center, radius, Math.PI / 2, -Math.PI / 2, false);
+  } else {
+    ctx.ellipse(center, center, Math.abs(shadowWidth), radius, 0, Math.PI / 2, -Math.PI / 2);
+    ctx.arc(center, center, radius, -Math.PI / 2, Math.PI / 2, false);
+  }
+  ctx.fill();
+
+  ctx.globalCompositeOperation = "source-over";
+  return canvas;
+}
+
+export function generatePlanetSprite(color: string): HTMLCanvasElement {
+  const size = 32;
+  const canvas = document.createElement("canvas");
+  canvas.width = size;
+  canvas.height = size;
+  const ctx = getContext(canvas);
+  if (!ctx) return canvas;
+  const center = size / 2;
+  const gradient = ctx.createRadialGradient(center, center, 0, center, center, center);
+  gradient.addColorStop(0, color);
+  gradient.addColorStop(0.5, color);
+  gradient.addColorStop(1, "rgba(0,0,0,0)");
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, size, size);
+  return canvas;
+}
+
+function spriteForBody(body: CelestialBody): HTMLCanvasElement {
+  if (body.id === "Sun") return generateSunSprite();
+  if (body.id === "Moon") return generateMoonSprite(body.illumination ?? 0.5, body.phaseAngle ?? 0);
+  return generatePlanetSprite(body.color);
+}
+
+export function createBodyLayer(scene: Scene): BodyLayer {
+  const billboards = new BillboardCollection({ scene });
+  scene.primitives.add(billboards);
+
+  function update(bodies: CelestialBody[], lat: number, lon: number): void {
+    billboards.removeAll();
+    for (const body of bodies) {
+      billboards.add({
+        position: altAzToCartesian(body.alt, body.az, lat, lon),
+        image: spriteForBody(body),
+        scale: body.size / 16,
+        color: Color.fromCssColorString(body.color).withAlpha(1.0),
+        horizontalOrigin: HorizontalOrigin.CENTER,
+        verticalOrigin: VerticalOrigin.CENTER,
+        disableDepthTestDistance: Number.POSITIVE_INFINITY,
+        id: body,
+      });
+    }
+  }
+
+  return { update };
+}

--- a/src/scene/index.ts
+++ b/src/scene/index.ts
@@ -3,3 +3,4 @@ export { type SceneInitError, createViewer } from "./viewer";
 export { initCamera } from "./camera";
 export { type StarLayer, createStarLayer } from "./stars";
 export { type Tooltip, createTooltip } from "./tooltip";
+export { type BodyLayer, createBodyLayer } from "./bodies";

--- a/src/scene/tooltip.test.ts
+++ b/src/scene/tooltip.test.ts
@@ -102,4 +102,36 @@ describe("createTooltip", () => {
     expect(mockDestroy).toHaveBeenCalledOnce();
     expect(container.querySelector("div")).toBeNull();
   });
+
+  it("shows tooltip with body info when a CelestialBody billboard is picked", () => {
+    const container = document.createElement("div");
+    const viewer = makeMockViewer();
+    createTooltip(viewer as never, container);
+
+    const moveCallback = mockSetInputAction.mock.calls[0]![0] as (movement: {
+      endPosition: { x: number; y: number };
+    }) => void;
+
+    mockPick.mockReturnValueOnce({
+      id: {
+        id: "Moon",
+        alt: 55.3,
+        az: 120.1,
+        ra: 100.5,
+        dec: -5.2,
+        mag: -12.7,
+        size: 20,
+        color: "#E8E8E0",
+        illumination: 0.75,
+        phaseAngle: 90,
+      },
+    });
+    moveCallback({ endPosition: { x: 150, y: 250 } });
+
+    const tooltipDiv = container.querySelector("div")!;
+    expect(tooltipDiv.style.display).toBe("block");
+    expect(tooltipDiv.innerHTML).toContain("Moon");
+    expect(tooltipDiv.innerHTML).toContain("-12.7");
+    expect(tooltipDiv.innerHTML).toContain("75%");
+  });
 });

--- a/src/scene/tooltip.ts
+++ b/src/scene/tooltip.ts
@@ -2,6 +2,7 @@
 import { ScreenSpaceEventHandler, ScreenSpaceEventType, defined } from "cesium";
 import type { Cartesian2, Viewer } from "cesium";
 import type { AltAzStar } from "../astro";
+import type { CelestialBody } from "../astro";
 
 export type Tooltip = {
   destroy: () => void;
@@ -33,6 +34,40 @@ function isAltAzStar(obj: unknown): obj is AltAzStar {
   );
 }
 
+function isCelestialBody(obj: unknown): obj is CelestialBody {
+  return (
+    typeof obj === "object" &&
+    obj !== null &&
+    "id" in obj &&
+    typeof (obj as Record<string, unknown>).id === "string" &&
+    "alt" in obj &&
+    "az" in obj &&
+    "mag" in obj
+  );
+}
+
+function formatStar(star: AltAzStar): string {
+  const label = star.name ?? `HIP ${String(star.hip)}`;
+  return (
+    `<strong>${label}</strong><br>` +
+    `mag ${star.mag.toFixed(2)}<br>` +
+    `Alt ${star.alt.toFixed(1)}\u00B0 Az ${star.az.toFixed(1)}\u00B0<br>` +
+    `RA ${formatRa(star.ra)} Dec ${formatDec(star.dec)}`
+  );
+}
+
+function formatBody(body: CelestialBody): string {
+  let html =
+    `<strong>${body.id}</strong><br>` +
+    `mag ${body.mag.toFixed(2)}<br>` +
+    `Alt ${body.alt.toFixed(1)}\u00B0 Az ${body.az.toFixed(1)}\u00B0<br>` +
+    `RA ${formatRa(body.ra)} Dec ${formatDec(body.dec)}`;
+  if (body.illumination !== undefined) {
+    html += `<br>${Math.round(body.illumination * 100)}% illuminated`;
+  }
+  return html;
+}
+
 export function createTooltip(viewer: Viewer, container: HTMLElement): Tooltip {
   const el = document.createElement("div");
   el.style.cssText =
@@ -47,14 +82,18 @@ export function createTooltip(viewer: Viewer, container: HTMLElement): Tooltip {
     const picked: { id?: unknown } | undefined = viewer.scene.pick(movement.endPosition) as
       | { id?: unknown }
       | undefined;
-    if (defined(picked) && picked !== undefined && isAltAzStar(picked.id)) {
-      const star = picked.id;
-      const label = star.name ?? `HIP ${String(star.hip)}`;
-      el.innerHTML =
-        `<strong>${label}</strong><br>` +
-        `mag ${star.mag.toFixed(2)}<br>` +
-        `Alt ${star.alt.toFixed(1)}\u00B0 Az ${star.az.toFixed(1)}\u00B0<br>` +
-        `RA ${formatRa(star.ra)} Dec ${formatDec(star.dec)}`;
+
+    let html: string | null = null;
+    if (defined(picked) && picked !== undefined) {
+      if (isAltAzStar(picked.id)) {
+        html = formatStar(picked.id);
+      } else if (isCelestialBody(picked.id)) {
+        html = formatBody(picked.id);
+      }
+    }
+
+    if (html !== null) {
+      el.innerHTML = html;
       el.style.display = "block";
       el.style.left = `${String(movement.endPosition.x + 14)}px`;
       el.style.top = `${String(movement.endPosition.y + 14)}px`;


### PR DESCRIPTION
Closes #63

Implements `createBodyLayer(scene)` for Plan 03 Task 4, rendering Sun, Moon, and five naked-eye planets as a `BillboardCollection` with canvas-generated sprites.

## What's included

- **`src/scene/bodies.ts`** — `createBodyLayer()` with three sprite generators:
  - Sun: 48×48 radial gradient (yellow glow)
  - Moon: 48×48 crescent via ellipse+arc clipping (waxing and waning paths)
  - Planets: 32×32 radial gradient colored dots
  - Exports `generateSunSprite`, `generateMoonSprite`, `generatePlanetSprite` for testability
- **`src/scene/bodies.test.ts`** — 11 tests covering layer creation, billboard counts, scale ordering, empty list, and all sprite drawing paths (both null-context fallback and mock 2d context)
- **`src/scene/tooltip.ts`** — adds `isCelestialBody` type guard and `formatBody` with illumination percentage display
- **`src/scene/tooltip.test.ts`** — adds Moon body tooltip test (6 total)
- **`src/scene/index.ts`** — exports `BodyLayer` and `createBodyLayer`
- **`src/app.ts`** — wires `computeBodyPositions` + `createBodyLayer` after star layer
- **`src/app.test.ts`** — adds `Color.fromCssColorString` to Cesium mock

## Gate results

- `pnpm typecheck` — PASS
- `pnpm format:check` — PASS
- `pnpm lint` — PASS
- `pnpm test:cov` — PASS (90 tests)
  - `src/scene/bodies.ts`: 97.89% lines, 86.36% branches
  - `src/scene/**` overall: 98.62% lines, 89.28% branches