### PR TITLE
Tune Sun/Jupiter body visuals

### DIFF
--- a/src/astro/bodies.ts
+++ b/src/astro/bodies.ts
@@ -25,12 +25,12 @@ type BodyConfig = {
 };
 
 const BODY_CONFIGS: BodyConfig[] = [
-  { body: Body.Sun, id: "Sun", color: "#FDB813", size: 24, mag: -26.74 },
+  { body: Body.Sun, id: "Sun", color: "#FFD700", size: 40, mag: -26.74 },
   { body: Body.Moon, id: "Moon", color: "#E8E8E0", size: 20, mag: -12.7 },
   { body: Body.Mercury, id: "Mercury", color: "#B5A7A7", size: 6, mag: 0.0 },
   { body: Body.Venus, id: "Venus", color: "#FFFFCC", size: 10, mag: -4.0 },
   { body: Body.Mars, id: "Mars", color: "#CC4422", size: 8, mag: 1.0 },
-  { body: Body.Jupiter, id: "Jupiter", color: "#D4A96A", size: 9, mag: -2.0 },
+  { body: Body.Jupiter, id: "Jupiter", color: "#E8C8C0", size: 9, mag: -2.0 },
   { body: Body.Saturn, id: "Saturn", color: "#C8B07A", size: 7, mag: 0.5 },
 ];
 

--- a/src/scene/bodies.test.ts
+++ b/src/scene/bodies.test.ts
@@ -100,9 +100,9 @@ describe("sprite generators (with 2d context)", () => {
     mockGetContext.mockReturnValueOnce(ctx);
     const canvas = generateSunSprite();
     expect(canvas).toBeInstanceOf(HTMLCanvasElement);
-    expect(canvas.width).toBe(48);
+    expect(canvas.width).toBe(96);
     expect(ctx.createRadialGradient).toHaveBeenCalledOnce();
-    expect(ctx.gradient.addColorStop).toHaveBeenCalledTimes(4);
+    expect(ctx.gradient.addColorStop).toHaveBeenCalledTimes(5);
     expect(ctx.fillRect).toHaveBeenCalledOnce();
   });
 

--- a/src/scene/bodies.ts
+++ b/src/scene/bodies.ts
@@ -18,7 +18,7 @@ function getContext(canvas: HTMLCanvasElement): CanvasRenderingContext2D | null 
 }
 
 export function generateSunSprite(): HTMLCanvasElement {
-  const size = 48;
+  const size = 96;
   const canvas = document.createElement("canvas");
   canvas.width = size;
   canvas.height = size;
@@ -26,10 +26,11 @@ export function generateSunSprite(): HTMLCanvasElement {
   if (!ctx) return canvas;
   const center = size / 2;
   const gradient = ctx.createRadialGradient(center, center, 0, center, center, center);
-  gradient.addColorStop(0, "rgba(253, 184, 19, 1)");
-  gradient.addColorStop(0.2, "rgba(253, 184, 19, 0.8)");
-  gradient.addColorStop(0.5, "rgba(253, 150, 19, 0.3)");
-  gradient.addColorStop(1, "rgba(253, 150, 19, 0)");
+  gradient.addColorStop(0, "rgba(255, 255, 50, 1)");
+  gradient.addColorStop(0.1, "rgba(255, 230, 0, 0.95)");
+  gradient.addColorStop(0.25, "rgba(255, 215, 0, 0.7)");
+  gradient.addColorStop(0.5, "rgba(255, 200, 0, 0.25)");
+  gradient.addColorStop(1, "rgba(255, 180, 0, 0)");
   ctx.fillStyle = gradient;
   ctx.fillRect(0, 0, size, size);
   return canvas;


### PR DESCRIPTION
## Summary
- Sun: larger sprite (96px up from 48), more vivid yellow, base size 40 (up from 24)
- Jupiter: warmer pinkish tone (#E8C8C0)
- Updated sun sprite test for new canvas size + gradient stop count

Visual tuning based on live review.