### PR TITLE
Plan 06 — Tasks 8-13: UI controls panel + app wiring

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,10 +28,22 @@
     </style>
   </head>
   <body>
-    <main id="app">
-      <div id="cesium-container"></div>
-      <div id="error" style="display: none"></div>
-    </main>
+    <div
+      id="error"
+      style="
+        display: none;
+        position: fixed;
+        top: 8px;
+        left: 8px;
+        color: red;
+        background: rgba(0, 0, 0, 0.7);
+        padding: 8px;
+        border-radius: 4px;
+        z-index: 9999;
+      "
+    ></div>
+    <div id="ui-panel-root"></div>
+    <div id="cesium-container" style="width: 100vw; height: 100vh"></div>
     <script type="module" src="/src/main.ts"></script>
   </body>
 </html>

--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -19,6 +19,7 @@ vi.mock("cesium", () => ({
   BillboardCollection: vi.fn().mockImplementation(() => ({
     add: vi.fn(),
     removeAll: vi.fn(),
+    show: true,
     length: 0,
   })),
   Cartesian3: Object.assign(
@@ -51,15 +52,20 @@ vi.mock("cesium", () => ({
   ScreenSpaceEventType: { MOUSE_MOVE: 0 },
   defined: (v: unknown) => v !== undefined && v !== null,
   PolylineCollection: vi.fn().mockImplementation(() => ({
-    add: vi.fn(),
+    add: vi.fn().mockReturnValue({ material: { uniforms: { color: { alpha: 1 } } } }),
     removeAll: vi.fn(),
+    get length() {
+      return 0;
+    },
+    show: true,
   })),
   LabelCollection: vi.fn().mockImplementation(() => ({
     add: vi.fn(),
     removeAll: vi.fn(),
+    show: true,
   })),
   LabelStyle: { FILL: 0 },
-  Material: { fromType: vi.fn().mockReturnValue({}) },
+  Material: { fromType: vi.fn().mockReturnValue({ uniforms: { color: { alpha: 1 } } }) },
 }));
 
 vi.mock("../data/stars.json", () => ({
@@ -71,6 +77,37 @@ vi.mock("../data/stars.json", () => ({
 
 vi.mock("../data/constellations.json", () => ({
   default: [{ id: "Ori", name: "Orion", lines: [[27366, 26311]] }],
+}));
+
+vi.mock("../data/boundaries.json", () => ({
+  default: [
+    {
+      id: "Ori",
+      vertices: [
+        { ra: 75, dec: 10 },
+        { ra: 90, dec: 10 },
+        { ra: 90, dec: -10 },
+      ],
+    },
+  ],
+}));
+
+// Captured dispatch function from UI mock — used in intent tests
+let capturedDispatch: ((intent: unknown) => void) | null = null;
+
+// Mock UI modules — they exercise DOM which is fully covered in their own tests
+vi.mock("./ui", () => ({
+  createPanel: vi.fn().mockReturnValue({
+    element: document.createElement("div"),
+    setContent: vi.fn(),
+    setCollapsed: vi.fn(),
+  }),
+  createTimeControls: vi.fn().mockImplementation((_time: unknown, dispatch: unknown) => {
+    capturedDispatch = dispatch as (intent: unknown) => void;
+    return document.createElement("div");
+  }),
+  createLocationControls: vi.fn().mockReturnValue(document.createElement("div")),
+  createLayerControls: vi.fn().mockReturnValue(document.createElement("div")),
 }));
 
 // Mock the TLE bundled data
@@ -168,5 +205,88 @@ describe("bootstrap", () => {
     expect(errorDiv.style.display).not.toBe("none");
     expect(errorDiv.textContent).toMatch(/Scene error/);
     document.body.removeChild(root);
+  });
+
+  it("builds UI panel when ui-panel-root is present", async () => {
+    capturedDispatch = null;
+    const root = document.createElement("main");
+    root.id = "app";
+    const cesiumDiv = document.createElement("div");
+    cesiumDiv.id = "cesium-container";
+    root.appendChild(cesiumDiv);
+    const errorDiv = document.createElement("div");
+    errorDiv.id = "error";
+    root.appendChild(errorDiv);
+    const panelRoot = document.createElement("div");
+    panelRoot.id = "ui-panel-root";
+    document.body.appendChild(panelRoot);
+    document.body.appendChild(root);
+
+    await bootstrap(root);
+
+    expect(capturedDispatch).not.toBeNull();
+    document.body.removeChild(root);
+    document.body.removeChild(panelRoot);
+  });
+});
+
+describe("handleIntent routing", () => {
+  function makeRoot() {
+    const root = document.createElement("main");
+    root.id = "app";
+    const cesiumDiv = document.createElement("div");
+    cesiumDiv.id = "cesium-container";
+    root.appendChild(cesiumDiv);
+    const errorDiv = document.createElement("div");
+    errorDiv.id = "error";
+    root.appendChild(errorDiv);
+    const panelRoot = document.createElement("div");
+    panelRoot.id = "ui-panel-root";
+    document.body.appendChild(panelRoot);
+    document.body.appendChild(root);
+    return { root, panelRoot };
+  }
+
+  it("set-time intent re-renders without throwing", async () => {
+    capturedDispatch = null;
+    const { root, panelRoot } = makeRoot();
+    await bootstrap(root);
+    expect(capturedDispatch).not.toBeNull();
+    expect(() =>
+      capturedDispatch!({ type: "set-time", time: new Date("2026-05-01T00:00:00Z") }),
+    ).not.toThrow();
+    document.body.removeChild(root);
+    document.body.removeChild(panelRoot);
+  });
+
+  it("set-observer intent re-renders without throwing", async () => {
+    capturedDispatch = null;
+    const { root, panelRoot } = makeRoot();
+    await bootstrap(root);
+    expect(() =>
+      capturedDispatch!({ type: "set-observer", lat: 51.5, lon: -0.12 }),
+    ).not.toThrow();
+    document.body.removeChild(root);
+    document.body.removeChild(panelRoot);
+  });
+
+  it("toggle-layer intent updates layer visibility without throwing", async () => {
+    capturedDispatch = null;
+    const { root, panelRoot } = makeRoot();
+    await bootstrap(root);
+    expect(() => capturedDispatch!({ type: "toggle-layer", layer: "stars" })).not.toThrow();
+    document.body.removeChild(root);
+    document.body.removeChild(panelRoot);
+  });
+
+  it("set-opacity intent updates opacity without throwing", async () => {
+    capturedDispatch = null;
+    const { root, panelRoot } = makeRoot();
+    await bootstrap(root);
+    expect(() =>
+      capturedDispatch!({ type: "set-opacity", layer: "constellationLines", value: 0.5 }),
+    ).not.toThrow();
+    document.body.removeChild(root);
+    document.body.removeChild(panelRoot);
   });
 });

--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -263,9 +263,7 @@ describe("handleIntent routing", () => {
     capturedDispatch = null;
     const { root, panelRoot } = makeRoot();
     await bootstrap(root);
-    expect(() =>
-      capturedDispatch!({ type: "set-observer", lat: 51.5, lon: -0.12 }),
-    ).not.toThrow();
+    expect(() => capturedDispatch!({ type: "set-observer", lat: 51.5, lon: -0.12 })).not.toThrow();
     document.body.removeChild(root);
     document.body.removeChild(panelRoot);
   });

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,11 +1,14 @@
 /* SPDX-License-Identifier: Apache-2.0 */
-import { parseStateFromSearchParams } from "./state";
+import { parseStateFromSearchParams, serializeStateToSearchParams } from "./state";
+import type { AppState, LayerVisibility } from "./state/state";
 import {
   parseCatalog,
   filterVisibleStars,
   computeBodyPositions,
   parseConstellations,
   filterVisibleConstellations,
+  parseBoundaries,
+  filterVisibleBoundaries,
 } from "./astro";
 import {
   createViewer,
@@ -16,10 +19,90 @@ import {
   createConstellationLayer,
   createCompassLayer,
   createSatelliteLayer,
+  createBoundaryLayer,
+} from "./scene";
+import type {
+  StarLayer,
+  BodyLayer,
+  ConstellationLayer,
+  BoundaryLayer,
+  SatelliteLayer,
+  CompassLayer,
 } from "./scene";
 import { fetchTle, parseTle, propagateSatellites } from "./sat";
+import { createPanel, createTimeControls, createLocationControls, createLayerControls } from "./ui";
+import type { UIIntent } from "./ui";
 import rawStars from "../data/stars.json";
 import rawConstellations from "../data/constellations.json";
+import rawBoundaries from "../data/boundaries.json";
+
+type Layers = {
+  star: StarLayer;
+  body: BodyLayer;
+  constellation: ConstellationLayer;
+  boundary: BoundaryLayer;
+  satellite: SatelliteLayer | null;
+  compass: CompassLayer;
+};
+
+function applyLayerVisibility(layers: Layers, visibility: LayerVisibility): void {
+  layers.star.setVisible(visibility.stars);
+  layers.body.setVisible(visibility.planets);
+  layers.constellation.setVisible(visibility.constellationLines);
+  layers.boundary.setVisible(visibility.constellationBoundaries);
+  layers.compass.setVisible(visibility.compass);
+  if (layers.satellite) layers.satellite.setVisible(visibility.satellites);
+}
+
+function rerender(
+  state: AppState,
+  layers: Layers,
+  catalogResult: ReturnType<typeof parseCatalog>,
+): void {
+  if (!catalogResult.ok) return;
+  const { observer, timeUtc } = state;
+
+  const visibleStars = filterVisibleStars(catalogResult.value, observer.lat, observer.lon, timeUtc);
+  layers.star.update(visibleStars, observer.lat, observer.lon);
+
+  const bodies = computeBodyPositions(observer.lat, observer.lon, timeUtc, true);
+  layers.body.update(bodies, observer.lat, observer.lon);
+
+  const constellationResult = parseConstellations(rawConstellations);
+  if (constellationResult.ok) {
+    const visibleConstellations = filterVisibleConstellations(
+      constellationResult.value,
+      visibleStars,
+    );
+    layers.constellation.update(visibleConstellations, observer.lat, observer.lon);
+  }
+
+  const boundaryResult = parseBoundaries(rawBoundaries);
+  if (boundaryResult.ok) {
+    const visibleBoundaries = filterVisibleBoundaries(
+      boundaryResult.value,
+      observer.lat,
+      observer.lon,
+      timeUtc,
+    );
+    layers.boundary.update(visibleBoundaries, observer.lat, observer.lon);
+  } else {
+    console.warn(`Boundary load warning: ${boundaryResult.error.message}`);
+  }
+
+  layers.compass.update(observer.lat, observer.lon);
+
+  applyLayerVisibility(layers, state.layers);
+  layers.constellation.setOpacity(state.opacity.constellationLines * 0.25);
+  layers.boundary.setOpacity(state.opacity.constellationBoundaries * 0.15);
+  if (layers.satellite) layers.satellite.setOpacity(state.opacity.satelliteTrails * 0.3);
+}
+
+function updateUrl(state: AppState): void {
+  const params = serializeStateToSearchParams(state);
+  const url = `${globalThis.location.pathname}?${params.toString()}`;
+  globalThis.history.replaceState(null, "", url);
+}
 
 export async function bootstrap(
   root: HTMLElement | null,
@@ -34,7 +117,7 @@ export async function bootstrap(
     showError(errorDiv, `State error: ${stateResult.error.kind}`);
     return;
   }
-  const { observer, timeUtc } = stateResult.value;
+  let state = stateResult.value;
 
   const catalogResult = parseCatalog(rawStars);
   if (!catalogResult.ok) {
@@ -49,52 +132,101 @@ export async function bootstrap(
   }
   const viewer = viewerResult.value;
 
-  initCamera(viewer.camera, observer.lat, observer.lon);
+  initCamera(viewer.camera, state.observer.lat, state.observer.lon);
 
-  const visibleStars = filterVisibleStars(catalogResult.value, observer.lat, observer.lon, timeUtc);
-  const starLayer = createStarLayer(viewer.scene);
-  starLayer.update(visibleStars, observer.lat, observer.lon);
+  // Create all layers
+  const layers: Layers = {
+    star: createStarLayer(viewer.scene),
+    body: createBodyLayer(viewer.scene),
+    constellation: createConstellationLayer(viewer.scene),
+    boundary: createBoundaryLayer(viewer.scene),
+    satellite: null,
+    compass: createCompassLayer(viewer.scene),
+  };
 
-  const bodies = computeBodyPositions(observer.lat, observer.lon, timeUtc, true);
-  const bodyLayer = createBodyLayer(viewer.scene);
-  bodyLayer.update(bodies, observer.lat, observer.lon);
+  // Initial render
+  rerender(state, layers, catalogResult);
 
-  const constellationResult = parseConstellations(rawConstellations);
-  if (constellationResult.ok) {
-    const visibleConstellations = filterVisibleConstellations(
-      constellationResult.value,
-      visibleStars,
-    );
-    const constellationLayer = createConstellationLayer(viewer.scene);
-    constellationLayer.update(visibleConstellations, observer.lat, observer.lon);
-  } else {
-    console.warn(`Constellation load warning: ${constellationResult.error.message}`);
-  }
-
-  const compassLayer = createCompassLayer(viewer.scene);
-  compassLayer.update(observer.lat, observer.lon);
-
+  // Satellite layer (async)
   const tleResult = await fetchTle();
   if (tleResult.ok) {
     const satResult = parseTle(tleResult.value);
     if (satResult.ok) {
+      const satLayer = createSatelliteLayer(viewer.scene);
+      layers.satellite = satLayer;
       const visibleSats = propagateSatellites(
         satResult.value,
-        observer.lat,
-        observer.lon,
-        timeUtc,
+        state.observer.lat,
+        state.observer.lon,
+        state.timeUtc,
         true,
       );
-      const satLayer = createSatelliteLayer(viewer.scene);
-      satLayer.update(visibleSats, observer.lat, observer.lon);
+      satLayer.update(visibleSats, state.observer.lat, state.observer.lon);
+      satLayer.setVisible(state.layers.satellites);
+      satLayer.setOpacity(state.opacity.satelliteTrails * 0.3);
     } else {
       console.warn(`TLE parse warning: ${satResult.error.message}`);
     }
   }
 
+  // Tooltip
   const cesiumContainer = document.getElementById("cesium-container");
   if (cesiumContainer) {
     createTooltip(viewer, cesiumContainer);
+  }
+
+  // Intent handler
+  function handleIntent(intent: UIIntent): void {
+    switch (intent.type) {
+      case "set-time": {
+        state = { ...state, timeUtc: intent.time };
+        rerender(state, layers, catalogResult);
+        updateUrl(state);
+        break;
+      }
+      case "set-observer": {
+        state = { ...state, observer: { lat: intent.lat, lon: intent.lon } };
+        initCamera(viewer.camera, intent.lat, intent.lon);
+        rerender(state, layers, catalogResult);
+        updateUrl(state);
+        break;
+      }
+      case "toggle-layer": {
+        const newLayers = { ...state.layers, [intent.layer]: !state.layers[intent.layer] };
+        state = { ...state, layers: newLayers };
+        applyLayerVisibility(layers, state.layers);
+        updateUrl(state);
+        break;
+      }
+      case "set-opacity": {
+        const newOpacity = { ...state.opacity, [intent.layer]: intent.value };
+        state = { ...state, opacity: newOpacity };
+        layers.constellation.setOpacity(state.opacity.constellationLines * 0.25);
+        layers.boundary.setOpacity(state.opacity.constellationBoundaries * 0.15);
+        if (layers.satellite) layers.satellite.setOpacity(state.opacity.satelliteTrails * 0.3);
+        updateUrl(state);
+        break;
+      }
+    }
+  }
+
+  // Build UI panel
+  const panelRoot = document.getElementById("ui-panel-root");
+  if (panelRoot) {
+    const panel = createPanel(panelRoot);
+
+    const uiContainer = document.createElement("div");
+
+    const timeEl = createTimeControls(state.timeUtc, handleIntent);
+    uiContainer.appendChild(timeEl);
+
+    const locationEl = createLocationControls(state.observer.lat, state.observer.lon, handleIntent);
+    uiContainer.appendChild(locationEl);
+
+    const layerEl = createLayerControls(state.layers, state.opacity, handleIntent);
+    uiContainer.appendChild(layerEl);
+
+    panel.setContent(uiContainer);
   }
 }
 

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -1,0 +1,14 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+export type { Panel } from "./panel";
+export { createPanel } from "./panel";
+export { createTimeControls } from "./time-controls";
+export { createLocationControls } from "./location-controls";
+export { createLayerControls } from "./layer-controls";
+
+import type { LayerVisibility, LayerOpacity } from "../state/state";
+
+export type UIIntent =
+  | { type: "set-time"; time: Date }
+  | { type: "set-observer"; lat: number; lon: number }
+  | { type: "toggle-layer"; layer: keyof LayerVisibility }
+  | { type: "set-opacity"; layer: keyof LayerOpacity; value: number };

--- a/src/ui/layer-controls.test.ts
+++ b/src/ui/layer-controls.test.ts
@@ -1,0 +1,99 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createLayerControls } from "./layer-controls";
+import type { UIIntent } from "./index";
+import type { LayerVisibility, LayerOpacity } from "../state/state";
+
+const DEFAULT_VISIBILITY: LayerVisibility = {
+  stars: true,
+  planets: true,
+  satellites: true,
+  constellationLines: true,
+  constellationBoundaries: true,
+  compass: true,
+};
+
+const DEFAULT_OPACITY: LayerOpacity = {
+  constellationLines: 1.0,
+  constellationBoundaries: 1.0,
+  satelliteTrails: 1.0,
+};
+
+describe("createLayerControls", () => {
+  let dispatch: ReturnType<typeof vi.fn>;
+  let el: HTMLElement;
+
+  beforeEach(() => {
+    dispatch = vi.fn();
+    el = createLayerControls(DEFAULT_VISIBILITY, DEFAULT_OPACITY, dispatch);
+  });
+
+  it("returns an HTMLElement", () => {
+    expect(el).toBeInstanceOf(HTMLElement);
+  });
+
+  it("renders a toggle for each layer", () => {
+    const toggles = el.querySelectorAll("input[type='checkbox']");
+    expect(toggles.length).toBe(6);
+  });
+
+  it("toggles reflect initial visibility state", () => {
+    const checkboxes = [...el.querySelectorAll<HTMLInputElement>("input[type='checkbox']")];
+    expect(checkboxes.every((cb) => cb.checked)).toBe(true);
+  });
+
+  it("clicking a layer toggle dispatches toggle-layer intent", () => {
+    const starsToggle = el.querySelector<HTMLInputElement>("input[data-layer='stars']")!;
+    starsToggle.checked = false;
+    starsToggle.dispatchEvent(new Event("change"));
+    expect(dispatch).toHaveBeenCalledOnce();
+    const intent = dispatch.mock.calls[0]![0] as UIIntent;
+    expect(intent.type).toBe("toggle-layer");
+    if (intent.type === "toggle-layer") {
+      expect(intent.layer).toBe("stars");
+    }
+  });
+
+  it("renders opacity sliders for dimmable layers", () => {
+    const sliders = el.querySelectorAll("input[type='range']");
+    expect(sliders.length).toBe(3);
+  });
+
+  it("opacity sliders reflect initial opacity (100%)", () => {
+    const sliders = [...el.querySelectorAll<HTMLInputElement>("input[type='range']")];
+    expect(sliders.every((s) => Number(s.value) === 100)).toBe(true);
+  });
+
+  it("moving an opacity slider dispatches set-opacity intent", () => {
+    const slider = el.querySelector<HTMLInputElement>("input[data-opacity='constellationLines']")!;
+    slider.value = "50";
+    slider.dispatchEvent(new Event("input"));
+    expect(dispatch).toHaveBeenCalledOnce();
+    const intent = dispatch.mock.calls[0]![0] as UIIntent;
+    expect(intent.type).toBe("set-opacity");
+    if (intent.type === "set-opacity") {
+      expect(intent.layer).toBe("constellationLines");
+      expect(intent.value).toBeCloseTo(0.5);
+    }
+  });
+
+  it("opacity slider is hidden when parent layer toggle is off", () => {
+    // Start with constellationLines off
+    const offVisibility: LayerVisibility = { ...DEFAULT_VISIBILITY, constellationLines: false };
+    const el2 = createLayerControls(offVisibility, DEFAULT_OPACITY, vi.fn());
+    const sliderRow = el2.querySelector<HTMLElement>("[data-opacity-row='constellationLines']")!;
+    expect(sliderRow.style.display).toBe("none");
+  });
+
+  it("opacity slider becomes visible when parent layer is toggled on", () => {
+    const toggle = el.querySelector<HTMLInputElement>("input[data-layer='constellationLines']")!;
+    const sliderRow = el.querySelector<HTMLElement>("[data-opacity-row='constellationLines']")!;
+    // Currently visible; toggle off then on
+    toggle.checked = false;
+    toggle.dispatchEvent(new Event("change"));
+    expect(sliderRow.style.display).toBe("none");
+    toggle.checked = true;
+    toggle.dispatchEvent(new Event("change"));
+    expect(sliderRow.style.display).not.toBe("none");
+  });
+});

--- a/src/ui/layer-controls.ts
+++ b/src/ui/layer-controls.ts
@@ -1,0 +1,150 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { applyBaseText, ACCENT_COLOR, GAP } from "./styles";
+import type { UIIntent } from "./index";
+import type { LayerVisibility, LayerOpacity } from "../state/state";
+
+type LayerDef = {
+  key: keyof LayerVisibility;
+  label: string;
+};
+
+type OpacityDef = {
+  key: keyof LayerOpacity;
+  label: string;
+  parentLayer: keyof LayerVisibility;
+};
+
+const LAYERS: LayerDef[] = [
+  { key: "stars", label: "Stars ☆" },
+  { key: "planets", label: "Planets ☾" },
+  { key: "satellites", label: "Satellites 🛰" },
+  { key: "constellationLines", label: "Constellation Lines ╱" },
+  { key: "constellationBoundaries", label: "Constellation Boundaries ⬡" },
+  { key: "compass", label: "Compass ◎" },
+];
+
+const OPACITY_CONTROLS: OpacityDef[] = [
+  {
+    key: "constellationLines",
+    label: "Constellation Lines opacity",
+    parentLayer: "constellationLines",
+  },
+  {
+    key: "constellationBoundaries",
+    label: "Constellation Boundaries opacity",
+    parentLayer: "constellationBoundaries",
+  },
+  { key: "satelliteTrails", label: "Satellite Trails opacity", parentLayer: "satellites" },
+];
+
+export function createLayerControls(
+  initialVisibility: LayerVisibility,
+  initialOpacity: LayerOpacity,
+  dispatch: (intent: UIIntent) => void,
+): HTMLElement {
+  const visibility = { ...initialVisibility };
+
+  const section = document.createElement("div");
+  section.style.marginBottom = GAP;
+
+  // Layers heading
+  const layersHeading = document.createElement("div");
+  layersHeading.textContent = "Layers";
+  layersHeading.style.fontWeight = "bold";
+  layersHeading.style.marginBottom = GAP;
+  applyBaseText(layersHeading);
+  section.appendChild(layersHeading);
+
+  // Map from layer key → opacity slider row element, for show/hide
+  const opacityRowMap = new Map<string, HTMLElement>();
+
+  // Build each layer toggle row
+  for (const layer of LAYERS) {
+    const row = document.createElement("div");
+    row.style.display = "flex";
+    row.style.alignItems = "center";
+    row.style.justifyContent = "space-between";
+    row.style.marginBottom = "6px";
+
+    const lbl = document.createElement("label");
+    lbl.style.display = "flex";
+    lbl.style.alignItems = "center";
+    lbl.style.gap = "6px";
+    lbl.style.cursor = "pointer";
+    applyBaseText(lbl);
+
+    const checkbox = document.createElement("input");
+    checkbox.type = "checkbox";
+    checkbox.dataset.layer = layer.key;
+    checkbox.checked = visibility[layer.key];
+    // Style as toggle-like accent checkbox
+    checkbox.style.accentColor = ACCENT_COLOR;
+    checkbox.style.width = "16px";
+    checkbox.style.height = "16px";
+
+    const labelText = document.createTextNode(layer.label);
+
+    lbl.appendChild(checkbox);
+    lbl.appendChild(labelText);
+    row.appendChild(lbl);
+    section.appendChild(row);
+
+    checkbox.addEventListener("change", () => {
+      visibility[layer.key] = checkbox.checked;
+      // Show/hide associated opacity row if any
+      for (const od of OPACITY_CONTROLS) {
+        if (od.parentLayer === layer.key) {
+          const opRow = opacityRowMap.get(od.key);
+          if (opRow) opRow.style.display = checkbox.checked ? "" : "none";
+        }
+      }
+      dispatch({ type: "toggle-layer", layer: layer.key });
+    });
+  }
+
+  // Opacity heading
+  const opacityHeading = document.createElement("div");
+  opacityHeading.textContent = "Opacity";
+  opacityHeading.style.fontWeight = "bold";
+  opacityHeading.style.marginTop = "8px";
+  opacityHeading.style.marginBottom = GAP;
+  applyBaseText(opacityHeading);
+  section.appendChild(opacityHeading);
+
+  // Build each opacity slider row
+  for (const od of OPACITY_CONTROLS) {
+    const row = document.createElement("div");
+    row.dataset.opacityRow = od.key;
+    row.style.marginBottom = "6px";
+    // Hidden if parent layer is off
+    if (!visibility[od.parentLayer]) row.style.display = "none";
+    opacityRowMap.set(od.key, row);
+
+    const lbl = document.createElement("div");
+    lbl.textContent = od.label;
+    applyBaseText(lbl);
+    lbl.style.fontSize = "12px";
+    lbl.style.marginBottom = "2px";
+
+    const slider = document.createElement("input");
+    slider.type = "range";
+    slider.dataset.opacity = od.key;
+    slider.min = "0";
+    slider.max = "100";
+    slider.step = "1";
+    slider.value = String(Math.round(initialOpacity[od.key] * 100));
+    slider.style.width = "100%";
+    slider.style.accentColor = ACCENT_COLOR;
+
+    slider.addEventListener("input", () => {
+      const value = Number(slider.value) / 100;
+      dispatch({ type: "set-opacity", layer: od.key, value });
+    });
+
+    row.appendChild(lbl);
+    row.appendChild(slider);
+    section.appendChild(row);
+  }
+
+  return section;
+}

--- a/src/ui/location-controls.test.ts
+++ b/src/ui/location-controls.test.ts
@@ -1,0 +1,74 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createLocationControls } from "./location-controls";
+import type { UIIntent } from "./index";
+
+describe("createLocationControls", () => {
+  let dispatch: ReturnType<typeof vi.fn>;
+  let el: HTMLElement;
+
+  beforeEach(() => {
+    dispatch = vi.fn();
+    el = createLocationControls(33.45, -117.15, dispatch);
+  });
+
+  it("returns an HTMLElement", () => {
+    expect(el).toBeInstanceOf(HTMLElement);
+  });
+
+  it("has lat and lon number inputs prefilled with initial values", () => {
+    const inputs = el.querySelectorAll<HTMLInputElement>("input[type='number']");
+    expect(inputs.length).toBeGreaterThanOrEqual(2);
+    const latInput = [...inputs].find((i) => i.dataset.field === "lat");
+    const lonInput = [...inputs].find((i) => i.dataset.field === "lon");
+    expect(latInput).not.toBeNull();
+    expect(lonInput).not.toBeNull();
+    expect(Number(latInput!.value)).toBeCloseTo(33.45);
+    expect(Number(lonInput!.value)).toBeCloseTo(-117.15);
+  });
+
+  it("has a preset cities dropdown", () => {
+    const select = el.querySelector("select");
+    expect(select).not.toBeNull();
+    // Should include at least New York and Tokyo
+    const options = [...select!.querySelectorAll("option")].map((o) => o.textContent);
+    expect(options.some((t) => t?.includes("New York"))).toBe(true);
+    expect(options.some((t) => t?.includes("Tokyo"))).toBe(true);
+  });
+
+  it("changing lat/lon inputs dispatches set-observer intent", () => {
+    const latInput = el.querySelector<HTMLInputElement>("input[data-field='lat']")!;
+    latInput.value = "51.5";
+    latInput.dispatchEvent(new Event("change"));
+    expect(dispatch).toHaveBeenCalledOnce();
+    const intent = dispatch.mock.calls[0]![0] as UIIntent;
+    expect(intent.type).toBe("set-observer");
+    if (intent.type === "set-observer") {
+      expect(intent.lat).toBeCloseTo(51.5);
+    }
+  });
+
+  it("ignores non-numeric lat input", () => {
+    const latInput = el.querySelector<HTMLInputElement>("input[data-field='lat']")!;
+    latInput.value = "abc";
+    latInput.dispatchEvent(new Event("change"));
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it("selecting a preset city dispatches set-observer with city coordinates", () => {
+    const select = el.querySelector<HTMLSelectElement>("select")!;
+    // Find the New York option
+    const nyOption = [...select.querySelectorAll("option")].find((o) =>
+      o.textContent?.includes("New York"),
+    )!;
+    select.value = nyOption.value;
+    select.dispatchEvent(new Event("change"));
+    expect(dispatch).toHaveBeenCalledOnce();
+    const intent = dispatch.mock.calls[0]![0] as UIIntent;
+    expect(intent.type).toBe("set-observer");
+    if (intent.type === "set-observer") {
+      expect(intent.lat).toBeCloseTo(40.71, 1);
+      expect(intent.lon).toBeCloseTo(-74.01, 1);
+    }
+  });
+});

--- a/src/ui/location-controls.ts
+++ b/src/ui/location-controls.ts
@@ -1,0 +1,139 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { applyBaseText, GAP } from "./styles";
+import type { UIIntent } from "./index";
+
+type City = { name: string; lat: number; lon: number };
+
+const PRESET_CITIES: City[] = [
+  { name: "New York", lat: 40.71, lon: -74.01 },
+  { name: "London", lat: 51.51, lon: -0.13 },
+  { name: "Tokyo", lat: 35.69, lon: 139.69 },
+  { name: "Sydney", lat: -33.87, lon: 151.21 },
+  { name: "São Paulo", lat: -23.55, lon: -46.63 },
+  { name: "Cape Town", lat: -33.93, lon: 18.42 },
+  { name: "Los Angeles", lat: 34.05, lon: -118.24 },
+  { name: "Mumbai", lat: 19.08, lon: 72.88 },
+];
+
+export function createLocationControls(
+  initialLat: number,
+  initialLon: number,
+  dispatch: (intent: UIIntent) => void,
+): HTMLElement {
+  let currentLat = initialLat;
+  let currentLon = initialLon;
+
+  const section = document.createElement("div");
+  section.style.marginBottom = GAP;
+
+  const heading = document.createElement("div");
+  heading.textContent = "Location";
+  heading.style.fontWeight = "bold";
+  heading.style.marginBottom = GAP;
+  applyBaseText(heading);
+  section.appendChild(heading);
+
+  function makeNumberInput(
+    label: string,
+    field: "lat" | "lon",
+    value: number,
+    min: number,
+    max: number,
+  ): HTMLElement {
+    const row = document.createElement("div");
+    row.style.display = "flex";
+    row.style.alignItems = "center";
+    row.style.gap = "6px";
+    row.style.marginBottom = "4px";
+
+    const lbl = document.createElement("label");
+    lbl.textContent = label;
+    lbl.style.color = "#fff";
+    lbl.style.fontSize = "12px";
+    lbl.style.width = "30px";
+    lbl.style.fontFamily = "sans-serif";
+
+    const input = document.createElement("input");
+    input.type = "number";
+    input.dataset.field = field;
+    input.value = String(value);
+    input.min = String(min);
+    input.max = String(max);
+    input.step = "0.01";
+    input.style.flex = "1";
+    input.style.background = "rgba(255,255,255,0.1)";
+    input.style.border = "1px solid rgba(255,255,255,0.3)";
+    input.style.borderRadius = "4px";
+    input.style.color = "#fff";
+    input.style.fontSize = "12px";
+    input.style.padding = "4px";
+
+    input.addEventListener("change", () => {
+      if (input.value === "") return;
+      const n = Number(input.value);
+      if (!Number.isFinite(n)) return;
+      if (field === "lat") currentLat = n;
+      else currentLon = n;
+      dispatch({ type: "set-observer", lat: currentLat, lon: currentLon });
+    });
+
+    row.appendChild(lbl);
+    row.appendChild(input);
+    return row;
+  }
+
+  section.appendChild(makeNumberInput("Lat", "lat", initialLat, -90, 90));
+  section.appendChild(makeNumberInput("Lon", "lon", initialLon, -180, 180));
+
+  // Preset dropdown
+  const presetLabel = document.createElement("div");
+  presetLabel.textContent = "City preset";
+  presetLabel.style.color = "#fff";
+  presetLabel.style.fontSize = "12px";
+  presetLabel.style.marginTop = "6px";
+  presetLabel.style.marginBottom = "4px";
+  presetLabel.style.fontFamily = "sans-serif";
+  section.appendChild(presetLabel);
+
+  const select = document.createElement("select");
+  select.style.width = "100%";
+  select.style.background = "rgba(255,255,255,0.1)";
+  select.style.border = "1px solid rgba(255,255,255,0.3)";
+  select.style.borderRadius = "4px";
+  select.style.color = "#fff";
+  select.style.fontSize = "12px";
+  select.style.padding = "4px";
+
+  const placeholder = document.createElement("option");
+  placeholder.value = "";
+  placeholder.textContent = "— Select city —";
+  select.appendChild(placeholder);
+
+  for (const city of PRESET_CITIES) {
+    const opt = document.createElement("option");
+    opt.value = JSON.stringify({ lat: city.lat, lon: city.lon });
+    opt.textContent = city.name;
+    select.appendChild(opt);
+  }
+
+  select.addEventListener("change", () => {
+    if (!select.value) return;
+    try {
+      const { lat, lon } = JSON.parse(select.value) as { lat: number; lon: number };
+      currentLat = lat;
+      currentLon = lon;
+      // Update inputs
+      const latInput = section.querySelector<HTMLInputElement>("input[data-field='lat']");
+      const lonInput = section.querySelector<HTMLInputElement>("input[data-field='lon']");
+      if (latInput) latInput.value = String(lat);
+      if (lonInput) lonInput.value = String(lon);
+      dispatch({ type: "set-observer", lat, lon });
+    } catch {
+      // ignore malformed value
+    }
+  });
+
+  section.appendChild(select);
+
+  return section;
+}

--- a/src/ui/panel.test.ts
+++ b/src/ui/panel.test.ts
@@ -1,0 +1,58 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { beforeEach, describe, expect, it } from "vitest";
+import { createPanel } from "./panel";
+
+describe("createPanel", () => {
+  let container: HTMLElement;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+  });
+
+  it("returns an object with element, setContent, and setCollapsed", () => {
+    const panel = createPanel(container);
+    expect(panel).toHaveProperty("element");
+    expect(panel).toHaveProperty("setContent");
+    expect(panel).toHaveProperty("setCollapsed");
+  });
+
+  it("appends the panel element to the container", () => {
+    createPanel(container);
+    expect(container.children.length).toBe(1);
+  });
+
+  it("panel has a header with a title and toggle button", () => {
+    const { element } = createPanel(container);
+    const header = element.querySelector("[data-testid='panel-header']");
+    expect(header).not.toBeNull();
+    const btn = element.querySelector("[data-testid='panel-toggle']");
+    expect(btn).not.toBeNull();
+  });
+
+  it("collapse button toggles the body visibility", () => {
+    const { element } = createPanel(container);
+    const btn = element.querySelector<HTMLButtonElement>("[data-testid='panel-toggle']")!;
+    const body = element.querySelector<HTMLElement>("[data-testid='panel-body']")!;
+    // starts expanded
+    expect(body.style.display).not.toBe("none");
+    btn.click();
+    expect(body.style.display).toBe("none");
+    btn.click();
+    expect(body.style.display).not.toBe("none");
+  });
+
+  it("setCollapsed(true) hides the body", () => {
+    const { element, setCollapsed } = createPanel(container);
+    const body = element.querySelector<HTMLElement>("[data-testid='panel-body']")!;
+    setCollapsed(true);
+    expect(body.style.display).toBe("none");
+  });
+
+  it("setContent replaces the body content", () => {
+    const { setContent } = createPanel(container);
+    const child = document.createElement("span");
+    child.textContent = "hello";
+    setContent(child);
+    expect(container.querySelector("span")).not.toBeNull();
+  });
+});

--- a/src/ui/panel.ts
+++ b/src/ui/panel.ts
@@ -1,0 +1,85 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import {
+  PANEL_BG,
+  PANEL_BORDER,
+  PANEL_RADIUS,
+  PANEL_WIDTH,
+  PANEL_MAX_HEIGHT,
+  TEXT_COLOR,
+  applyButton,
+} from "./styles";
+
+export type Panel = {
+  element: HTMLElement;
+  setContent: (child: HTMLElement) => void;
+  setCollapsed: (collapsed: boolean) => void;
+};
+
+export function createPanel(container: HTMLElement): Panel {
+  const panel = document.createElement("div");
+  panel.style.position = "fixed";
+  panel.style.top = "16px";
+  panel.style.right = "16px";
+  panel.style.width = PANEL_WIDTH;
+  panel.style.maxHeight = PANEL_MAX_HEIGHT;
+  panel.style.overflowY = "auto";
+  panel.style.background = PANEL_BG;
+  panel.style.border = PANEL_BORDER;
+  panel.style.borderRadius = PANEL_RADIUS;
+  panel.style.zIndex = "1000";
+  panel.style.boxSizing = "border-box";
+
+  // Header
+  const header = document.createElement("div");
+  header.dataset.testid = "panel-header";
+  header.style.display = "flex";
+  header.style.justifyContent = "space-between";
+  header.style.alignItems = "center";
+  header.style.padding = "8px 12px";
+  header.style.borderBottom = "1px solid rgba(255,255,255,0.15)";
+
+  const title = document.createElement("span");
+  title.textContent = "Planisphere";
+  title.style.color = TEXT_COLOR;
+  title.style.fontSize = "14px";
+  title.style.fontWeight = "bold";
+  title.style.fontFamily = "sans-serif";
+
+  const toggleBtn = document.createElement("button");
+  toggleBtn.dataset.testid = "panel-toggle";
+  toggleBtn.textContent = "⚙";
+  toggleBtn.title = "Toggle panel";
+  applyButton(toggleBtn);
+
+  header.appendChild(title);
+  header.appendChild(toggleBtn);
+
+  // Body
+  const body = document.createElement("div");
+  body.dataset.testid = "panel-body";
+  body.style.padding = "8px 12px";
+
+  panel.appendChild(header);
+  panel.appendChild(body);
+  container.appendChild(panel);
+
+  let collapsed = false;
+
+  toggleBtn.addEventListener("click", () => {
+    collapsed = !collapsed;
+    body.style.display = collapsed ? "none" : "";
+    toggleBtn.textContent = collapsed ? "⚙" : "×";
+  });
+
+  function setCollapsed(value: boolean): void {
+    collapsed = value;
+    body.style.display = value ? "none" : "";
+    toggleBtn.textContent = value ? "⚙" : "×";
+  }
+
+  function setContent(child: HTMLElement): void {
+    body.replaceChildren(child);
+  }
+
+  return { element: panel, setContent, setCollapsed };
+}

--- a/src/ui/styles.ts
+++ b/src/ui/styles.ts
@@ -1,0 +1,35 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+export const PANEL_BG = "rgba(0, 0, 0, 0.85)";
+export const PANEL_BORDER = "1px solid rgba(255, 255, 255, 0.2)";
+export const PANEL_RADIUS = "8px";
+export const PANEL_WIDTH = "280px";
+export const PANEL_MAX_HEIGHT = "80vh";
+export const ACCENT_COLOR = "#00FF88";
+export const TEXT_COLOR = "#ffffff";
+export const FONT_SIZE = "13px";
+export const FONT_FAMILY = "sans-serif";
+export const GAP = "8px";
+
+export function applyBaseText(el: HTMLElement): void {
+  el.style.color = TEXT_COLOR;
+  el.style.fontSize = FONT_SIZE;
+  el.style.fontFamily = FONT_FAMILY;
+}
+
+export function applyButton(el: HTMLButtonElement): void {
+  el.style.background = "rgba(255, 255, 255, 0.1)";
+  el.style.border = "1px solid rgba(255, 255, 255, 0.3)";
+  el.style.borderRadius = "4px";
+  el.style.color = TEXT_COLOR;
+  el.style.cursor = "pointer";
+  el.style.fontSize = "12px";
+  el.style.padding = "2px 6px";
+}
+
+export function applyLabel(el: HTMLElement): void {
+  el.style.color = TEXT_COLOR;
+  el.style.fontSize = FONT_SIZE;
+  el.style.fontFamily = FONT_FAMILY;
+  el.style.userSelect = "none";
+}

--- a/src/ui/time-controls.test.ts
+++ b/src/ui/time-controls.test.ts
@@ -1,0 +1,106 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createTimeControls } from "./time-controls";
+import type { UIIntent } from "./index";
+
+const BASE_TIME = new Date("2026-04-15T12:00:00Z");
+
+describe("createTimeControls", () => {
+  let dispatch: ReturnType<typeof vi.fn>;
+  let el: HTMLElement;
+
+  beforeEach(() => {
+    dispatch = vi.fn();
+    el = createTimeControls(BASE_TIME, dispatch);
+  });
+
+  it("returns an HTMLElement", () => {
+    expect(el).toBeInstanceOf(HTMLElement);
+  });
+
+  it("contains a datetime-local input pre-filled from the given time", () => {
+    const input = el.querySelector<HTMLInputElement>("input[type='datetime-local']");
+    expect(input).not.toBeNull();
+    expect(input!.value).not.toBe("");
+  });
+
+  it("contains a Now button", () => {
+    const buttons = [...el.querySelectorAll("button")].map((b) => b.textContent);
+    expect(buttons.some((t) => t?.includes("Now"))).toBe(true);
+  });
+
+  it("Now button dispatches set-time with approximately current time", () => {
+    const btn = [...el.querySelectorAll("button")].find((b) => b.textContent?.includes("Now"))!;
+    const before = Date.now();
+    btn.click();
+    const after = Date.now();
+    expect(dispatch).toHaveBeenCalledOnce();
+    const intent = dispatch.mock.calls[0]![0] as UIIntent;
+    expect(intent.type).toBe("set-time");
+    if (intent.type === "set-time") {
+      expect(intent.time.getTime()).toBeGreaterThanOrEqual(before);
+      expect(intent.time.getTime()).toBeLessThanOrEqual(after + 100);
+    }
+  });
+
+  it("+1h button dispatches set-time one hour ahead of current value", () => {
+    const btn = [...el.querySelectorAll("button")].find((b) => b.textContent?.includes("+1h"))!;
+    btn.click();
+    expect(dispatch).toHaveBeenCalledOnce();
+    const intent = dispatch.mock.calls[0]![0] as UIIntent;
+    expect(intent.type).toBe("set-time");
+    if (intent.type === "set-time") {
+      expect(intent.time.getTime()).toBe(BASE_TIME.getTime() + 3_600_000);
+    }
+  });
+
+  it("-1h button dispatches set-time one hour behind current value", () => {
+    const btn = [...el.querySelectorAll("button")].find((b) => b.textContent?.includes("-1h"))!;
+    btn.click();
+    const intent = dispatch.mock.calls[0]![0] as UIIntent;
+    expect(intent.type).toBe("set-time");
+    if (intent.type === "set-time") {
+      expect(intent.time.getTime()).toBe(BASE_TIME.getTime() - 3_600_000);
+    }
+  });
+
+  it("+1d button dispatches set-time 24 hours ahead", () => {
+    const btn = [...el.querySelectorAll("button")].find((b) => b.textContent?.includes("+1d"))!;
+    btn.click();
+    const intent = dispatch.mock.calls[0]![0] as UIIntent;
+    expect(intent.type).toBe("set-time");
+    if (intent.type === "set-time") {
+      expect(intent.time.getTime()).toBe(BASE_TIME.getTime() + 86_400_000);
+    }
+  });
+
+  it("-1d button dispatches set-time 24 hours behind", () => {
+    const btn = [...el.querySelectorAll("button")].find((b) => b.textContent?.includes("-1d"))!;
+    btn.click();
+    const intent = dispatch.mock.calls[0]![0] as UIIntent;
+    expect(intent.type).toBe("set-time");
+    if (intent.type === "set-time") {
+      expect(intent.time.getTime()).toBe(BASE_TIME.getTime() - 86_400_000);
+    }
+  });
+
+  it("+1m button dispatches set-time one minute ahead", () => {
+    const btn = [...el.querySelectorAll("button")].find((b) => b.textContent?.includes("+1m"))!;
+    btn.click();
+    const intent = dispatch.mock.calls[0]![0] as UIIntent;
+    expect(intent.type).toBe("set-time");
+    if (intent.type === "set-time") {
+      expect(intent.time.getTime()).toBe(BASE_TIME.getTime() + 60_000);
+    }
+  });
+
+  it("-1m button dispatches set-time one minute behind", () => {
+    const btn = [...el.querySelectorAll("button")].find((b) => b.textContent?.includes("-1m"))!;
+    btn.click();
+    const intent = dispatch.mock.calls[0]![0] as UIIntent;
+    expect(intent.type).toBe("set-time");
+    if (intent.type === "set-time") {
+      expect(intent.time.getTime()).toBe(BASE_TIME.getTime() - 60_000);
+    }
+  });
+});

--- a/src/ui/time-controls.ts
+++ b/src/ui/time-controls.ts
@@ -1,0 +1,95 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { applyButton, applyBaseText, GAP } from "./styles";
+import type { UIIntent } from "./index";
+
+const STEPS: Array<{ label: string; deltaMs: number }> = [
+  { label: "-1d", deltaMs: -86_400_000 },
+  { label: "-1h", deltaMs: -3_600_000 },
+  { label: "-1m", deltaMs: -60_000 },
+  { label: "+1m", deltaMs: 60_000 },
+  { label: "+1h", deltaMs: 3_600_000 },
+  { label: "+1d", deltaMs: 86_400_000 },
+];
+
+/** Format a Date to a value suitable for <input type="datetime-local"> (local time, no Z). */
+function toDatetimeLocal(d: Date): string {
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return (
+    `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}` +
+    `T${pad(d.getHours())}:${pad(d.getMinutes())}`
+  );
+}
+
+export function createTimeControls(
+  initial: Date,
+  dispatch: (intent: UIIntent) => void,
+): HTMLElement {
+  let current = new Date(initial);
+
+  const section = document.createElement("div");
+  section.style.marginBottom = GAP;
+
+  const heading = document.createElement("div");
+  heading.textContent = "Time";
+  heading.style.fontWeight = "bold";
+  heading.style.marginBottom = GAP;
+  applyBaseText(heading);
+  section.appendChild(heading);
+
+  const input = document.createElement("input");
+  input.type = "datetime-local";
+  input.value = toDatetimeLocal(current);
+  input.style.width = "100%";
+  input.style.background = "rgba(255,255,255,0.1)";
+  input.style.border = "1px solid rgba(255,255,255,0.3)";
+  input.style.borderRadius = "4px";
+  input.style.color = "#fff";
+  input.style.fontSize = "12px";
+  input.style.padding = "4px";
+  input.style.boxSizing = "border-box";
+  input.style.marginBottom = GAP;
+  section.appendChild(input);
+
+  input.addEventListener("change", () => {
+    const d = new Date(input.value);
+    if (!Number.isNaN(d.getTime())) {
+      current = d;
+      dispatch({ type: "set-time", time: d });
+    }
+  });
+
+  // Step buttons row
+  const buttonsRow = document.createElement("div");
+  buttonsRow.style.display = "flex";
+  buttonsRow.style.gap = "4px";
+  buttonsRow.style.flexWrap = "wrap";
+  buttonsRow.style.marginBottom = GAP;
+
+  for (const step of STEPS) {
+    const btn = document.createElement("button");
+    btn.textContent = step.label;
+    applyButton(btn);
+    btn.addEventListener("click", () => {
+      current = new Date(current.getTime() + step.deltaMs);
+      input.value = toDatetimeLocal(current);
+      dispatch({ type: "set-time", time: new Date(current) });
+    });
+    buttonsRow.appendChild(btn);
+  }
+  section.appendChild(buttonsRow);
+
+  // Now button
+  const nowBtn = document.createElement("button");
+  nowBtn.textContent = "Now";
+  applyButton(nowBtn);
+  nowBtn.style.width = "100%";
+  nowBtn.addEventListener("click", () => {
+    const now = new Date();
+    current = now;
+    input.value = toDatetimeLocal(now);
+    dispatch({ type: "set-time", time: new Date(now) });
+  });
+  section.appendChild(nowBtn);
+
+  return section;
+}


### PR DESCRIPTION
Closes #116
Closes #117
Closes #118
Closes #119
Closes #120
Closes #121

## Summary

- **Task 8 (Panel container):** `src/ui/panel.ts` + `src/ui/styles.ts` — collapsible floating panel fixed top-right, 280px wide, dark background, gear icon toggle, `data-testid` attributes for test queries.
- **Task 9 (Time controls):** `src/ui/time-controls.ts` — datetime-local input + six step buttons (±1d/1h/1m) + Now button; each dispatches `{ type: "set-time", time: Date }` via callback.
- **Task 10 (Location controls):** `src/ui/location-controls.ts` — lat/lon number inputs (step 0.01) + 8-city preset dropdown (New York, London, Tokyo, Sydney, São Paulo, Cape Town, Los Angeles, Mumbai); dispatches `{ type: "set-observer" }`.
- **Task 11 (Layer controls):** `src/ui/layer-controls.ts` — 6 checkbox toggles for all layers + 3 range sliders for opacity (constellation lines, boundaries, satellite trails); sliders hidden when parent toggle is off; dispatches `toggle-layer` and `set-opacity` intents.
- **Task 12 (UI barrel):** `src/ui/index.ts` exports all UI functions and the `UIIntent` discriminated union type.
- **Task 13 (App wiring):** `src/app.ts` rewritten as central orchestrator — creates all 6 layers, builds UI panel, routes `UIIntent` via `handleIntent()`, updates URL after each state change; `index.html` gains `#ui-panel-root`; `src/app.test.ts` gains intent routing tests with captured dispatch.

## Test plan

- [ ] 206 tests pass across 27 test files
- [ ] `pnpm typecheck` clean
- [ ] `pnpm format:check` clean
- [ ] `pnpm lint` clean
- [ ] `pnpm test:cov` passes all thresholds (app.ts 91% lines, ui/** 96.9% lines)
- [ ] `pnpm build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)