### PR TITLE
feat: camera view direction controls (buttons + Alt/Az inputs)

### DIFF
--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -108,6 +108,7 @@ vi.mock("./ui", () => ({
   }),
   createLocationControls: vi.fn().mockReturnValue(document.createElement("div")),
   createLayerControls: vi.fn().mockReturnValue(document.createElement("div")),
+  createViewControls: vi.fn().mockReturnValue(document.createElement("div")),
 }));
 
 // Mock the TLE bundled data
@@ -284,6 +285,15 @@ describe("handleIntent routing", () => {
     expect(() =>
       capturedDispatch!({ type: "set-opacity", layer: "constellationLines", value: 0.5 }),
     ).not.toThrow();
+    document.body.removeChild(root);
+    document.body.removeChild(panelRoot);
+  });
+
+  it("set-view intent changes camera direction without throwing", async () => {
+    capturedDispatch = null;
+    const { root, panelRoot } = makeRoot();
+    await bootstrap(root);
+    expect(() => capturedDispatch!({ type: "set-view", az: 180, alt: 30 })).not.toThrow();
     document.body.removeChild(root);
     document.body.removeChild(panelRoot);
   });

--- a/src/app.ts
+++ b/src/app.ts
@@ -20,6 +20,7 @@ import {
   createCompassLayer,
   createSatelliteLayer,
   createBoundaryLayer,
+  setCameraView,
 } from "./scene";
 import type {
   StarLayer,
@@ -30,7 +31,13 @@ import type {
   CompassLayer,
 } from "./scene";
 import { fetchTle, parseTle, propagateSatellites } from "./sat";
-import { createPanel, createTimeControls, createLocationControls, createLayerControls } from "./ui";
+import {
+  createPanel,
+  createTimeControls,
+  createLocationControls,
+  createLayerControls,
+  createViewControls,
+} from "./ui";
 import type { UIIntent } from "./ui";
 import rawStars from "../data/stars.json";
 import rawConstellations from "../data/constellations.json";
@@ -207,6 +214,10 @@ export async function bootstrap(
         updateUrl(state);
         break;
       }
+      case "set-view": {
+        setCameraView(viewer.camera, state.observer.lat, state.observer.lon, intent.az, intent.alt);
+        break;
+      }
     }
   }
 
