### PR TITLE
Plan 05 — Tasks 6-8: Satellite scene layer + app wiring

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -22,3 +22,11 @@ Constellation stick-figure data derived from Stellarium
 (https://github.com/Stellarium/stellarium).
 Stellarium is licensed under GPL-2.0; the constellation line data
 (skycultures/modern_st/) is in the public domain.
+
+satellite.js
+Copyright (c) 2013-2024 Shashwat Kandadai and Contributors
+License: MIT
+https://github.com/shashwatak/satellite-js
+
+TLE data from CelesTrak (https://celestrak.org)
+Dr. T.S. Kelso. Used with attribution.

--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -73,12 +73,27 @@ vi.mock("../data/constellations.json", () => ({
   default: [{ id: "Ori", name: "Orion", lines: [[27366, 26311]] }],
 }));
 
+// Mock the TLE bundled data
+vi.mock("../data/tle/visual.txt?raw", () => ({
+  default:
+    "ISS (ZARYA)\n1 25544U 98067A   24100.50000000  .00016717  00000-0  10270-3 0  9006\n2 25544  51.6400 208.9163 0002476 102.8574 355.4846 15.49909786447384",
+}));
+
+// Mock the sat module so tests don't do real network/propagation
+vi.mock("./sat", () => ({
+  fetchTle: vi.fn().mockResolvedValue({ ok: true, value: "" }),
+  parseTle: vi
+    .fn()
+    .mockReturnValue({ ok: false, error: { kind: "tle-parse-failed", message: "mocked" } }),
+  propagateSatellites: vi.fn().mockReturnValue([]),
+}));
+
 import { bootstrap } from "./app";
 import * as astro from "./astro";
 import { err } from "./result";
 
 describe("bootstrap", () => {
-  it("creates a cesium-container div when root exists", () => {
+  it("creates a cesium-container div when root exists", async () => {
     const root = document.createElement("main");
     root.id = "app";
     const cesiumDiv = document.createElement("div");
@@ -89,17 +104,17 @@ describe("bootstrap", () => {
     root.appendChild(errorDiv);
     document.body.appendChild(root);
 
-    bootstrap(root);
+    await bootstrap(root);
 
     expect(document.getElementById("cesium-container")).toBeTruthy();
     document.body.removeChild(root);
   });
 
-  it("does nothing when root is null", () => {
-    expect(() => bootstrap(null)).not.toThrow();
+  it("does nothing when root is null", async () => {
+    await expect(bootstrap(null)).resolves.toBeUndefined();
   });
 
-  it("shows error text when state parsing fails", () => {
+  it("shows error text when state parsing fails", async () => {
     const root = document.createElement("main");
     root.id = "app";
     const errorDiv = document.createElement("div");
@@ -107,14 +122,14 @@ describe("bootstrap", () => {
     root.appendChild(errorDiv);
     document.body.appendChild(root);
 
-    bootstrap(root, new URLSearchParams({ lat: "999" }));
+    await bootstrap(root, new URLSearchParams({ lat: "999" }));
 
     expect(errorDiv.style.display).not.toBe("none");
     expect(errorDiv.textContent).toMatch(/lat-out-of-range/);
     document.body.removeChild(root);
   });
 
-  it("shows error text when catalog parsing fails", () => {
+  it("shows error text when catalog parsing fails", async () => {
     const spy = vi
       .spyOn(astro, "parseCatalog")
       .mockReturnValueOnce(err({ kind: "catalog-load-failed", message: "empty catalog" }));
@@ -125,7 +140,10 @@ describe("bootstrap", () => {
     root.appendChild(errorDiv);
     document.body.appendChild(root);
 
-    bootstrap(root, new URLSearchParams({ lat: "34", lon: "-118", t: "2026-01-15T04:00:00Z" }));
+    await bootstrap(
+      root,
+      new URLSearchParams({ lat: "34", lon: "-118", t: "2026-01-15T04:00:00Z" }),
+    );
 
     expect(errorDiv.style.display).not.toBe("none");
     expect(errorDiv.textContent).toMatch(/Catalog error/);
@@ -133,7 +151,7 @@ describe("bootstrap", () => {
     spy.mockRestore();
   });
 
-  it("shows error text when viewer creation fails", () => {
+  it("shows error text when viewer creation fails", async () => {
     const root = document.createElement("main");
     root.id = "app";
     const errorDiv = document.createElement("div");
@@ -142,7 +160,10 @@ describe("bootstrap", () => {
     // No #cesium-container in DOM → createViewer returns Err
     document.body.appendChild(root);
 
-    bootstrap(root, new URLSearchParams({ lat: "34", lon: "-118", t: "2026-01-15T04:00:00Z" }));
+    await bootstrap(
+      root,
+      new URLSearchParams({ lat: "34", lon: "-118", t: "2026-01-15T04:00:00Z" }),
+    );
 
     expect(errorDiv.style.display).not.toBe("none");
     expect(errorDiv.textContent).toMatch(/Scene error/);

--- a/src/app.ts
+++ b/src/app.ts
@@ -15,14 +15,16 @@ import {
   createTooltip,
   createConstellationLayer,
   createCompassLayer,
+  createSatelliteLayer,
 } from "./scene";
+import { fetchTle, parseTle, propagateSatellites } from "./sat";
 import rawStars from "../data/stars.json";
 import rawConstellations from "../data/constellations.json";
 
-export function bootstrap(
+export async function bootstrap(
   root: HTMLElement | null,
   params: URLSearchParams = new URLSearchParams(globalThis.location?.search ?? ""),
-): void {
+): Promise<void> {
   if (!root) return;
 
   const errorDiv = root.querySelector<HTMLElement>("#error");
@@ -71,6 +73,24 @@ export function bootstrap(
 
   const compassLayer = createCompassLayer(viewer.scene);
   compassLayer.update(observer.lat, observer.lon);
+
+  const tleResult = await fetchTle();
+  if (tleResult.ok) {
+    const satResult = parseTle(tleResult.value);
+    if (satResult.ok) {
+      const visibleSats = propagateSatellites(
+        satResult.value,
+        observer.lat,
+        observer.lon,
+        timeUtc,
+        true,
+      );
+      const satLayer = createSatelliteLayer(viewer.scene);
+      satLayer.update(visibleSats, observer.lat, observer.lon);
+    } else {
+      console.warn(`TLE parse warning: ${satResult.error.message}`);
+    }
+  }
 
   const cesiumContainer = document.getElementById("cesium-container");
   if (cesiumContainer) {

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,2 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /// <reference types="vite/client" />
+
+declare module "*.txt?raw" {
+  const content: string;
+  export default content;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,4 +2,4 @@
 import "cesium/Build/Cesium/Widgets/widgets.css";
 import { bootstrap } from "./app";
 
-bootstrap(document.getElementById("app"));
+void bootstrap(document.getElementById("app"));

--- a/src/scene/index.ts
+++ b/src/scene/index.ts
@@ -6,3 +6,4 @@ export { type Tooltip, createTooltip } from "./tooltip";
 export { type BodyLayer, createBodyLayer } from "./bodies";
 export { type ConstellationLayer, createConstellationLayer } from "./constellations";
 export { type CompassLayer, createCompassLayer } from "./compass";
+export { type SatelliteLayer, createSatelliteLayer } from "./satellites";

--- a/src/scene/satellites.test.ts
+++ b/src/scene/satellites.test.ts
@@ -1,0 +1,142 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { createSatelliteLayer } from "./satellites";
+import type { VisibleSatellite } from "../sat";
+
+const mockGetContext = vi.fn().mockReturnValue(null);
+beforeAll(() => {
+  HTMLCanvasElement.prototype.getContext =
+    mockGetContext as typeof HTMLCanvasElement.prototype.getContext;
+});
+
+const mockBillboardAdd = vi.fn().mockReturnValue({ show: true });
+const mockBillboardRemoveAll = vi.fn();
+const mockPolylineAdd = vi.fn();
+const mockPolylineRemoveAll = vi.fn();
+
+vi.mock("cesium", () => {
+  const MockCartesian3 = vi.fn().mockImplementation((x: number, y: number, z: number) => ({
+    x,
+    y,
+    z,
+  }));
+  (MockCartesian3 as unknown as { fromDegrees: ReturnType<typeof vi.fn> }).fromDegrees = vi
+    .fn()
+    .mockReturnValue({ x: 1, y: 2, z: 3 });
+
+  return {
+    BillboardCollection: vi.fn().mockImplementation(() => ({
+      add: mockBillboardAdd,
+      removeAll: mockBillboardRemoveAll,
+      length: 0,
+    })),
+    PolylineCollection: vi.fn().mockImplementation(() => ({
+      add: mockPolylineAdd,
+      removeAll: mockPolylineRemoveAll,
+    })),
+    Cartesian3: MockCartesian3,
+    Color: {
+      fromCssColorString: vi.fn().mockReturnValue({ withAlpha: (a: number) => ({ alpha: a }) }),
+    },
+    HorizontalOrigin: { CENTER: 0 },
+    VerticalOrigin: { CENTER: 0 },
+    Math: { toRadians: (d: number) => (d * Math.PI) / 180 },
+    Transforms: {
+      eastNorthUpToFixedFrame: vi
+        .fn()
+        .mockReturnValue([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]),
+    },
+    Matrix4: {
+      multiplyByPoint: vi.fn().mockReturnValue({ x: 10, y: 20, z: 30 }),
+    },
+    Material: { fromType: vi.fn().mockReturnValue({}) },
+  };
+});
+
+function makeMockScene() {
+  return { primitives: { add: vi.fn() } };
+}
+
+const SATS: VisibleSatellite[] = [
+  {
+    name: "ISS (ZARYA)",
+    noradId: 25544,
+    alt: 45,
+    az: 200,
+    height: 420,
+    velocity: 7.66,
+    trail: [
+      { alt: 40, az: 195 },
+      { alt: 42, az: 197 },
+      { alt: 44, az: 199 },
+    ],
+  },
+  {
+    name: "HUBBLE",
+    noradId: 20580,
+    alt: 30,
+    az: 150,
+    height: 540,
+    velocity: 7.59,
+    trail: [{ alt: 28, az: 148 }],
+  },
+];
+
+beforeEach(() => {
+  mockBillboardAdd.mockClear();
+  mockBillboardRemoveAll.mockClear();
+  mockPolylineAdd.mockClear();
+  mockPolylineRemoveAll.mockClear();
+});
+
+describe("createSatelliteLayer", () => {
+  it("returns an object with an update method", () => {
+    const layer = createSatelliteLayer(makeMockScene() as never);
+    expect(layer).toHaveProperty("update");
+  });
+
+  it("registers collections with scene.primitives", () => {
+    const scene = makeMockScene();
+    createSatelliteLayer(scene as never);
+    expect(scene.primitives.add).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("SatelliteLayer.update", () => {
+  it("adds a billboard for each satellite", () => {
+    const layer = createSatelliteLayer(makeMockScene() as never);
+    layer.update(SATS, 33, -117);
+    expect(mockBillboardRemoveAll).toHaveBeenCalledOnce();
+    expect(mockBillboardAdd).toHaveBeenCalledTimes(2);
+  });
+
+  it("adds a polyline for each satellite trail", () => {
+    const layer = createSatelliteLayer(makeMockScene() as never);
+    layer.update(SATS, 33, -117);
+    expect(mockPolylineRemoveAll).toHaveBeenCalledOnce();
+    // Only the first satellite has >= 2 trail points
+    expect(mockPolylineAdd).toHaveBeenCalledTimes(1);
+  });
+
+  it("works with empty input", () => {
+    const layer = createSatelliteLayer(makeMockScene() as never);
+    layer.update([], 0, 0);
+    expect(mockBillboardAdd).not.toHaveBeenCalled();
+    expect(mockPolylineAdd).not.toHaveBeenCalled();
+  });
+
+  it("clears previous before adding", () => {
+    const layer = createSatelliteLayer(makeMockScene() as never);
+    layer.update(SATS, 33, -117);
+    mockBillboardAdd.mockClear();
+    mockPolylineAdd.mockClear();
+    mockBillboardRemoveAll.mockClear();
+    mockPolylineRemoveAll.mockClear();
+    layer.update(SATS.slice(0, 1), 33, -117);
+    expect(mockBillboardRemoveAll).toHaveBeenCalledOnce();
+    expect(mockPolylineRemoveAll).toHaveBeenCalledOnce();
+    expect(mockBillboardAdd).toHaveBeenCalledTimes(1);
+    // First satellite has >= 2 trail points, so polyline is added
+    expect(mockPolylineAdd).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/scene/satellites.ts
+++ b/src/scene/satellites.ts
@@ -1,0 +1,81 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import {
+  BillboardCollection,
+  PolylineCollection,
+  Color,
+  HorizontalOrigin,
+  VerticalOrigin,
+  Material,
+} from "cesium";
+import type { Scene } from "cesium";
+import type { VisibleSatellite } from "../sat";
+import { altAzToCartesian } from "./stars";
+
+const SAT_COLOR = "#00FF88";
+
+export type SatelliteLayer = {
+  update: (satellites: VisibleSatellite[], lat: number, lon: number) => void;
+};
+
+function generateSatSprite(): HTMLCanvasElement {
+  const size = 16;
+  const canvas = document.createElement("canvas");
+  canvas.width = size;
+  canvas.height = size;
+  let ctx: CanvasRenderingContext2D | null;
+  try {
+    ctx = canvas.getContext("2d");
+  } catch {
+    // jsdom / test environment: getContext throws if canvas package absent
+    ctx = null;
+  }
+  if (!ctx) return canvas;
+  const center = size / 2;
+  const gradient = ctx.createRadialGradient(center, center, 0, center, center, center);
+  gradient.addColorStop(0, SAT_COLOR);
+  gradient.addColorStop(0.5, SAT_COLOR);
+  gradient.addColorStop(1, "rgba(0,0,0,0)");
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, size, size);
+  return canvas;
+}
+
+export function createSatelliteLayer(scene: Scene): SatelliteLayer {
+  const billboards = new BillboardCollection({ scene });
+  const polylines = new PolylineCollection();
+  scene.primitives.add(billboards);
+  scene.primitives.add(polylines);
+  const spriteImage = generateSatSprite();
+
+  function update(satellites: VisibleSatellite[], lat: number, lon: number): void {
+    billboards.removeAll();
+    polylines.removeAll();
+
+    for (const sat of satellites) {
+      billboards.add({
+        position: altAzToCartesian(sat.alt, sat.az, lat, lon),
+        image: spriteImage,
+        scale: 0.375,
+        color: Color.fromCssColorString(SAT_COLOR).withAlpha(1.0),
+        horizontalOrigin: HorizontalOrigin.CENTER,
+        verticalOrigin: VerticalOrigin.CENTER,
+        disableDepthTestDistance: Number.POSITIVE_INFINITY,
+        id: sat,
+      });
+
+      if (sat.trail.length >= 2) {
+        const positions = sat.trail.map((pt) => altAzToCartesian(pt.alt, pt.az, lat, lon));
+        positions.push(altAzToCartesian(sat.alt, sat.az, lat, lon));
+        polylines.add({
+          positions,
+          width: 1,
+          material: Material.fromType("Color", {
+            color: Color.fromCssColorString(SAT_COLOR).withAlpha(0.3),
+          }),
+        });
+      }
+    }
+  }
+
+  return { update };
+}

--- a/src/scene/tooltip.test.ts
+++ b/src/scene/tooltip.test.ts
@@ -134,4 +134,33 @@ describe("createTooltip", () => {
     expect(tooltipDiv.innerHTML).toContain("-12.7");
     expect(tooltipDiv.innerHTML).toContain("75%");
   });
+
+  it("shows tooltip with satellite info when a VisibleSatellite billboard is picked", () => {
+    const container = document.createElement("div");
+    const viewer = makeMockViewer();
+    createTooltip(viewer as never, container);
+
+    const moveCallback = mockSetInputAction.mock.calls[0]![0] as (movement: {
+      endPosition: { x: number; y: number };
+    }) => void;
+
+    mockPick.mockReturnValueOnce({
+      id: {
+        name: "ISS (ZARYA)",
+        noradId: 25544,
+        alt: 45.2,
+        az: 200.3,
+        height: 420,
+        velocity: 7.66,
+        trail: [],
+      },
+    });
+    moveCallback({ endPosition: { x: 200, y: 300 } });
+
+    const tooltipDiv = container.querySelector("div")!;
+    expect(tooltipDiv.style.display).toBe("block");
+    expect(tooltipDiv.innerHTML).toContain("ISS");
+    expect(tooltipDiv.innerHTML).toContain("25544");
+    expect(tooltipDiv.innerHTML).toContain("420");
+  });
 });

--- a/src/scene/tooltip.ts
+++ b/src/scene/tooltip.ts
@@ -3,6 +3,7 @@ import { ScreenSpaceEventHandler, ScreenSpaceEventType, defined } from "cesium";
 import type { Cartesian2, Viewer } from "cesium";
 import type { AltAzStar } from "../astro";
 import type { CelestialBody } from "../astro";
+import type { VisibleSatellite } from "../sat";
 
 export type Tooltip = {
   destroy: () => void;
@@ -68,6 +69,26 @@ function formatBody(body: CelestialBody): string {
   return html;
 }
 
+function isVisibleSatellite(obj: unknown): obj is VisibleSatellite {
+  return (
+    typeof obj === "object" &&
+    obj !== null &&
+    "noradId" in obj &&
+    "alt" in obj &&
+    "az" in obj &&
+    "velocity" in obj
+  );
+}
+
+function formatSatellite(sat: VisibleSatellite): string {
+  return (
+    `<strong>${sat.name}</strong> (NORAD ${String(sat.noradId)})<br>` +
+    `Alt ${sat.alt.toFixed(1)}\u00B0 Az ${sat.az.toFixed(1)}\u00B0<br>` +
+    `Orbit: ${Math.round(sat.height)} km<br>` +
+    `Velocity: ${sat.velocity.toFixed(2)} km/s`
+  );
+}
+
 export function createTooltip(viewer: Viewer, container: HTMLElement): Tooltip {
   const el = document.createElement("div");
   el.style.cssText =
@@ -89,6 +110,8 @@ export function createTooltip(viewer: Viewer, container: HTMLElement): Tooltip {
         html = formatStar(picked.id);
       } else if (isCelestialBody(picked.id)) {
         html = formatBody(picked.id);
+      } else if (isVisibleSatellite(picked.id)) {
+        html = formatSatellite(picked.id);
       }
     }
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,9 +2,34 @@
 import { defineConfig } from "vite";
 import { fileURLToPath, URL } from "node:url";
 import cesium from "vite-plugin-cesium";
+import type { Plugin } from "vite";
+
+// satellite.js v7 ships pthreads WASM build which uses top-level await and
+// Node-specific imports. We only use the pure-JS SGP4 API (twoline2satrec,
+// propagate, transforms) so we stub out the problematic WASM pthreads module.
+function stubSatelliteJsWasm(): Plugin {
+  const PTHREADS_PATH =
+    "node_modules/.pnpm/satellite.js@7.0.0/node_modules/satellite.js/wasm-build/pthreads-release/index.js";
+  const STUB_ID = "\0satellite-wasm-pthreads-stub";
+  return {
+    name: "stub-satellite-js-wasm",
+    enforce: "pre",
+    resolveId(id) {
+      // Intercept by exact wasm-build path or package-internal alias
+      if (id.includes("pthreads-release") || id === "#wasm-multi-thread") {
+        return STUB_ID;
+      }
+    },
+    load(id) {
+      if (id === STUB_ID || id.includes(PTHREADS_PATH)) {
+        return `export default function Module() { return Promise.resolve({}); }`;
+      }
+    },
+  };
+}
 
 export default defineConfig({
-  plugins: [cesium()],
+  plugins: [cesium(), stubSatelliteJsWasm()],
   resolve: {
     alias: {
       "@": fileURLToPath(new URL("./src", import.meta.url)),


### PR DESCRIPTION
Closes #96
Closes #97
Closes #98

## Summary

- **Task 6** (`src/scene/satellites.ts`): `createSatelliteLayer(scene)` renders `VisibleSatellite` objects as green (#00FF88) billboard dots (16px canvas sprite, scale 0.375) with `disableDepthTestDistance: Infinity`. Trail polylines rendered for satellites with ≥2 trail points at 30% alpha.
- **Task 7** (`src/scene/tooltip.ts`, `src/scene/index.ts`, `NOTICE`): Added `isVisibleSatellite` type guard and `formatSatellite` (name, NORAD ID, Alt/Az, orbital altitude, velocity). Inserts satellite branch between `isCelestialBody` and `else` in pick handler. Exports `SatelliteLayer` from scene barrel. Adds satellite.js (MIT) + CelesTrak attributions to NOTICE.
- **Task 8** (`src/app.ts`, `src/app.test.ts`, `src/main.ts`, `src/env.d.ts`, `vite.config.ts`): `bootstrap()` is now `async`; after the constellation block fetches TLEs, parses, propagates (visible-only), and renders. All satellite steps are non-fatal with `console.warn`. Updates `main.ts` to `void bootstrap(...)`. Adds `*.txt?raw` declaration to `env.d.ts`. Adds a Vite plugin to stub out satellite.js's pthreads WASM build (it uses top-level await + `node:module` imports incompatible with IIFE/browser targets).

## Gate results

- `pnpm typecheck` ✓
- `pnpm format:check` ✓
- `pnpm lint` ✓ (SPDX OK)
- `pnpm test:cov` ✓ — 134 tests, 21 files, all thresholds met
  - `src/sat/**`: 99.24% lines, 88.88% branches
  - `src/scene/**`: 96.7% lines, 90.8% branches
  - `src/app.ts`: 84.5% lines, 73.33% branches
- `pnpm build` ✓ (403KB bundle)

## Surprises

**satellite.js v7 ships pthreads WASM** (`wasm-build/pthreads-release/index.js`) that uses `async function Module` (top-level await) and imports `node:module` / `node:worker_threads`. Rollup in IIFE mode rejects this. Solution: `stubSatelliteJsWasm` Vite plugin (`enforce: "pre"`) intercepts any `resolveId` containing `pthreads-release` and returns a no-op stub. The pure-JS SGP4 functions (`twoline2satrec`, `propagate`, `eciToGeodetic`, etc.) used by `src/sat/` come from `dist/index.js` and are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)