### PR TITLE
feat(astro): add parseConstellations and filterVisibleConstellations

### DIFF
--- a/src/astro/constellations.test.ts
+++ b/src/astro/constellations.test.ts
@@ -1,0 +1,99 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { describe, expect, it } from "vitest";
+import { isErr, isOk, expectOk } from "../result";
+import { parseConstellations, filterVisibleConstellations } from "./constellations";
+import type { AltAzStar } from "./visibility";
+
+const VALID_DATA = [
+  {
+    id: "Ori",
+    name: "Orion",
+    lines: [
+      [27366, 26311],
+      [26311, 25336],
+      [25336, 25930],
+    ],
+  },
+  {
+    id: "UMa",
+    name: "Ursa Major",
+    lines: [
+      [54061, 53910],
+      [53910, 58001],
+    ],
+  },
+];
+
+describe("parseConstellations", () => {
+  it("parses valid constellation array", () => {
+    const r = parseConstellations(VALID_DATA);
+    expect(isOk(r)).toBe(true);
+    const data = expectOk(r);
+    expect(data).toHaveLength(2);
+    expect(data[0]!.id).toBe("Ori");
+    expect(data[0]!.lines).toHaveLength(3);
+  });
+
+  it("returns Err for non-array input", () => {
+    const r = parseConstellations("not an array");
+    expect(isErr(r)).toBe(true);
+  });
+
+  it("returns Err for empty array", () => {
+    const r = parseConstellations([]);
+    expect(isErr(r)).toBe(true);
+  });
+
+  it("skips entries with missing id or name", () => {
+    const data = [
+      { id: "Ori", name: "Orion", lines: [[1, 2]] },
+      { name: "Bad", lines: [[3, 4]] },
+    ];
+    const result = expectOk(parseConstellations(data));
+    expect(result).toHaveLength(1);
+  });
+});
+
+describe("filterVisibleConstellations", () => {
+  const starMap: AltAzStar[] = [
+    { hip: 27366, ra: 88.79, dec: 7.41, alt: 45, az: 180, mag: 0.5, size: 14, opacity: 0.95 },
+    { hip: 26311, ra: 81.28, dec: 6.35, alt: 30, az: 170, mag: 1.7, size: 10, opacity: 0.8 },
+    { hip: 25336, ra: 78.63, dec: -8.2, alt: -5, az: 160, mag: 2.1, size: 9, opacity: 0.75 },
+    { hip: 25930, ra: 80.0, dec: -1.0, alt: 20, az: 165, mag: 1.9, size: 9, opacity: 0.78 },
+    { hip: 54061, ra: 166.45, dec: 61.75, alt: 60, az: 350, mag: 1.8, size: 10, opacity: 0.8 },
+    { hip: 53910, ra: 165.93, dec: 61.45, alt: 58, az: 348, mag: 2.4, size: 8, opacity: 0.7 },
+    { hip: 58001, ra: 178.46, dec: 53.69, alt: 55, az: 340, mag: 2.4, size: 8, opacity: 0.7 },
+  ];
+
+  const constellations = expectOk(parseConstellations(VALID_DATA));
+
+  it("includes lines where both stars are visible", () => {
+    const result = filterVisibleConstellations(constellations, starMap);
+    const uma = result.find((c) => c.id === "UMa");
+    expect(uma).toBeDefined();
+    expect(uma!.lines).toHaveLength(2);
+  });
+
+  it("excludes lines where one star is below horizon", () => {
+    const result = filterVisibleConstellations(constellations, starMap);
+    const ori = result.find((c) => c.id === "Ori");
+    expect(ori).toBeDefined();
+    // star 25336 is at alt=-5, so lines involving it are excluded
+    // Line [27366,26311] both visible, [26311,25336] one below, [25336,25930] one below
+    expect(ori!.lines).toHaveLength(1);
+  });
+
+  it("excludes constellations with no visible lines", () => {
+    const noStars: AltAzStar[] = [];
+    const result = filterVisibleConstellations(constellations, noStars);
+    expect(result).toHaveLength(0);
+  });
+
+  it("computes centroid from visible endpoints", () => {
+    const result = filterVisibleConstellations(constellations, starMap);
+    const uma = result.find((c) => c.id === "UMa");
+    expect(uma).toBeDefined();
+    expect(uma!.centroid.alt).toBeGreaterThan(0);
+    expect(uma!.centroid.az).toBeGreaterThan(0);
+  });
+});

