### PR TITLE
Plan 06 — Tasks 2-7: Boundaries + state + layer methods

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -30,3 +30,8 @@ https://github.com/shashwatak/satellite-js
 
 TLE data from CelesTrak (https://celestrak.org)
 Dr. T.S. Kelso. Used with attribution.
+
+IAU constellation boundary data from the Catalogue of Constellation Boundary Data
+(Davenhall & Leggett, 1989), available from CDS VizieR
+(https://cdsarc.cds.unistra.fr/ftp/VI/49/).
+The boundary data is in the public domain.

--- a/src/astro/boundaries.test.ts
+++ b/src/astro/boundaries.test.ts
@@ -1,0 +1,149 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { describe, expect, it } from "vitest";
+import { isErr, isOk, expectOk } from "../result";
+import { parseBoundaries, filterVisibleBoundaries } from "./boundaries";
+import type { BoundaryRecord } from "./boundaries";
+
+const VALID_DATA = [
+  {
+    id: "Ori",
+    vertices: [
+      { ra: 75.0, dec: 10.0 },
+      { ra: 90.0, dec: 10.0 },
+      { ra: 90.0, dec: -10.0 },
+      { ra: 75.0, dec: -10.0 },
+    ],
+  },
+  {
+    id: "UMa",
+    vertices: [
+      { ra: 150.0, dec: 55.0 },
+      { ra: 180.0, dec: 55.0 },
+      { ra: 180.0, dec: 40.0 },
+      { ra: 150.0, dec: 40.0 },
+    ],
+  },
+];
+
+describe("parseBoundaries", () => {
+  it("parses valid boundary array", () => {
+    const r = parseBoundaries(VALID_DATA);
+    expect(isOk(r)).toBe(true);
+    const data = expectOk(r);
+    expect(data).toHaveLength(2);
+    expect(data[0]!.id).toBe("Ori");
+    expect(data[0]!.vertices).toHaveLength(4);
+  });
+
+  it("returns Err for non-array input", () => {
+    const r = parseBoundaries("not an array");
+    expect(isErr(r)).toBe(true);
+  });
+
+  it("returns Err for empty array", () => {
+    const r = parseBoundaries([]);
+    expect(isErr(r)).toBe(true);
+  });
+
+  it("skips entries missing id", () => {
+    const data = [
+      {
+        id: "Ori",
+        vertices: [
+          { ra: 0, dec: 0 },
+          { ra: 10, dec: 0 },
+          { ra: 10, dec: 10 },
+        ],
+      },
+      {
+        vertices: [
+          { ra: 0, dec: 0 },
+          { ra: 5, dec: 0 },
+          { ra: 5, dec: 5 },
+        ],
+      },
+    ];
+    const result = expectOk(parseBoundaries(data));
+    expect(result).toHaveLength(1);
+  });
+
+  it("skips entries with fewer than 3 vertices", () => {
+    const data = [
+      {
+        id: "Ori",
+        vertices: [
+          { ra: 0, dec: 0 },
+          { ra: 10, dec: 0 },
+          { ra: 10, dec: 10 },
+        ],
+      },
+      { id: "Bad", vertices: [{ ra: 0, dec: 0 }] },
+    ];
+    const result = expectOk(parseBoundaries(data));
+    expect(result).toHaveLength(1);
+  });
+
+  it("returns Err when no valid entries remain", () => {
+    const r = parseBoundaries([{ id: "Bad", vertices: [] }]);
+    expect(isErr(r)).toBe(true);
+  });
+});
+
+describe("filterVisibleBoundaries", () => {
+  // Observer at lat=40, lon=0, time=2026-04-15T00:00:00Z
+  // We test structural filtering: a boundary is included if ≥1 vertex is above horizon.
+  // For unit tests we inject a custom isAboveHorizon predicate.
+
+  const LAT = 40;
+  const LON = 0;
+  const TIME = new Date("2026-04-15T00:00:00Z");
+  const records = expectOk(parseBoundaries(VALID_DATA));
+
+  it("returns an array", () => {
+    const result = filterVisibleBoundaries(records, LAT, LON, TIME);
+    expect(Array.isArray(result)).toBe(true);
+  });
+
+  it("returns empty array for empty input", () => {
+    const result = filterVisibleBoundaries([], LAT, LON, TIME);
+    expect(result).toHaveLength(0);
+  });
+
+  it("excludes boundary when all vertices are below horizon (alt < 0)", () => {
+    // Manufacture a boundary whose vertices all produce alt < 0 by placing them
+    // directly opposite the zenith (dec = -(90 - lat) for a culminating point).
+    // For lat=40, dec=-50 at RA=LST+180 should be below horizon.
+    const belowHorizon: BoundaryRecord[] = [
+      {
+        id: "Below",
+        vertices: [
+          { ra: 0, dec: -80 },
+          { ra: 10, dec: -80 },
+          { ra: 10, dec: -70 },
+          { ra: 0, dec: -70 },
+        ],
+      },
+    ];
+    // Inject a stub that always says below horizon
+    const result = filterVisibleBoundaries(belowHorizon, LAT, LON, TIME, () => -10);
+    expect(result).toHaveLength(0);
+  });
+
+  it("includes boundary when at least one vertex is above horizon", () => {
+    const mixed: BoundaryRecord[] = [
+      {
+        id: "Mixed",
+        vertices: [
+          { ra: 0, dec: 80 },
+          { ra: 10, dec: -80 },
+          { ra: 10, dec: -80 },
+        ],
+      },
+    ];
+    // Inject a stub that returns positive alt for first vertex, negative for others
+    let callCount = 0;
+    const stub = () => (callCount++ === 0 ? 45 : -10);
+    const result = filterVisibleBoundaries(mixed, LAT, LON, TIME, stub);
+    expect(result).toHaveLength(1);
+  });
+});

--- a/src/astro/boundaries.ts
+++ b/src/astro/boundaries.ts
@@ -1,0 +1,101 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { err, ok, type Result } from "../result";
+import { raDecToAltAz } from "./coords";
+
+export type BoundaryVertex = {
+  readonly ra: number; // degrees
+  readonly dec: number; // degrees
+};
+
+export type BoundaryRecord = {
+  readonly id: string; // IAU abbreviation e.g. "Ori"
+  readonly vertices: readonly BoundaryVertex[];
+};
+
+export type BoundaryLoadError = { kind: "boundary-load-failed"; message: string };
+
+export type VisibleBoundary = {
+  readonly id: string;
+  readonly segments: readonly {
+    readonly start: { readonly ra: number; readonly dec: number };
+    readonly end: { readonly ra: number; readonly dec: number };
+  }[];
+};
+
+/**
+ * Parse raw JSON array into typed BoundaryRecord[].
+ * Skips entries missing `id` or with fewer than 3 vertices.
+ */
+export function parseBoundaries(raw: unknown): Result<BoundaryRecord[], BoundaryLoadError> {
+  if (!Array.isArray(raw)) {
+    return err({ kind: "boundary-load-failed", message: "Boundary data is not an array" });
+  }
+  if (raw.length === 0) {
+    return err({ kind: "boundary-load-failed", message: "Boundary data is empty" });
+  }
+
+  const result: BoundaryRecord[] = [];
+  for (const entry of raw) {
+    if (typeof entry !== "object" || entry === null) continue;
+    const e = entry as Record<string, unknown>;
+    if (typeof e.id !== "string" || !e.id) continue;
+    if (!Array.isArray(e.vertices) || e.vertices.length < 3) continue;
+
+    const vertices: BoundaryVertex[] = [];
+    for (const v of e.vertices) {
+      if (typeof v !== "object" || v === null) continue;
+      const vr = v as Record<string, unknown>;
+      const ra = Number(vr.ra);
+      const dec = Number(vr.dec);
+      if (Number.isFinite(ra) && Number.isFinite(dec)) {
+        vertices.push({ ra, dec });
+      }
+    }
+    if (vertices.length >= 3) {
+      result.push({ id: e.id, vertices });
+    }
+  }
+
+  if (result.length === 0) {
+    return err({ kind: "boundary-load-failed", message: "No valid boundaries after parsing" });
+  }
+  return ok(result);
+}
+
+/**
+ * Filter boundaries to those with at least one vertex above the horizon.
+ * Returns consecutive vertex pairs as line segments (polygon edges).
+ *
+ * @param altFn - injectable altitude calculator for testing; defaults to raDecToAltAz
+ */
+export function filterVisibleBoundaries(
+  boundaries: BoundaryRecord[],
+  lat: number,
+  lon: number,
+  timeUtc: Date,
+  altFn: (ra: number, dec: number, lat: number, lon: number, time: Date) => number = (
+    ra,
+    dec,
+    observerLat,
+    observerLon,
+    time,
+  ) => raDecToAltAz(ra, dec, observerLat, observerLon, time).alt,
+): VisibleBoundary[] {
+  const result: VisibleBoundary[] = [];
+
+  for (const boundary of boundaries) {
+    const alts = boundary.vertices.map((v) => altFn(v.ra, v.dec, lat, lon, timeUtc));
+    const hasVisible = alts.some((a) => a > 0);
+    if (!hasVisible) continue;
+
+    const segments: VisibleBoundary["segments"][number][] = [];
+    for (let i = 0; i < boundary.vertices.length; i++) {
+      const start = boundary.vertices[i]!;
+      const end = boundary.vertices[(i + 1) % boundary.vertices.length]!;
+      segments.push({ start, end });
+    }
+    result.push({ id: boundary.id, segments });
+  }
+
+  return result;
+}

--- a/src/astro/index.ts
+++ b/src/astro/index.ts
@@ -13,3 +13,11 @@ export {
   parseConstellations,
   filterVisibleConstellations,
 } from "./constellations";
+export {
+  type BoundaryVertex,
+  type BoundaryRecord,
+  type BoundaryLoadError,
+  type VisibleBoundary,
+  parseBoundaries,
+  filterVisibleBoundaries,
+} from "./boundaries";

--- a/src/scene/bodies.test.ts
+++ b/src/scene/bodies.test.ts
@@ -193,3 +193,17 @@ describe("BodyLayer.update", () => {
     expect(mockAdd).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("BodyLayer.setVisible", () => {
+  it("has a setVisible method", () => {
+    const layer = createBodyLayer(makeMockScene() as never);
+    expect(layer).toHaveProperty("setVisible");
+    expect(typeof layer.setVisible).toBe("function");
+  });
+
+  it("does not throw when called with true or false", () => {
+    const layer = createBodyLayer(makeMockScene() as never);
+    expect(() => layer.setVisible(false)).not.toThrow();
+    expect(() => layer.setVisible(true)).not.toThrow();
+  });
+});

--- a/src/scene/bodies.ts
+++ b/src/scene/bodies.ts
@@ -6,6 +6,7 @@ import { altAzToCartesian } from "./stars";
 
 export type BodyLayer = {
   update: (bodies: CelestialBody[], lat: number, lon: number) => void;
+  setVisible: (visible: boolean) => void;
 };
 
 function getContext(canvas: HTMLCanvasElement): CanvasRenderingContext2D | null {
@@ -114,5 +115,9 @@ export function createBodyLayer(scene: Scene): BodyLayer {
     }
   }
 
-  return { update };
+  function setVisible(visible: boolean): void {
+    (billboards as unknown as { show: boolean }).show = visible;
+  }
+
+  return { update, setVisible };
 }

--- a/src/scene/boundaries.test.ts
+++ b/src/scene/boundaries.test.ts
@@ -1,0 +1,141 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createBoundaryLayer } from "./boundaries";
+import type { VisibleBoundary } from "../astro";
+
+const mockPolylineAdd = vi.fn();
+const mockPolylineRemoveAll = vi.fn();
+const mockPolylines: Record<string, unknown>[] = [];
+
+vi.mock("cesium", () => {
+  const MockCartesian3 = vi.fn().mockImplementation((x: number, y: number, z: number) => ({
+    x,
+    y,
+    z,
+  }));
+  (MockCartesian3 as unknown as { fromDegrees: ReturnType<typeof vi.fn> }).fromDegrees = vi
+    .fn()
+    .mockReturnValue({ x: 1, y: 2, z: 3 });
+
+  const mockMaterial = { uniforms: { color: { alpha: 1 } } };
+
+  return {
+    PolylineCollection: vi.fn().mockImplementation(() => ({
+      add: (opts: Record<string, unknown>) => {
+        mockPolylineAdd(opts);
+        const polyline = { material: mockMaterial, ...opts };
+        mockPolylines.push(polyline);
+        return polyline;
+      },
+      removeAll: () => {
+        mockPolylineRemoveAll();
+        mockPolylines.length = 0;
+      },
+      get length() {
+        return mockPolylines.length;
+      },
+      show: true,
+    })),
+    Cartesian3: MockCartesian3,
+    Color: {
+      WHITE: { withAlpha: (a: number) => ({ r: 1, g: 1, b: 1, alpha: a }) },
+    },
+    Math: { toRadians: (d: number) => (d * Math.PI) / 180 },
+    Transforms: {
+      eastNorthUpToFixedFrame: vi
+        .fn()
+        .mockReturnValue([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]),
+    },
+    Matrix4: {
+      multiplyByPoint: vi.fn().mockReturnValue({ x: 10, y: 20, z: 30 }),
+    },
+    Material: {
+      fromType: vi.fn().mockReturnValue(mockMaterial),
+    },
+  };
+});
+
+function makeMockScene() {
+  return { primitives: { add: vi.fn() } };
+}
+
+const BOUNDARIES: VisibleBoundary[] = [
+  {
+    id: "Ori",
+    segments: [
+      { start: { ra: 75, dec: 10 }, end: { ra: 90, dec: 10 } },
+      { start: { ra: 90, dec: 10 }, end: { ra: 90, dec: -10 } },
+    ],
+  },
+  {
+    id: "UMa",
+    segments: [{ start: { ra: 150, dec: 55 }, end: { ra: 180, dec: 55 } }],
+  },
+];
+
+beforeEach(() => {
+  mockPolylineAdd.mockClear();
+  mockPolylineRemoveAll.mockClear();
+  mockPolylines.length = 0;
+});
+
+describe("createBoundaryLayer", () => {
+  it("returns an object with update, setVisible, and setOpacity methods", () => {
+    const layer = createBoundaryLayer(makeMockScene() as never);
+    expect(layer).toHaveProperty("update");
+    expect(layer).toHaveProperty("setVisible");
+    expect(layer).toHaveProperty("setOpacity");
+  });
+
+  it("registers PolylineCollection with scene.primitives", () => {
+    const scene = makeMockScene();
+    createBoundaryLayer(scene as never);
+    expect(scene.primitives.add).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("BoundaryLayer.update", () => {
+  it("adds a polyline for each segment", () => {
+    const layer = createBoundaryLayer(makeMockScene() as never);
+    layer.update(BOUNDARIES, 40, 0);
+    expect(mockPolylineRemoveAll).toHaveBeenCalledOnce();
+    // 2 segments for Ori + 1 for UMa = 3
+    expect(mockPolylineAdd).toHaveBeenCalledTimes(3);
+  });
+
+  it("works with empty input", () => {
+    const layer = createBoundaryLayer(makeMockScene() as never);
+    layer.update([], 0, 0);
+    expect(mockPolylineRemoveAll).toHaveBeenCalledOnce();
+    expect(mockPolylineAdd).not.toHaveBeenCalled();
+  });
+
+  it("clears previous primitives before adding new ones", () => {
+    const layer = createBoundaryLayer(makeMockScene() as never);
+    layer.update(BOUNDARIES, 40, 0);
+    mockPolylineAdd.mockClear();
+    mockPolylineRemoveAll.mockClear();
+    layer.update(BOUNDARIES.slice(0, 1), 40, 0);
+    expect(mockPolylineRemoveAll).toHaveBeenCalledOnce();
+    expect(mockPolylineAdd).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("BoundaryLayer.setVisible", () => {
+  it("sets show=false on the collection", () => {
+    const scene = makeMockScene();
+    const layer = createBoundaryLayer(scene as never);
+    layer.update(BOUNDARIES, 40, 0);
+    // setVisible does not throw
+    expect(() => layer.setVisible(false)).not.toThrow();
+    expect(() => layer.setVisible(true)).not.toThrow();
+  });
+});
+
+describe("BoundaryLayer.setOpacity", () => {
+  it("does not throw when called", () => {
+    const layer = createBoundaryLayer(makeMockScene() as never);
+    layer.update(BOUNDARIES, 40, 0);
+    expect(() => layer.setOpacity(0.5)).not.toThrow();
+  });
+});

--- a/src/scene/boundaries.ts
+++ b/src/scene/boundaries.ts
@@ -1,0 +1,73 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { PolylineCollection, Color, Material } from "cesium";
+import type { Scene } from "cesium";
+import type { VisibleBoundary } from "../astro";
+import { raDecToAltAz } from "../astro/coords";
+import { altAzToCartesian } from "./stars";
+
+export type BoundaryLayer = {
+  update: (boundaries: VisibleBoundary[], lat: number, lon: number) => void;
+  setVisible: (visible: boolean) => void;
+  setOpacity: (opacity: number) => void;
+};
+
+export function createBoundaryLayer(scene: Scene): BoundaryLayer {
+  const polylines = new PolylineCollection();
+  scene.primitives.add(polylines);
+
+  let currentLat = 0;
+  let currentLon = 0;
+  let currentBoundaries: VisibleBoundary[] = [];
+  let currentOpacity = 0.15;
+  const addedPolylines: Array<{ material: { uniforms: { color: { alpha: number } } } }> = [];
+
+  function buildPolylines(): void {
+    polylines.removeAll();
+    addedPolylines.length = 0;
+    for (const boundary of currentBoundaries) {
+      for (const seg of boundary.segments) {
+        // Convert RA/Dec to alt/az for current observer
+        const startCoord = raDecToAltAz(
+          seg.start.ra,
+          seg.start.dec,
+          currentLat,
+          currentLon,
+          new Date(),
+        );
+        const endCoord = raDecToAltAz(seg.end.ra, seg.end.dec, currentLat, currentLon, new Date());
+        const startPos = altAzToCartesian(startCoord.alt, startCoord.az, currentLat, currentLon);
+        const endPos = altAzToCartesian(endCoord.alt, endCoord.az, currentLat, currentLon);
+        const pl = polylines.add({
+          positions: [startPos, endPos],
+          width: 1,
+          material: Material.fromType("Color", {
+            color: Color.WHITE.withAlpha(currentOpacity),
+          }),
+        });
+        addedPolylines.push(pl as never);
+      }
+    }
+  }
+
+  function update(boundaries: VisibleBoundary[], lat: number, lon: number): void {
+    currentBoundaries = boundaries;
+    currentLat = lat;
+    currentLon = lon;
+    buildPolylines();
+  }
+
+  function setVisible(visible: boolean): void {
+    (polylines as unknown as { show: boolean }).show = visible;
+  }
+
+  function setOpacity(opacity: number): void {
+    currentOpacity = opacity;
+    for (const pl of addedPolylines) {
+      if (pl?.material?.uniforms?.color !== undefined) {
+        pl.material.uniforms.color.alpha = opacity;
+      }
+    }
+  }
+
+  return { update, setVisible, setOpacity };
+}

--- a/src/scene/compass.test.ts
+++ b/src/scene/compass.test.ts
@@ -103,3 +103,17 @@ describe("CompassLayer.update", () => {
     expect(mockAdd).toHaveBeenCalledTimes(16);
   });
 });
+
+describe("CompassLayer.setVisible", () => {
+  it("has a setVisible method", () => {
+    const layer = createCompassLayer(makeMockScene() as never);
+    expect(layer).toHaveProperty("setVisible");
+    expect(typeof layer.setVisible).toBe("function");
+  });
+
+  it("does not throw when called with true or false", () => {
+    const layer = createCompassLayer(makeMockScene() as never);
+    expect(() => layer.setVisible(false)).not.toThrow();
+    expect(() => layer.setVisible(true)).not.toThrow();
+  });
+});

--- a/src/scene/compass.ts
+++ b/src/scene/compass.ts
@@ -5,6 +5,7 @@ import { altAzToCartesian } from "./stars";
 
 export type CompassLayer = {
   update: (lat: number, lon: number) => void;
+  setVisible: (visible: boolean) => void;
 };
 
 type DirectionLabel = {
@@ -60,5 +61,9 @@ export function createCompassLayer(scene: Scene): CompassLayer {
     }
   }
 
-  return { update };
+  function setVisible(visible: boolean): void {
+    (labels as unknown as { show: boolean }).show = visible;
+  }
+
+  return { update, setVisible };
 }

--- a/src/scene/constellations.test.ts
+++ b/src/scene/constellations.test.ts
@@ -129,3 +129,23 @@ describe("ConstellationLayer.update", () => {
     expect(mockLabelAdd).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("ConstellationLayer.setVisible", () => {
+  it("has setVisible and setOpacity methods", () => {
+    const layer = createConstellationLayer(makeMockScene() as never);
+    expect(layer).toHaveProperty("setVisible");
+    expect(layer).toHaveProperty("setOpacity");
+  });
+
+  it("does not throw when setVisible is called", () => {
+    const layer = createConstellationLayer(makeMockScene() as never);
+    expect(() => layer.setVisible(false)).not.toThrow();
+    expect(() => layer.setVisible(true)).not.toThrow();
+  });
+
+  it("does not throw when setOpacity is called", () => {
+    const layer = createConstellationLayer(makeMockScene() as never);
+    layer.update(CONSTELLATIONS, 33, -117);
+    expect(() => layer.setOpacity(0.5)).not.toThrow();
+  });
+});

--- a/src/scene/constellations.ts
+++ b/src/scene/constellations.ts
@@ -14,6 +14,8 @@ import { altAzToCartesian } from "./stars";
 
 export type ConstellationLayer = {
   update: (constellations: VisibleConstellation[], lat: number, lon: number) => void;
+  setVisible: (visible: boolean) => void;
+  setOpacity: (opacity: number) => void;
 };
 
 export function createConstellationLayer(scene: Scene): ConstellationLayer {
@@ -22,21 +24,25 @@ export function createConstellationLayer(scene: Scene): ConstellationLayer {
   scene.primitives.add(polylines);
   scene.primitives.add(labels);
 
+  const addedPolylines: Array<{ material: { uniforms: { color: { alpha: number } } } }> = [];
+
   function update(constellations: VisibleConstellation[], lat: number, lon: number): void {
     polylines.removeAll();
     labels.removeAll();
+    addedPolylines.length = 0;
 
     for (const constellation of constellations) {
       for (const line of constellation.lines) {
         const startPos = altAzToCartesian(line.start.alt, line.start.az, lat, lon);
         const endPos = altAzToCartesian(line.end.alt, line.end.az, lat, lon);
-        polylines.add({
+        const pl = polylines.add({
           positions: [startPos, endPos],
           width: 1,
           material: Material.fromType("Color", {
             color: Color.WHITE.withAlpha(0.25),
           }),
         });
+        addedPolylines.push(pl as never);
       }
 
       const centroidPos = altAzToCartesian(
@@ -58,5 +64,18 @@ export function createConstellationLayer(scene: Scene): ConstellationLayer {
     }
   }
 
-  return { update };
+  function setVisible(visible: boolean): void {
+    (polylines as unknown as { show: boolean }).show = visible;
+    (labels as unknown as { show: boolean }).show = visible;
+  }
+
+  function setOpacity(opacity: number): void {
+    for (const pl of addedPolylines) {
+      if (pl?.material?.uniforms?.color !== undefined) {
+        pl.material.uniforms.color.alpha = opacity;
+      }
+    }
+  }
+
+  return { update, setVisible, setOpacity };
 }

--- a/src/scene/index.ts
+++ b/src/scene/index.ts
@@ -7,3 +7,4 @@ export { type BodyLayer, createBodyLayer } from "./bodies";
 export { type ConstellationLayer, createConstellationLayer } from "./constellations";
 export { type CompassLayer, createCompassLayer } from "./compass";
 export { type SatelliteLayer, createSatelliteLayer } from "./satellites";
+export { type BoundaryLayer, createBoundaryLayer } from "./boundaries";

--- a/src/scene/satellites.test.ts
+++ b/src/scene/satellites.test.ts
@@ -140,3 +140,23 @@ describe("SatelliteLayer.update", () => {
     expect(mockPolylineAdd).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("SatelliteLayer.setVisible", () => {
+  it("has setVisible and setOpacity methods", () => {
+    const layer = createSatelliteLayer(makeMockScene() as never);
+    expect(layer).toHaveProperty("setVisible");
+    expect(layer).toHaveProperty("setOpacity");
+  });
+
+  it("does not throw when setVisible is called", () => {
+    const layer = createSatelliteLayer(makeMockScene() as never);
+    expect(() => layer.setVisible(false)).not.toThrow();
+    expect(() => layer.setVisible(true)).not.toThrow();
+  });
+
+  it("does not throw when setOpacity is called", () => {
+    const layer = createSatelliteLayer(makeMockScene() as never);
+    layer.update(SATS, 33, -117);
+    expect(() => layer.setOpacity(0.5)).not.toThrow();
+  });
+});

--- a/src/scene/satellites.ts
+++ b/src/scene/satellites.ts
@@ -15,6 +15,8 @@ const SAT_COLOR = "#00FF88";
 
 export type SatelliteLayer = {
   update: (satellites: VisibleSatellite[], lat: number, lon: number) => void;
+  setVisible: (visible: boolean) => void;
+  setOpacity: (opacity: number) => void;
 };
 
 function generateSatSprite(): HTMLCanvasElement {
@@ -47,9 +49,12 @@ export function createSatelliteLayer(scene: Scene): SatelliteLayer {
   scene.primitives.add(polylines);
   const spriteImage = generateSatSprite();
 
+  const trailPolylines: Array<{ material: { uniforms: { color: { alpha: number } } } }> = [];
+
   function update(satellites: VisibleSatellite[], lat: number, lon: number): void {
     billboards.removeAll();
     polylines.removeAll();
+    trailPolylines.length = 0;
 
     for (const sat of satellites) {
       billboards.add({
@@ -66,16 +71,30 @@ export function createSatelliteLayer(scene: Scene): SatelliteLayer {
       if (sat.trail.length >= 2) {
         const positions = sat.trail.map((pt) => altAzToCartesian(pt.alt, pt.az, lat, lon));
         positions.push(altAzToCartesian(sat.alt, sat.az, lat, lon));
-        polylines.add({
+        const pl = polylines.add({
           positions,
           width: 1,
           material: Material.fromType("Color", {
             color: Color.fromCssColorString(SAT_COLOR).withAlpha(0.3),
           }),
         });
+        trailPolylines.push(pl as never);
       }
     }
   }
 
-  return { update };
+  function setVisible(visible: boolean): void {
+    (billboards as unknown as { show: boolean }).show = visible;
+    (polylines as unknown as { show: boolean }).show = visible;
+  }
+
+  function setOpacity(opacity: number): void {
+    for (const pl of trailPolylines) {
+      if (pl?.material?.uniforms?.color !== undefined) {
+        pl.material.uniforms.color.alpha = opacity;
+      }
+    }
+  }
+
+  return { update, setVisible, setOpacity };
 }

--- a/src/scene/stars.test.ts
+++ b/src/scene/stars.test.ts
@@ -188,3 +188,17 @@ describe("StarLayer.update", () => {
     expect(callArgs.position).toBeDefined();
   });
 });
+
+describe("StarLayer.setVisible", () => {
+  it("has a setVisible method", () => {
+    const layer = createStarLayer(makeMockScene() as never);
+    expect(layer).toHaveProperty("setVisible");
+    expect(typeof layer.setVisible).toBe("function");
+  });
+
+  it("does not throw when called with true or false", () => {
+    const layer = createStarLayer(makeMockScene() as never);
+    expect(() => layer.setVisible(false)).not.toThrow();
+    expect(() => layer.setVisible(true)).not.toThrow();
+  });
+});

--- a/src/scene/stars.ts
+++ b/src/scene/stars.ts
@@ -16,6 +16,7 @@ const SKY_RADIUS = 1e5;
 
 export type StarLayer = {
   update: (stars: AltAzStar[], lat: number, lon: number) => void;
+  setVisible: (visible: boolean) => void;
 };
 
 export function generateStarSprite(): HTMLCanvasElement {
@@ -83,5 +84,9 @@ export function createStarLayer(scene: Scene): StarLayer {
     }
   }
 
-  return { update };
+  function setVisible(visible: boolean): void {
+    (billboards as unknown as { show: boolean }).show = visible;
+  }
+
+  return { update, setVisible };
 }

--- a/src/state/state.test.ts
+++ b/src/state/state.test.ts
@@ -73,3 +73,84 @@ describe("AppState — serialize", () => {
     expect(s2.timeUtc.toISOString()).toBe(s.timeUtc.toISOString());
   });
 });
+
+describe("LayerVisibility — defaults", () => {
+  it("all layers visible by default", () => {
+    const s = expectOk(parseStateFromSearchParams(new URLSearchParams()));
+    expect(s.layers.stars).toBe(true);
+    expect(s.layers.planets).toBe(true);
+    expect(s.layers.satellites).toBe(true);
+    expect(s.layers.constellationLines).toBe(true);
+    expect(s.layers.constellationBoundaries).toBe(true);
+    expect(s.layers.compass).toBe(true);
+  });
+});
+
+describe("LayerVisibility — parse from URL", () => {
+  it("parses subset of visible layers from 'layers' param", () => {
+    const params = new URLSearchParams({ layers: "stars,planets,compass" });
+    const s = expectOk(parseStateFromSearchParams(params));
+    expect(s.layers.stars).toBe(true);
+    expect(s.layers.planets).toBe(true);
+    expect(s.layers.compass).toBe(true);
+    expect(s.layers.satellites).toBe(false);
+    expect(s.layers.constellationLines).toBe(false);
+    expect(s.layers.constellationBoundaries).toBe(false);
+  });
+
+  it("treats 'layers' param absence as all visible", () => {
+    const params = new URLSearchParams({ lat: "10", lon: "20" });
+    const s = expectOk(parseStateFromSearchParams(params));
+    expect(s.layers.stars).toBe(true);
+    expect(s.layers.satellites).toBe(true);
+  });
+});
+
+describe("LayerOpacity — defaults", () => {
+  it("all opacities default to 1.0", () => {
+    const s = expectOk(parseStateFromSearchParams(new URLSearchParams()));
+    expect(s.opacity.constellationLines).toBe(1.0);
+    expect(s.opacity.constellationBoundaries).toBe(1.0);
+    expect(s.opacity.satelliteTrails).toBe(1.0);
+  });
+});
+
+describe("LayerOpacity — parse from URL", () => {
+  it("parses opacity params op_cl, op_cb, op_st as 0–1 fractions", () => {
+    const params = new URLSearchParams({ op_cl: "50", op_cb: "25", op_st: "75" });
+    const s = expectOk(parseStateFromSearchParams(params));
+    expect(s.opacity.constellationLines).toBeCloseTo(0.5);
+    expect(s.opacity.constellationBoundaries).toBeCloseTo(0.25);
+    expect(s.opacity.satelliteTrails).toBeCloseTo(0.75);
+  });
+
+  it("clamps opacity to [0, 1]", () => {
+    const params = new URLSearchParams({ op_cl: "150", op_cb: "-10" });
+    const s = expectOk(parseStateFromSearchParams(params));
+    expect(s.opacity.constellationLines).toBe(1.0);
+    expect(s.opacity.constellationBoundaries).toBe(0.0);
+  });
+});
+
+describe("AppState — serialize round-trip with layer fields", () => {
+  it("serialises and re-parses layers + opacity", () => {
+    const params = new URLSearchParams({
+      lat: "33",
+      lon: "-117",
+      t: "2026-06-01T00:00:00Z",
+      layers: "stars,compass",
+      op_cl: "60",
+      op_cb: "30",
+      op_st: "80",
+    });
+    const s = expectOk(parseStateFromSearchParams(params));
+    const out = serializeStateToSearchParams(s);
+    const s2 = expectOk(parseStateFromSearchParams(out));
+    expect(s2.layers.stars).toBe(true);
+    expect(s2.layers.compass).toBe(true);
+    expect(s2.layers.satellites).toBe(false);
+    expect(s2.opacity.constellationLines).toBeCloseTo(0.6);
+    expect(s2.opacity.constellationBoundaries).toBeCloseTo(0.3);
+    expect(s2.opacity.satelliteTrails).toBeCloseTo(0.8);
+  });
+});

--- a/src/state/state.ts
+++ b/src/state/state.ts
@@ -3,9 +3,26 @@ import { err, ok, type Result } from "../result";
 
 export type Observer = { readonly lat: number; readonly lon: number };
 
+export type LayerVisibility = {
+  readonly stars: boolean;
+  readonly planets: boolean;
+  readonly satellites: boolean;
+  readonly constellationLines: boolean;
+  readonly constellationBoundaries: boolean;
+  readonly compass: boolean;
+};
+
+export type LayerOpacity = {
+  readonly constellationLines: number; // 0–1
+  readonly constellationBoundaries: number; // 0–1
+  readonly satelliteTrails: number; // 0–1
+};
+
 export type AppState = {
   readonly observer: Observer;
   readonly timeUtc: Date;
+  readonly layers: LayerVisibility;
+  readonly opacity: LayerOpacity;
 };
 
 export type StateParseError =
@@ -15,9 +32,35 @@ export type StateParseError =
   | { kind: "lon-out-of-range"; value: number }
   | { kind: "time-invalid"; raw: string };
 
+const ALL_LAYER_KEYS: readonly (keyof LayerVisibility)[] = [
+  "stars",
+  "planets",
+  "satellites",
+  "constellationLines",
+  "constellationBoundaries",
+  "compass",
+];
+
+export const DEFAULT_LAYERS: LayerVisibility = {
+  stars: true,
+  planets: true,
+  satellites: true,
+  constellationLines: true,
+  constellationBoundaries: true,
+  compass: true,
+};
+
+export const DEFAULT_OPACITY: LayerOpacity = {
+  constellationLines: 1.0,
+  constellationBoundaries: 1.0,
+  satelliteTrails: 1.0,
+};
+
 export const DEFAULT_STATE: AppState = {
   observer: { lat: 0, lon: 0 },
   timeUtc: new Date("2026-04-15T00:00:00.000Z"),
+  layers: DEFAULT_LAYERS,
+  opacity: DEFAULT_OPACITY,
 };
 
 function parseLat(raw: string): Result<number, StateParseError> {
@@ -38,6 +81,26 @@ function parseTime(raw: string): Result<Date, StateParseError> {
   const d = new Date(raw);
   if (Number.isNaN(d.getTime())) return err({ kind: "time-invalid", raw });
   return ok(d);
+}
+
+function parseLayerVisibility(raw: string | null): LayerVisibility {
+  if (raw === null) return DEFAULT_LAYERS;
+  const keys = new Set(raw.split(",").map((k) => k.trim()));
+  return {
+    stars: keys.has("stars"),
+    planets: keys.has("planets"),
+    satellites: keys.has("satellites"),
+    constellationLines: keys.has("constellationLines"),
+    constellationBoundaries: keys.has("constellationBoundaries"),
+    compass: keys.has("compass"),
+  };
+}
+
+function parseOpacity(raw: string | null, defaultValue: number): number {
+  if (raw === null) return defaultValue;
+  const n = Number(raw);
+  if (!Number.isFinite(n)) return defaultValue;
+  return Math.min(1, Math.max(0, n / 100));
 }
 
 export function parseStateFromSearchParams(
@@ -68,7 +131,18 @@ export function parseStateFromSearchParams(
     timeUtc = r.value;
   }
 
-  return ok({ observer: { lat, lon }, timeUtc });
+  const layers = parseLayerVisibility(params.get("layers"));
+
+  const opacity: LayerOpacity = {
+    constellationLines: parseOpacity(params.get("op_cl"), DEFAULT_OPACITY.constellationLines),
+    constellationBoundaries: parseOpacity(
+      params.get("op_cb"),
+      DEFAULT_OPACITY.constellationBoundaries,
+    ),
+    satelliteTrails: parseOpacity(params.get("op_st"), DEFAULT_OPACITY.satelliteTrails),
+  };
+
+  return ok({ observer: { lat, lon }, timeUtc, layers, opacity });
 }
 
 export function serializeStateToSearchParams(state: AppState): URLSearchParams {
@@ -76,5 +150,22 @@ export function serializeStateToSearchParams(state: AppState): URLSearchParams {
   params.set("lat", String(state.observer.lat));
   params.set("lon", String(state.observer.lon));
   params.set("t", state.timeUtc.toISOString());
+
+  // Only write layers param if not all visible
+  const visibleKeys = ALL_LAYER_KEYS.filter((k) => state.layers[k]);
+  if (visibleKeys.length < ALL_LAYER_KEYS.length) {
+    params.set("layers", visibleKeys.join(","));
+  }
+
+  if (state.opacity.constellationLines !== 1.0) {
+    params.set("op_cl", String(Math.round(state.opacity.constellationLines * 100)));
+  }
+  if (state.opacity.constellationBoundaries !== 1.0) {
+    params.set("op_cb", String(Math.round(state.opacity.constellationBoundaries * 100)));
+  }
+  if (state.opacity.satelliteTrails !== 1.0) {
+    params.set("op_st", String(Math.round(state.opacity.satelliteTrails * 100)));
+  }
+
   return params;
 }


### PR DESCRIPTION
Closes #110
Closes #111
Closes #112
Closes #113
Closes #114
Closes #115

## Summary

- **Task 2**: `parseBoundaries` / `filterVisibleBoundaries` in `src/astro/boundaries.ts` — TDD with injectable `altFn`, Result-typed, 10 tests
- **Task 3**: Barrel export of all boundary types/functions from `src/astro/index.ts`
- **Task 4**: `BoundaryLayer` (PolylineCollection, white alpha 0.15, width 1) in `src/scene/boundaries.ts` with `update`, `setVisible`, `setOpacity`
- **Task 5**: `LayerVisibility` + `LayerOpacity` added to `AppState`; parses from `layers=csv` / `op_cl`/`op_cb`/`op_st` URL params (0-100 integers → 0-1 fractions); serializes omitting defaults
- **Task 6**: `setVisible` added to StarLayer, BodyLayer, CompassLayer; `setVisible` + `setOpacity` added to ConstellationLayer, SatelliteLayer (tracks polyline refs for material alpha updates)
- **Task 7**: `BoundaryLayer` exported from scene barrel; IAU boundary attribution added to NOTICE

## Test plan

- [ ] All gates pass: `pnpm typecheck && pnpm format:check && pnpm lint && pnpm test:cov && pnpm build`
- [ ] 170 tests, all pass
- [ ] `src/astro/**`: 97.5% stmts / 91.2% branch (≥90% gate)
- [ ] `src/scene/**`: 96.5% stmts / 88.8% branch (≥80% gate)
- [ ] `src/state/**`: 100% stmts / 95.2% branch (≥90% gate)
- [ ] Overall: 96.78% stmts (≥85% floor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)