### PR TITLE
Fix satellite.js dev server + .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ coverage/
 # Worktrees (managed by git worktree; contents must never be tracked)
 .worktrees/
 
+# Claude Code
+.claude/
+
 # Editor / OS
 .DS_Store
 .vscode/

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -35,6 +35,9 @@ export default defineConfig({
       "@": fileURLToPath(new URL("./src", import.meta.url)),
     },
   },
+  optimizeDeps: {
+    exclude: ["satellite.js"],
+  },
   build: {
     target: "es2022",
     sourcemap: true,


### PR DESCRIPTION
Closes #99

- Exclude satellite.js from Vite `optimizeDeps` so esbuild doesn't choke on the WASM pthreads top-level await
- Add `.claude/` to `.gitignore`
- Visually verified: satellites render with green dots + trails at dusk/dawn times