--- a/src/astro/constellations.ts
+++ b/src/astro/constellations.ts
@@ -1,0 +1,110 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { err, ok, type Result } from "../result";
+import type { AltAzStar } from "./visibility";
+
+export type ConstellationRecord = {
+  readonly id: string;
+  readonly name: string;
+  readonly lines: readonly (readonly [number, number])[];
+};
+
+export type ConstellationLoadError = { kind: "constellation-load-failed"; message: string };
+
+export type VisibleLine = {
+  readonly start: { readonly alt: number; readonly az: number };
+  readonly end: { readonly alt: number; readonly az: number };
+};
+
+export type VisibleConstellation = {
+  readonly id: string;
+  readonly name: string;
+  readonly lines: readonly VisibleLine[];
+  readonly centroid: { readonly alt: number; readonly az: number };
+};
+
+export function parseConstellations(
+  raw: unknown,
+): Result<ConstellationRecord[], ConstellationLoadError> {
+  if (!Array.isArray(raw)) {
+    return err({
+      kind: "constellation-load-failed",
+      message: "Constellation data is not an array",
+    });
+  }
+  if (raw.length === 0) {
+    return err({ kind: "constellation-load-failed", message: "Constellation data is empty" });
+  }
+
+  const result: ConstellationRecord[] = [];
+  for (const entry of raw) {
+    if (typeof entry !== "object" || entry === null) continue;
+    const e = entry as Record<string, unknown>;
+    if (typeof e.id !== "string" || typeof e.name !== "string") continue;
+    if (!Array.isArray(e.lines)) continue;
+
+    const lines: [number, number][] = [];
+    for (const pair of e.lines) {
+      if (Array.isArray(pair) && pair.length >= 2) {
+        const a = Number(pair[0]);
+        const b = Number(pair[1]);
+        if (Number.isFinite(a) && Number.isFinite(b) && a > 0 && b > 0) {
+          lines.push([a, b]);
+        }
+      }
+    }
+    if (lines.length > 0) {
+      result.push({ id: e.id, name: e.name, lines });
+    }
+  }
+
+  if (result.length === 0) {
+    return err({
+      kind: "constellation-load-failed",
+      message: "No valid constellations after parsing",
+    });
+  }
+  return ok(result);
+}
+
+export function filterVisibleConstellations(
+  constellations: ConstellationRecord[],
+  visibleStars: AltAzStar[],
+): VisibleConstellation[] {
+  const starMap = new Map<number, AltAzStar>();
+  for (const star of visibleStars) {
+    starMap.set(star.hip, star);
+  }
+
+  const result: VisibleConstellation[] = [];
+  for (const constellation of constellations) {
+    const visibleLines: VisibleLine[] = [];
+    let altSum = 0;
+    let azSum = 0;
+    let pointCount = 0;
+
+    for (const [hipA, hipB] of constellation.lines) {
+      const starA = starMap.get(hipA);
+      const starB = starMap.get(hipB);
+      if (starA && starB && starA.alt > 0 && starB.alt > 0) {
+        visibleLines.push({
+          start: { alt: starA.alt, az: starA.az },
+          end: { alt: starB.alt, az: starB.az },
+        });
+        altSum += starA.alt + starB.alt;
+        azSum += starA.az + starB.az;
+        pointCount += 2;
+      }
+    }
+
+    if (visibleLines.length > 0 && pointCount > 0) {
+      result.push({
+        id: constellation.id,
+        name: constellation.name,
+        lines: visibleLines,
+        centroid: { alt: altSum / pointCount, az: azSum / pointCount },
+      });
+    }
+  }
+
+  return result;
+}


### PR DESCRIPTION
## Summary

- Adds `parseConstellations(raw)` returning `Result<ConstellationRecord[], ConstellationLoadError>` — validates raw JSON data, skips malformed entries, fails on empty/non-array input
- Adds `filterVisibleConstellations(constellations, visibleStars)` returning `VisibleConstellation[]` — builds a HIP→star map, keeps only line segments where both endpoints are above the horizon (`alt > 0`), computes centroid from visible endpoints

Closes #76

## Test plan

- [x] TDD: wrote 8 failing tests first, confirmed red (module not found), then implemented
- [x] `pnpm typecheck` — passes
- [x] `pnpm format:check` — passes
- [x] `pnpm lint` — passes
- [x] `pnpm test` — 98 tests pass (15 test files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)