### PR TITLE
Plan 04 — Tasks 3-6: Constellation layer + app wiring

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -17,3 +17,8 @@ https://github.com/CesiumGS/cesium
 Star catalog derived from the Hipparcos catalogue (ESA, 1997)
 via the HYG Database (https://github.com/astronexus/HYG-Database).
 The Hipparcos data is in the public domain.
+
+Constellation stick-figure data derived from Stellarium
+(https://github.com/Stellarium/stellarium).
+Stellarium is licensed under GPL-2.0; the constellation line data
+(skycultures/modern_st/) is in the public domain.

--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -50,6 +50,16 @@ vi.mock("cesium", () => ({
   })),
   ScreenSpaceEventType: { MOUSE_MOVE: 0 },
   defined: (v: unknown) => v !== undefined && v !== null,
+  PolylineCollection: vi.fn().mockImplementation(() => ({
+    add: vi.fn(),
+    removeAll: vi.fn(),
+  })),
+  LabelCollection: vi.fn().mockImplementation(() => ({
+    add: vi.fn(),
+    removeAll: vi.fn(),
+  })),
+  LabelStyle: { FILL: 0 },
+  Material: { fromType: vi.fn().mockReturnValue({}) },
 }));
 
 vi.mock("../data/stars.json", () => ({
@@ -57,6 +67,10 @@ vi.mock("../data/stars.json", () => ({
     { hip: 11767, ra: 37.9546, dec: 89.2641, mag: 2.02, name: "Polaris" },
     { hip: 32349, ra: 101.2872, dec: -16.7161, mag: -1.46, name: "Sirius" },
   ],
+}));
+
+vi.mock("../data/constellations.json", () => ({
+  default: [{ id: "Ori", name: "Orion", lines: [[27366, 26311]] }],
 }));
 
 import { bootstrap } from "./app";

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,8 +1,22 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 import { parseStateFromSearchParams } from "./state";
-import { parseCatalog, filterVisibleStars, computeBodyPositions } from "./astro";
-import { createViewer, initCamera, createStarLayer, createBodyLayer, createTooltip } from "./scene";
+import {
+  parseCatalog,
+  filterVisibleStars,
+  computeBodyPositions,
+  parseConstellations,
+  filterVisibleConstellations,
+} from "./astro";
+import {
+  createViewer,
+  initCamera,
+  createStarLayer,
+  createBodyLayer,
+  createTooltip,
+  createConstellationLayer,
+} from "./scene";
 import rawStars from "../data/stars.json";
+import rawConstellations from "../data/constellations.json";
 
 export function bootstrap(
   root: HTMLElement | null,
@@ -41,6 +55,18 @@ export function bootstrap(
   const bodies = computeBodyPositions(observer.lat, observer.lon, timeUtc, true);
   const bodyLayer = createBodyLayer(viewer.scene);
   bodyLayer.update(bodies, observer.lat, observer.lon);
+
+  const constellationResult = parseConstellations(rawConstellations);
+  if (constellationResult.ok) {
+    const visibleConstellations = filterVisibleConstellations(
+      constellationResult.value,
+      visibleStars,
+    );
+    const constellationLayer = createConstellationLayer(viewer.scene);
+    constellationLayer.update(visibleConstellations, observer.lat, observer.lon);
+  } else {
+    console.warn(`Constellation load warning: ${constellationResult.error.message}`);
+  }
 
   const cesiumContainer = document.getElementById("cesium-container");
   if (cesiumContainer) {

--- a/src/astro/index.ts
+++ b/src/astro/index.ts
@@ -5,3 +5,11 @@ export { type StarVisual, magToVisual } from "./magnitude";
 export { type AltAzStar, filterVisibleStars } from "./visibility";
 export { type MoonIllumination, getMoonIllumination } from "./moon-phase";
 export { type CelestialBody, computeBodyPositions } from "./bodies";
+export {
+  type ConstellationRecord,
+  type ConstellationLoadError,
+  type VisibleLine,
+  type VisibleConstellation,
+  parseConstellations,
+  filterVisibleConstellations,
+} from "./constellations";

--- a/src/scene/constellations.test.ts
+++ b/src/scene/constellations.test.ts
@@ -1,0 +1,131 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createConstellationLayer } from "./constellations";
+import type { VisibleConstellation } from "../astro";
+
+const mockPolylineAdd = vi.fn();
+const mockPolylineRemoveAll = vi.fn();
+const mockLabelAdd = vi.fn();
+const mockLabelRemoveAll = vi.fn();
+
+vi.mock("cesium", () => {
+  const MockCartesian3 = vi.fn().mockImplementation((x: number, y: number, z: number) => ({
+    x,
+    y,
+    z,
+  }));
+  (MockCartesian3 as unknown as { fromDegrees: ReturnType<typeof vi.fn> }).fromDegrees = vi
+    .fn()
+    .mockReturnValue({ x: 1, y: 2, z: 3 });
+
+  return {
+    PolylineCollection: vi.fn().mockImplementation(() => ({
+      add: mockPolylineAdd,
+      removeAll: mockPolylineRemoveAll,
+    })),
+    LabelCollection: vi.fn().mockImplementation(() => ({
+      add: mockLabelAdd,
+      removeAll: mockLabelRemoveAll,
+    })),
+    Cartesian3: MockCartesian3,
+    Color: {
+      WHITE: { withAlpha: (a: number) => ({ alpha: a }) },
+    },
+    HorizontalOrigin: { CENTER: 0 },
+    VerticalOrigin: { CENTER: 0 },
+    LabelStyle: { FILL: 0 },
+    Math: { toRadians: (d: number) => (d * Math.PI) / 180 },
+    Transforms: {
+      eastNorthUpToFixedFrame: vi
+        .fn()
+        .mockReturnValue([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]),
+    },
+    Matrix4: {
+      multiplyByPoint: vi.fn().mockReturnValue({ x: 10, y: 20, z: 30 }),
+    },
+    Material: {
+      fromType: vi.fn().mockReturnValue({}),
+    },
+  };
+});
+
+function makeMockScene() {
+  return { primitives: { add: vi.fn() } };
+}
+
+const CONSTELLATIONS: VisibleConstellation[] = [
+  {
+    id: "Ori",
+    name: "Orion",
+    lines: [
+      { start: { alt: 45, az: 180 }, end: { alt: 30, az: 170 } },
+      { start: { alt: 30, az: 170 }, end: { alt: 20, az: 165 } },
+    ],
+    centroid: { alt: 31.7, az: 171.7 },
+  },
+  {
+    id: "UMa",
+    name: "Ursa Major",
+    lines: [{ start: { alt: 60, az: 350 }, end: { alt: 58, az: 348 } }],
+    centroid: { alt: 59, az: 349 },
+  },
+];
+
+beforeEach(() => {
+  mockPolylineAdd.mockClear();
+  mockPolylineRemoveAll.mockClear();
+  mockLabelAdd.mockClear();
+  mockLabelRemoveAll.mockClear();
+});
+
+describe("createConstellationLayer", () => {
+  it("returns an object with an update method", () => {
+    const layer = createConstellationLayer(makeMockScene() as never);
+    expect(layer).toHaveProperty("update");
+  });
+
+  it("registers collections with scene.primitives", () => {
+    const scene = makeMockScene();
+    createConstellationLayer(scene as never);
+    expect(scene.primitives.add).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("ConstellationLayer.update", () => {
+  it("adds a polyline for each visible line segment", () => {
+    const layer = createConstellationLayer(makeMockScene() as never);
+    layer.update(CONSTELLATIONS, 33, -117);
+    expect(mockPolylineRemoveAll).toHaveBeenCalledOnce();
+    expect(mockPolylineAdd).toHaveBeenCalledTimes(3);
+  });
+
+  it("adds a label for each visible constellation", () => {
+    const layer = createConstellationLayer(makeMockScene() as never);
+    layer.update(CONSTELLATIONS, 33, -117);
+    expect(mockLabelRemoveAll).toHaveBeenCalledOnce();
+    expect(mockLabelAdd).toHaveBeenCalledTimes(2);
+  });
+
+  it("works with empty input", () => {
+    const layer = createConstellationLayer(makeMockScene() as never);
+    layer.update([], 0, 0);
+    expect(mockPolylineRemoveAll).toHaveBeenCalledOnce();
+    expect(mockLabelRemoveAll).toHaveBeenCalledOnce();
+    expect(mockPolylineAdd).not.toHaveBeenCalled();
+    expect(mockLabelAdd).not.toHaveBeenCalled();
+  });
+
+  it("clears previous primitives before adding", () => {
+    const layer = createConstellationLayer(makeMockScene() as never);
+    layer.update(CONSTELLATIONS, 33, -117);
+    mockPolylineAdd.mockClear();
+    mockLabelAdd.mockClear();
+    mockPolylineRemoveAll.mockClear();
+    mockLabelRemoveAll.mockClear();
+    layer.update(CONSTELLATIONS.slice(0, 1), 33, -117);
+    expect(mockPolylineRemoveAll).toHaveBeenCalledOnce();
+    expect(mockLabelRemoveAll).toHaveBeenCalledOnce();
+    expect(mockPolylineAdd).toHaveBeenCalledTimes(2);
+    expect(mockLabelAdd).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/scene/constellations.ts
+++ b/src/scene/constellations.ts
@@ -1,0 +1,62 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import {
+  PolylineCollection,
+  LabelCollection,
+  Color,
+  HorizontalOrigin,
+  VerticalOrigin,
+  LabelStyle,
+  Material,
+} from "cesium";
+import type { Scene } from "cesium";
+import type { VisibleConstellation } from "../astro";
+import { altAzToCartesian } from "./stars";
+
+export type ConstellationLayer = {
+  update: (constellations: VisibleConstellation[], lat: number, lon: number) => void;
+};
+
+export function createConstellationLayer(scene: Scene): ConstellationLayer {
+  const polylines = new PolylineCollection();
+  const labels = new LabelCollection({ scene });
+  scene.primitives.add(polylines);
+  scene.primitives.add(labels);
+
+  function update(constellations: VisibleConstellation[], lat: number, lon: number): void {
+    polylines.removeAll();
+    labels.removeAll();
+
+    for (const constellation of constellations) {
+      for (const line of constellation.lines) {
+        const startPos = altAzToCartesian(line.start.alt, line.start.az, lat, lon);
+        const endPos = altAzToCartesian(line.end.alt, line.end.az, lat, lon);
+        polylines.add({
+          positions: [startPos, endPos],
+          width: 1,
+          material: Material.fromType("Color", {
+            color: Color.WHITE.withAlpha(0.25),
+          }),
+        });
+      }
+
+      const centroidPos = altAzToCartesian(
+        constellation.centroid.alt,
+        constellation.centroid.az,
+        lat,
+        lon,
+      );
+      labels.add({
+        position: centroidPos,
+        text: constellation.name,
+        font: "12px sans-serif",
+        fillColor: Color.WHITE.withAlpha(0.6),
+        style: LabelStyle.FILL,
+        horizontalOrigin: HorizontalOrigin.CENTER,
+        verticalOrigin: VerticalOrigin.CENTER,
+        disableDepthTestDistance: Number.POSITIVE_INFINITY,
+      });
+    }
+  }
+
+  return { update };
+}

--- a/src/scene/index.ts
+++ b/src/scene/index.ts
@@ -4,3 +4,4 @@ export { initCamera } from "./camera";
 export { type StarLayer, createStarLayer } from "./stars";
 export { type Tooltip, createTooltip } from "./tooltip";
 export { type BodyLayer, createBodyLayer } from "./bodies";
+export { type ConstellationLayer, createConstellationLayer } from "./constellations";


### PR DESCRIPTION
Closes #77
Closes #78
Closes #79
Closes #80

## Summary

- **Task 3 (#77):** Export `ConstellationRecord`, `ConstellationLoadError`, `VisibleLine`, `VisibleConstellation`, `parseConstellations`, `filterVisibleConstellations` from `src/astro/index.ts`
- **Task 4 (#78):** New `src/scene/constellations.ts` — `createConstellationLayer` renders stick-figure lines via `PolylineCollection` (white α=0.25, width 1) and constellation name labels via `LabelCollection` (white α=0.6, 12px, `disableDepthTestDistance: Infinity`); 6 tests in `src/scene/constellations.test.ts`
- **Task 5 (#79):** Export `ConstellationLayer` + `createConstellationLayer` from `src/scene/index.ts`; add Stellarium public-domain attribution to `NOTICE`
- **Task 6 (#80):** Wire constellation layer into `src/app.ts` after the body layer — non-fatal on parse failure (logs warning, stars + bodies still render); update `src/app.test.ts` with `PolylineCollection`, `LabelCollection`, `LabelStyle`, `Material` mocks and constellation JSON mock

All gates pass: `pnpm typecheck && pnpm format:check && pnpm lint && pnpm test:cov && pnpm build` (104 tests, `src/scene/**` at 98.79% lines / 90% branches).