### PR TITLE
Fix body colors, compass toggle, index.html, add Austin

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,22 +28,11 @@
     </style>
   </head>
   <body>
-    <div
-      id="error"
-      style="
-        display: none;
-        position: fixed;
-        top: 8px;
-        left: 8px;
-        color: red;
-        background: rgba(0, 0, 0, 0.7);
-        padding: 8px;
-        border-radius: 4px;
-        z-index: 9999;
-      "
-    ></div>
-    <div id="ui-panel-root"></div>
-    <div id="cesium-container" style="width: 100vw; height: 100vh"></div>
+    <main id="app">
+      <div id="cesium-container"></div>
+      <div id="error" style="display: none"></div>
+      <div id="ui-panel-root"></div>
+    </main>
     <script type="module" src="/src/main.ts"></script>
   </body>
 </html>

--- a/src/scene/bodies.ts
+++ b/src/scene/bodies.ts
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: Apache-2.0 */
-import { BillboardCollection, Color, HorizontalOrigin, VerticalOrigin } from "cesium";
+import { BillboardCollection, HorizontalOrigin, VerticalOrigin } from "cesium";
 import type { Scene } from "cesium";
 import type { CelestialBody } from "../astro";
 import { altAzToCartesian } from "./stars";
@@ -106,7 +106,6 @@ export function createBodyLayer(scene: Scene): BodyLayer {
         position: altAzToCartesian(body.alt, body.az, lat, lon),
         image: spriteForBody(body),
         scale: body.size / 16,
-        color: Color.fromCssColorString(body.color).withAlpha(1.0),
         horizontalOrigin: HorizontalOrigin.CENTER,
         verticalOrigin: VerticalOrigin.CENTER,
         disableDepthTestDistance: Number.POSITIVE_INFINITY,

--- a/src/scene/compass.ts
+++ b/src/scene/compass.ts
@@ -62,7 +62,10 @@ export function createCompassLayer(scene: Scene): CompassLayer {
   }
 
   function setVisible(visible: boolean): void {
-    (labels as unknown as { show: boolean }).show = visible;
+    for (let i = 0; i < labels.length; i++) {
+      const label = labels.get(i);
+      label.show = visible;
+    }
   }
 
   return { update, setVisible };

--- a/src/ui/location-controls.ts
+++ b/src/ui/location-controls.ts
@@ -13,6 +13,7 @@ const PRESET_CITIES: City[] = [
   { name: "Cape Town", lat: -33.93, lon: 18.42 },
   { name: "Los Angeles", lat: 34.05, lon: -118.24 },
   { name: "Mumbai", lat: 19.08, lon: 72.88 },
+  { name: "Austin", lat: 30.27, lon: -97.74 },
 ];
 
 export function createLocationControls(


### PR DESCRIPTION
Closes #122

- Body billboards: removed double-tint (Color.fromCssColorString on already-colored sprites made Jupiter green)
- Compass: setVisible iterates individual labels instead of casting collection
- index.html: restored #app wrapper (Plan 06 rewrite dropped it, causing blank screen)
- Added Austin (30.27, -97.74) to preset cities
- Removed debug console.warn lines