@@ -222,6 +233,9 @@ export async function bootstrap(
 
     const locationEl = createLocationControls(state.observer.lat, state.observer.lon, handleIntent);
     uiContainer.appendChild(locationEl);
+
+    const viewEl = createViewControls(0, 89.9, handleIntent);
+    uiContainer.appendChild(viewEl);
 
     const layerEl = createLayerControls(state.layers, state.opacity, handleIntent);
     uiContainer.appendChild(layerEl);

--- a/src/scene/camera.ts
+++ b/src/scene/camera.ts
@@ -3,12 +3,23 @@ import { Cartesian3, Math as CesiumMath } from "cesium";
 import type { Camera } from "cesium";
 
 export function initCamera(camera: Camera, lat: number, lon: number): void {
+  setCameraView(camera, lat, lon, 0, 89.9);
+}
+
+export function setCameraView(
+  camera: Camera,
+  lat: number,
+  lon: number,
+  azDeg: number,
+  altDeg: number,
+): void {
   const height = 1.7;
+  const clampedAlt = Math.min(89.9, Math.max(0, altDeg));
   camera.setView({
     destination: Cartesian3.fromDegrees(lon, lat, height),
     orientation: {
-      heading: CesiumMath.toRadians(0),
-      pitch: CesiumMath.toRadians(89.9),
+      heading: CesiumMath.toRadians(azDeg),
+      pitch: CesiumMath.toRadians(clampedAlt),
       roll: 0,
     },
   });

--- a/src/scene/index.ts
+++ b/src/scene/index.ts
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 export { type SceneInitError, createViewer } from "./viewer";
-export { initCamera } from "./camera";
+export { initCamera, setCameraView } from "./camera";
 export { type StarLayer, createStarLayer } from "./stars";
 export { type Tooltip, createTooltip } from "./tooltip";
 export { type BodyLayer, createBodyLayer } from "./bodies";

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -4,6 +4,7 @@ export { createPanel } from "./panel";
 export { createTimeControls } from "./time-controls";
 export { createLocationControls } from "./location-controls";
 export { createLayerControls } from "./layer-controls";
+export { createViewControls } from "./view-controls";
 
 import type { LayerVisibility, LayerOpacity } from "../state/state";
 
@@ -11,4 +12,5 @@ export type UIIntent =
   | { type: "set-time"; time: Date }
   | { type: "set-observer"; lat: number; lon: number }
   | { type: "toggle-layer"; layer: keyof LayerVisibility }
-  | { type: "set-opacity"; layer: keyof LayerOpacity; value: number };
+  | { type: "set-opacity"; layer: keyof LayerOpacity; value: number }
+  | { type: "set-view"; az: number; alt: number };

--- a/src/ui/view-controls.test.ts
+++ b/src/ui/view-controls.test.ts
@@ -1,0 +1,51 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { describe, expect, it, vi } from "vitest";
+import { createViewControls } from "./view-controls";
+
+describe("createViewControls", () => {
+  it("creates a section with preset buttons and inputs", () => {
+    const el = createViewControls(0, 89.9, vi.fn());
+    expect(el.querySelector('[data-testid="view-zenith"]')).toBeTruthy();
+    expect(el.querySelector('[data-testid="view-n"]')).toBeTruthy();
+    expect(el.querySelector('[data-testid="view-s"]')).toBeTruthy();
+    expect(el.querySelector('[data-testid="view-e"]')).toBeTruthy();
+    expect(el.querySelector('[data-testid="view-w"]')).toBeTruthy();
+    expect(el.querySelector('[data-testid="view-az"]')).toBeTruthy();
+    expect(el.querySelector('[data-testid="view-alt"]')).toBeTruthy();
+  });
+
+  it("zenith button dispatches set-view with alt 89.9", () => {
+    const onIntent = vi.fn();
+    const el = createViewControls(0, 89.9, onIntent);
+    const btn = el.querySelector('[data-testid="view-zenith"]') as HTMLButtonElement;
+    btn.click();
+    expect(onIntent).toHaveBeenCalledWith({ type: "set-view", az: 0, alt: 89.9 });
+  });
+
+  it("south button dispatches set-view with az 180", () => {
+    const onIntent = vi.fn();
+    const el = createViewControls(0, 89.9, onIntent);
+    const btn = el.querySelector('[data-testid="view-s"]') as HTMLButtonElement;
+    btn.click();
+    expect(onIntent).toHaveBeenCalledWith({ type: "set-view", az: 180, alt: 30 });
+  });
+
+  it("changing az input dispatches set-view", () => {
+    const onIntent = vi.fn();
+    const el = createViewControls(0, 89.9, onIntent);
+    const azInput = el.querySelector('[data-testid="view-az"]') as HTMLInputElement;
+    azInput.value = "270";
+    azInput.dispatchEvent(new Event("change"));
+    expect(onIntent).toHaveBeenCalledWith(expect.objectContaining({ type: "set-view", az: 270 }));
+  });
+
+  it("preset buttons update input values", () => {
+    const el = createViewControls(0, 89.9, vi.fn());
+    const btn = el.querySelector('[data-testid="view-s"]') as HTMLButtonElement;
+    btn.click();
+    const azInput = el.querySelector('[data-testid="view-az"]') as HTMLInputElement;
+    const altInput = el.querySelector('[data-testid="view-alt"]') as HTMLInputElement;
+    expect(azInput.value).toBe("180");
+    expect(altInput.value).toBe("30");
+  });
+});

--- a/src/ui/view-controls.ts
+++ b/src/ui/view-controls.ts
@@ -1,0 +1,96 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import type { UIIntent } from "./index";
+
+type ViewPreset = { label: string; az: number; alt: number };
+
+const PRESETS: ViewPreset[] = [
+  { label: "Zenith", az: 0, alt: 89.9 },
+  { label: "N", az: 0, alt: 30 },
+  { label: "E", az: 90, alt: 30 },
+  { label: "S", az: 180, alt: 30 },
+  { label: "W", az: 270, alt: 30 },
+];
+
+export function createViewControls(
+  initialAz: number,
+  initialAlt: number,
+  onIntent: (intent: UIIntent) => void,
+): HTMLElement {
+  const section = document.createElement("div");
+  section.style.cssText = "padding:8px 0;border-top:1px solid rgba(255,255,255,0.1)";
+
+  const heading = document.createElement("div");
+  heading.textContent = "View Direction";
+  heading.style.cssText = "color:#fff;font:bold 12px sans-serif;margin-bottom:6px";
+  section.appendChild(heading);
+
+  // Preset buttons
+  const btnRow = document.createElement("div");
+  btnRow.style.cssText = "display:flex;gap:4px;margin-bottom:8px;flex-wrap:wrap";
+  for (const preset of PRESETS) {
+    const btn = document.createElement("button");
+    btn.textContent = preset.label;
+    btn.dataset.testid = `view-${preset.label.toLowerCase()}`;
+    btn.style.cssText =
+      "background:rgba(255,255,255,0.1);color:#fff;border:1px solid rgba(255,255,255,0.2);" +
+      "border-radius:4px;padding:4px 8px;cursor:pointer;font:12px sans-serif";
+    btn.addEventListener("click", () => {
+      azInput.value = String(preset.az);
+      altInput.value = String(preset.alt);
+      onIntent({ type: "set-view", az: preset.az, alt: preset.alt });
+    });
+    btnRow.appendChild(btn);
+  }
+  section.appendChild(btnRow);
+
+  // Az/Alt inputs
+  const inputRow = document.createElement("div");
+  inputRow.style.cssText = "display:flex;gap:8px;align-items:center";
+
+  const azLabel = document.createElement("label");
+  azLabel.textContent = "Az";
+  azLabel.style.cssText = "color:rgba(255,255,255,0.6);font:12px sans-serif";
+  const azInput = document.createElement("input");
+  azInput.type = "number";
+  azInput.min = "0";
+  azInput.max = "360";
+  azInput.step = "1";
+  azInput.value = String(initialAz);
+  azInput.dataset.testid = "view-az";
+  azInput.style.cssText =
+    "width:60px;background:rgba(255,255,255,0.1);color:#fff;border:1px solid rgba(255,255,255,0.2);" +
+    "border-radius:4px;padding:4px;font:12px sans-serif";
+
+  const altLabel = document.createElement("label");
+  altLabel.textContent = "Alt";
+  altLabel.style.cssText = "color:rgba(255,255,255,0.6);font:12px sans-serif";
+  const altInput = document.createElement("input");
+  altInput.type = "number";
+  altInput.min = "0";
+  altInput.max = "90";
+  altInput.step = "1";
+  altInput.value = String(initialAlt);
+  altInput.dataset.testid = "view-alt";
+  altInput.style.cssText =
+    "width:60px;background:rgba(255,255,255,0.1);color:#fff;border:1px solid rgba(255,255,255,0.2);" +
+    "border-radius:4px;padding:4px;font:12px sans-serif";
+
+  function onInputChange(): void {
+    const az = Number(azInput.value);
+    const alt = Number(altInput.value);
+    if (Number.isFinite(az) && Number.isFinite(alt)) {
+      onIntent({ type: "set-view", az, alt });
+    }
+  }
+
+  azInput.addEventListener("change", onInputChange);
+  altInput.addEventListener("change", onInputChange);
+
+  inputRow.appendChild(azLabel);
+  inputRow.appendChild(azInput);
+  inputRow.appendChild(altLabel);
+  inputRow.appendChild(altInput);
+  section.appendChild(inputRow);
+
+  return section;
+}


### PR DESCRIPTION
Closes #126

## Summary
- Cardinal direction buttons: Zenith, N, E, S, W — snap camera to that view
- Alt/Az number inputs for precise positioning
- `setCameraView(camera, lat, lon, az, alt)` exported from scene/camera.ts
- New `set-view` UIIntent wired through app.ts handleIntent
- 5 new view-controls tests + 1 app integration test (212 total)