### PR TITLE
feat(sat): add TLE parser with satellite.js

### DIFF
--- a/src/sat/tle.test.ts
+++ b/src/sat/tle.test.ts
@@ -1,0 +1,56 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { describe, expect, it } from "vitest";
+import { isErr, isOk, expectOk } from "../result";
+import { parseTle } from "./tle";
+
+const ISS_TLE = `ISS (ZARYA)
+1 25544U 98067A   24100.50000000  .00016717  00000-0  10270-3 0  9006
+2 25544  51.6400 208.9163 0002476 102.8574 355.4846 15.49909786447384`;
+
+const TWO_SATS = `ISS (ZARYA)
+1 25544U 98067A   24100.50000000  .00016717  00000-0  10270-3 0  9006
+2 25544  51.6400 208.9163 0002476 102.8574 355.4846 15.49909786447384
+HUBBLE
+1 20580U 90037B   24100.50000000  .00001234  00000-0  56789-4 0  9005
+2 20580  28.4700 123.4567 0002345  67.8901 292.1098 15.09876543210987`;
+
+describe("parseTle", () => {
+  it("parses a single satellite TLE", () => {
+    const r = parseTle(ISS_TLE);
+    expect(isOk(r)).toBe(true);
+    const sats = expectOk(r);
+    expect(sats).toHaveLength(1);
+    expect(sats[0]!.name).toBe("ISS (ZARYA)");
+    expect(sats[0]!.noradId).toBe(25544);
+    expect(sats[0]!.satrec).toBeDefined();
+  });
+
+  it("parses multiple satellites", () => {
+    const sats = expectOk(parseTle(TWO_SATS));
+    expect(sats).toHaveLength(2);
+    expect(sats[0]!.name).toBe("ISS (ZARYA)");
+    expect(sats[1]!.name).toBe("HUBBLE");
+    expect(sats[1]!.noradId).toBe(20580);
+  });
+
+  it("returns Err for empty input", () => {
+    const r = parseTle("");
+    expect(isErr(r)).toBe(true);
+    if (isErr(r)) expect(r.error.kind).toBe("tle-parse-failed");
+  });
+
+  it("returns Err for non-string input", () => {
+    const r = parseTle(42 as unknown as string);
+    expect(isErr(r)).toBe(true);
+  });
+
+  it("skips malformed TLE entries gracefully", () => {
+    const badTle = `BAD SAT
+1 99999X INVALID
+2 99999
+${ISS_TLE}`;
+    const sats = expectOk(parseTle(badTle));
+    expect(sats).toHaveLength(1);
+    expect(sats[0]!.name).toBe("ISS (ZARYA)");
+  });
+});

--- a/src/sat/tle.test.ts
+++ b/src/sat/tle.test.ts
@@ -53,4 +53,26 @@ ${ISS_TLE}`;
     expect(sats).toHaveLength(1);
     expect(sats[0]!.name).toBe("ISS (ZARYA)");
   });
+
+  it("skips lines that don't start with TLE line markers", () => {
+    const withJunk = `JUNK LINE ONE
+JUNK LINE TWO
+JUNK LINE THREE
+${ISS_TLE}`;
+    const sats = expectOk(parseTle(withJunk));
+    expect(sats).toHaveLength(1);
+    expect(sats[0]!.name).toBe("ISS (ZARYA)");
+  });
+
+  it("returns Err when all entries are invalid", () => {
+    const allBad = `BAD ONE
+NOT A TLE LINE 1
+NOT A TLE LINE 2
+BAD TWO
+ALSO NOT LINE 1
+ALSO NOT LINE 2`;
+    const r = parseTle(allBad);
+    expect(isErr(r)).toBe(true);
+    if (isErr(r)) expect(r.error.kind).toBe("tle-parse-failed");
+  });
 });

--- a/src/sat/tle.ts
+++ b/src/sat/tle.ts
@@ -37,7 +37,11 @@ export function parseTle(raw: unknown): Result<SatelliteRecord[], TleParseError>
 
     try {
       const satrec = twoline2satrec(line1, line2);
-      if (satrec.error !== SatRecError.None || !Number.isFinite(satrec.no) || !Number.isFinite(satrec.inclo)) {
+      if (
+        satrec.error !== SatRecError.None ||
+        !Number.isFinite(satrec.no) ||
+        !Number.isFinite(satrec.inclo)
+      ) {
         i += 3;
         continue;
       }

--- a/src/sat/tle.ts
+++ b/src/sat/tle.ts
@@ -1,0 +1,60 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { twoline2satrec, SatRecError } from "satellite.js";
+import type { SatRec } from "satellite.js";
+import { err, ok, type Result } from "../result";
+
+export type SatelliteRecord = {
+  readonly name: string;
+  readonly noradId: number;
+  readonly satrec: SatRec;
+};
+
+export type TleParseError = { kind: "tle-parse-failed"; message: string };
+
+export function parseTle(raw: unknown): Result<SatelliteRecord[], TleParseError> {
+  if (typeof raw !== "string") {
+    return err({ kind: "tle-parse-failed", message: "TLE input is not a string" });
+  }
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) {
+    return err({ kind: "tle-parse-failed", message: "TLE input is empty" });
+  }
+
+  const lines = trimmed.split("\n").map((l) => l.trim());
+  const satellites: SatelliteRecord[] = [];
+
+  let i = 0;
+  while (i < lines.length) {
+    if (i + 2 >= lines.length) break;
+    const nameLine = lines[i]!;
+    const line1 = lines[i + 1]!;
+    const line2 = lines[i + 2]!;
+
+    if (!line1.startsWith("1 ") || !line2.startsWith("2 ")) {
+      i++;
+      continue;
+    }
+
+    try {
+      const satrec = twoline2satrec(line1, line2);
+      if (satrec.error !== SatRecError.None || !Number.isFinite(satrec.no) || !Number.isFinite(satrec.inclo)) {
+        i += 3;
+        continue;
+      }
+      const noradId = parseInt(line1.substring(2, 7).trim(), 10);
+      satellites.push({
+        name: nameLine.trim(),
+        noradId: Number.isFinite(noradId) ? noradId : 0,
+        satrec,
+      });
+    } catch {
+      // malformed TLE — skip
+    }
+    i += 3;
+  }
+
+  if (satellites.length === 0) {
+    return err({ kind: "tle-parse-failed", message: "No valid TLE entries found" });
+  }
+  return ok(satellites);
+}


### PR DESCRIPTION
## Summary

- Implements `parseTle(raw)` returning `Result<SatelliteRecord[], TleParseError>` in `src/sat/tle.ts`
- Uses `twoline2satrec` from satellite.js v7 (named export confirmed)
- Handles non-string input, empty input, multiple satellites, and gracefully skips malformed TLE entries
- Detects invalid satrecs via `SatRecError` enum comparison and `Number.isFinite` checks on orbital elements (satellite.js v7 returns `NaN`, not `null`, for bad TLEs)

Closes #92

## Test plan

- [x] 5 unit tests in `src/sat/tle.test.ts` — all pass
- [x] `pnpm typecheck` — clean
- [x] `pnpm format:check` — clean
- [x] `pnpm lint` — clean (required `SatRecError` enum import to satisfy `@typescript-eslint/no-unsafe-enum-comparison`)
- [x] `pnpm test` — 116/116 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)