### PR TITLE
feat: RA/Dec grid, ecliptic line, opacity-only UI for line layers

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -9,6 +9,8 @@ import {
   filterVisibleConstellations,
   parseBoundaries,
   filterVisibleBoundaries,
+  computeRaDecGrid,
+  computeEclipticLine,
 } from "./astro";
 import {
   createViewer,
@@ -20,6 +22,8 @@ import {
   createCompassLayer,
   createSatelliteLayer,
   createBoundaryLayer,
+  createGridLayer,
+  createEclipticLayer,
   setCameraView,
 } from "./scene";
 import type {
@@ -29,6 +33,8 @@ import type {
   BoundaryLayer,
   SatelliteLayer,
   CompassLayer,
+  GridLayer,
+  EclipticLayer,
 } from "./scene";
 import { fetchTle, parseTle, propagateSatellites } from "./sat";
 import {
@@ -50,13 +56,13 @@ type Layers = {
   boundary: BoundaryLayer;
   satellite: SatelliteLayer | null;
   compass: CompassLayer;
+  grid: GridLayer;
+  ecliptic: EclipticLayer;
 };
 
 function applyLayerVisibility(layers: Layers, visibility: LayerVisibility): void {
   layers.star.setVisible(visibility.stars);
   layers.body.setVisible(visibility.planets);
-  layers.constellation.setVisible(visibility.constellationLines);
-  layers.boundary.setVisible(visibility.constellationBoundaries);
   layers.compass.setVisible(visibility.compass);
   if (layers.satellite) layers.satellite.setVisible(visibility.satellites);
 }
@@ -97,11 +103,19 @@ function rerender(
     console.warn(`Boundary load warning: ${boundaryResult.error.message}`);
   }
 
+  const gridData = computeRaDecGrid(observer.lat, observer.lon, timeUtc);
+  layers.grid.update(gridData, observer.lat, observer.lon);
+
+  const eclipticPoints = computeEclipticLine(observer.lat, observer.lon, timeUtc);
+  layers.ecliptic.update(eclipticPoints, observer.lat, observer.lon);
+
   layers.compass.update(observer.lat, observer.lon);
 
   applyLayerVisibility(layers, state.layers);
   layers.constellation.setOpacity(state.opacity.constellationLines * 0.25);
   layers.boundary.setOpacity(state.opacity.constellationBoundaries * 0.15);
+  layers.grid.setOpacity(state.opacity.raDecGrid);
+  layers.ecliptic.setOpacity(state.opacity.ecliptic);
   if (layers.satellite) layers.satellite.setOpacity(state.opacity.satelliteTrails * 0.3);
 }
 
@@ -149,6 +163,8 @@ export async function bootstrap(
     boundary: createBoundaryLayer(viewer.scene),
     satellite: null,
     compass: createCompassLayer(viewer.scene),
+    grid: createGridLayer(viewer.scene),
+    ecliptic: createEclipticLayer(viewer.scene),
   };
 
   // Initial render
@@ -210,6 +226,8 @@ export async function bootstrap(
         state = { ...state, opacity: newOpacity };
         layers.constellation.setOpacity(state.opacity.constellationLines * 0.25);
         layers.boundary.setOpacity(state.opacity.constellationBoundaries * 0.15);
+        layers.grid.setOpacity(state.opacity.raDecGrid);
+        layers.ecliptic.setOpacity(state.opacity.ecliptic);
         if (layers.satellite) layers.satellite.setOpacity(state.opacity.satelliteTrails * 0.3);
         updateUrl(state);
         break;

--- a/src/astro/ecliptic.test.ts
+++ b/src/astro/ecliptic.test.ts
@@ -1,0 +1,73 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { describe, expect, it } from "vitest";
+import { computeEclipticLine } from "./ecliptic";
+
+const LAT = 37.77; // San Francisco
+const LON = -122.42;
+const TIME = new Date("2026-04-15T03:00:00Z");
+
+describe("computeEclipticLine", () => {
+  it("returns an array of HorizontalCoord points", () => {
+    const points = computeEclipticLine(LAT, LON, TIME);
+    expect(Array.isArray(points)).toBe(true);
+  });
+
+  it("returns at most 180 points (one per 2° of ecliptic longitude)", () => {
+    const points = computeEclipticLine(LAT, LON, TIME);
+    expect(points.length).toBeLessThanOrEqual(180);
+  });
+
+  it("returns at least some points above the horizon for mid-latitude observer", () => {
+    const points = computeEclipticLine(LAT, LON, TIME);
+    expect(points.length).toBeGreaterThan(0);
+  });
+
+  it("all returned points are above the horizon (alt >= 0)", () => {
+    const points = computeEclipticLine(LAT, LON, TIME);
+    for (const pt of points) {
+      expect(pt.alt).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it("all points have valid alt range [0, 90]", () => {
+    const points = computeEclipticLine(LAT, LON, TIME);
+    for (const pt of points) {
+      expect(pt.alt).toBeGreaterThanOrEqual(0);
+      expect(pt.alt).toBeLessThanOrEqual(90);
+    }
+  });
+
+  it("all points have valid az range [0, 360)", () => {
+    const points = computeEclipticLine(LAT, LON, TIME);
+    for (const pt of points) {
+      expect(pt.az).toBeGreaterThanOrEqual(0);
+      expect(pt.az).toBeLessThan(360);
+    }
+  });
+
+  it("all points have finite numeric alt and az", () => {
+    const points = computeEclipticLine(LAT, LON, TIME);
+    for (const pt of points) {
+      expect(typeof pt.alt).toBe("number");
+      expect(typeof pt.az).toBe("number");
+      expect(Number.isFinite(pt.alt)).toBe(true);
+      expect(Number.isFinite(pt.az)).toBe(true);
+    }
+  });
+
+  it("ecliptic points span a reasonable azimuth range for a mid-latitude observer", () => {
+    const points = computeEclipticLine(LAT, LON, TIME);
+    if (points.length === 0) return; // edge case: no points visible
+    const azValues = points.map((p) => p.az);
+    const minAz = Math.min(...azValues);
+    const maxAz = Math.max(...azValues);
+    // Ecliptic should span at least 90° in az at a mid-latitude observer
+    expect(maxAz - minAz).toBeGreaterThan(90);
+  });
+
+  it("works for equatorial observer", () => {
+    const points = computeEclipticLine(0, 0, TIME);
+    expect(Array.isArray(points)).toBe(true);
+    expect(points.length).toBeGreaterThan(0);
+  });
+});

--- a/src/astro/ecliptic.ts
+++ b/src/astro/ecliptic.ts
@@ -1,0 +1,36 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import type { HorizontalCoord } from "./coords";
+import { raDecToAltAz } from "./coords";
+
+// Mean obliquity of the ecliptic (J2000.0, degrees)
+const OBLIQUITY_DEG = 23.4393;
+
+/**
+ * Compute a series of alt/az points tracing the ecliptic line.
+ * Samples ecliptic longitude at 2° intervals (0° to 358°, 180 points).
+ * Converts ecliptic (lon, lat=0) → equatorial (RA, Dec) → horizontal (alt, az).
+ * Only points above the horizon (alt >= 0) are included.
+ */
+export function computeEclipticLine(lat: number, lon: number, time: Date): HorizontalCoord[] {
+  const points: HorizontalCoord[] = [];
+  const epsilonRad = (OBLIQUITY_DEG * Math.PI) / 180;
+
+  for (let lambdaDeg = 0; lambdaDeg < 360; lambdaDeg += 2) {
+    const lambdaRad = (lambdaDeg * Math.PI) / 180;
+
+    // Ecliptic to equatorial conversion (ecliptic lat = 0)
+    const raDeg =
+      (Math.atan2(Math.sin(lambdaRad) * Math.cos(epsilonRad), Math.cos(lambdaRad)) * 180) / Math.PI;
+    const decDeg = (Math.asin(Math.sin(lambdaRad) * Math.sin(epsilonRad)) * 180) / Math.PI;
+
+    // atan2 returns [-180, 180]; normalize to [0, 360]
+    const raDegNorm = raDeg < 0 ? raDeg + 360 : raDeg;
+
+    const coord = raDecToAltAz(raDegNorm, decDeg, lat, lon, time);
+    if (coord.alt >= 0) {
+      points.push(coord);
+    }
+  }
+
+  return points;
+}

--- a/src/astro/grid.test.ts
+++ b/src/astro/grid.test.ts
@@ -1,0 +1,90 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { describe, expect, it } from "vitest";
+import { computeRaDecGrid } from "./grid";
+
+const LAT = 37.77; // San Francisco
+const LON = -122.42;
+const TIME = new Date("2026-04-15T03:00:00Z"); // Midnight local-ish, many objects above horizon
+
+describe("computeRaDecGrid", () => {
+  it("returns raLines and decLines arrays", () => {
+    const result = computeRaDecGrid(LAT, LON, TIME);
+    expect(Array.isArray(result.raLines)).toBe(true);
+    expect(Array.isArray(result.decLines)).toBe(true);
+  });
+
+  it("raLines has at most 24 lines (one per RA hour)", () => {
+    const result = computeRaDecGrid(LAT, LON, TIME);
+    expect(result.raLines.length).toBeGreaterThan(0);
+    expect(result.raLines.length).toBeLessThanOrEqual(24);
+  });
+
+  it("decLines has at most 17 lines (one per 10° Dec from -80 to +80)", () => {
+    const result = computeRaDecGrid(LAT, LON, TIME);
+    expect(result.decLines.length).toBeGreaterThan(0);
+    expect(result.decLines.length).toBeLessThanOrEqual(17);
+  });
+
+  it("each RA line has at least 2 points", () => {
+    const result = computeRaDecGrid(LAT, LON, TIME);
+    for (const line of result.raLines) {
+      expect(line.length).toBeGreaterThanOrEqual(2);
+    }
+  });
+
+  it("each Dec line has at least 2 points", () => {
+    const result = computeRaDecGrid(LAT, LON, TIME);
+    for (const line of result.decLines) {
+      expect(line.length).toBeGreaterThanOrEqual(2);
+    }
+  });
+
+  it("all points in raLines are above the horizon (alt >= 0)", () => {
+    const result = computeRaDecGrid(LAT, LON, TIME);
+    for (const line of result.raLines) {
+      for (const pt of line) {
+        expect(pt.alt).toBeGreaterThanOrEqual(0);
+      }
+    }
+  });
+
+  it("all points in decLines are above the horizon (alt >= 0)", () => {
+    const result = computeRaDecGrid(LAT, LON, TIME);
+    for (const line of result.decLines) {
+      for (const pt of line) {
+        expect(pt.alt).toBeGreaterThanOrEqual(0);
+      }
+    }
+  });
+
+  it("points have valid alt/az ranges", () => {
+    const result = computeRaDecGrid(LAT, LON, TIME);
+    const allPoints = [...result.raLines.flat(), ...result.decLines.flat()];
+    for (const pt of allPoints) {
+      expect(pt.alt).toBeGreaterThanOrEqual(0);
+      expect(pt.alt).toBeLessThanOrEqual(90);
+      expect(pt.az).toBeGreaterThanOrEqual(0);
+      expect(pt.az).toBeLessThan(360);
+    }
+  });
+
+  it("returns empty arrays at a polar location where all stars are at horizon", () => {
+    // At south pole, northern hemisphere stars never rise
+    // Just verify it returns valid structure regardless
+    const result = computeRaDecGrid(0, 0, TIME);
+    expect(result).toHaveProperty("raLines");
+    expect(result).toHaveProperty("decLines");
+  });
+
+  it("all raLines have correct alt/az structure", () => {
+    const result = computeRaDecGrid(LAT, LON, TIME);
+    for (const line of result.raLines) {
+      for (const pt of line) {
+        expect(typeof pt.alt).toBe("number");
+        expect(typeof pt.az).toBe("number");
+        expect(Number.isFinite(pt.alt)).toBe(true);
+        expect(Number.isFinite(pt.az)).toBe(true);
+      }
+    }
+  });
+});

--- a/src/astro/grid.ts
+++ b/src/astro/grid.ts
@@ -1,0 +1,51 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import type { HorizontalCoord } from "./coords";
+import { raDecToAltAz } from "./coords";
+
+export type GridData = {
+  readonly raLines: HorizontalCoord[][];
+  readonly decLines: HorizontalCoord[][];
+};
+
+/**
+ * Compute RA/Dec equatorial grid lines in alt/az coordinates.
+ * RA lines: 24 great circles at RA = 0, 15, 30, ..., 345°.
+ * Dec lines: 17 small circles at Dec = -80, -70, ..., +80°.
+ * Only points above the horizon (alt >= 0) are included.
+ */
+export function computeRaDecGrid(lat: number, lon: number, time: Date): GridData {
+  const raLines: HorizontalCoord[][] = [];
+  const decLines: HorizontalCoord[][] = [];
+
+  // RA lines: one per hour (every 15°), sampled at Dec = -80 to +80 in 10° steps
+  for (let raHour = 0; raHour < 24; raHour++) {
+    const raDeg = raHour * 15;
+    const line: HorizontalCoord[] = [];
+    for (let dec = -80; dec <= 80; dec += 10) {
+      const coord = raDecToAltAz(raDeg, dec, lat, lon, time);
+      if (coord.alt >= 0) {
+        line.push(coord);
+      }
+    }
+    if (line.length >= 2) {
+      raLines.push(line);
+    }
+  }
+
+  // Dec lines: every 10°, sampled at RA = 0 to 345 in 15° steps
+  for (let dec = -80; dec <= 80; dec += 10) {
+    const line: HorizontalCoord[] = [];
+    for (let raHour = 0; raHour < 24; raHour++) {
+      const raDeg = raHour * 15;
+      const coord = raDecToAltAz(raDeg, dec, lat, lon, time);
+      if (coord.alt >= 0) {
+        line.push(coord);
+      }
+    }
+    if (line.length >= 2) {
+      decLines.push(line);
+    }
+  }
+
+  return { raLines, decLines };
+}

--- a/src/astro/index.ts
+++ b/src/astro/index.ts
@@ -21,3 +21,5 @@ export {
   parseBoundaries,
   filterVisibleBoundaries,
 } from "./boundaries";
+export { type GridData, computeRaDecGrid } from "./grid";
+export { computeEclipticLine } from "./ecliptic";

--- a/src/scene/ecliptic.test.ts
+++ b/src/scene/ecliptic.test.ts
@@ -1,0 +1,138 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createEclipticLayer } from "./ecliptic";
+import type { HorizontalCoord } from "../astro/coords";
+
+const mockPolylineAdd = vi.fn();
+const mockPolylineRemoveAll = vi.fn();
+const mockPolylines: Array<{ material: { uniforms: { color: { alpha: number } } } }> = [];
+
+vi.mock("cesium", () => {
+  const MockCartesian3 = vi.fn().mockImplementation((x: number, y: number, z: number) => ({
+    x,
+    y,
+    z,
+  }));
+  (MockCartesian3 as unknown as { fromDegrees: ReturnType<typeof vi.fn> }).fromDegrees = vi
+    .fn()
+    .mockReturnValue({ x: 1, y: 2, z: 3 });
+
+  const mockMaterial = { uniforms: { color: { alpha: 1 } } };
+
+  return {
+    PolylineCollection: vi.fn().mockImplementation(() => ({
+      add: (opts: Record<string, unknown>) => {
+        mockPolylineAdd(opts);
+        const polyline = { material: mockMaterial, ...opts };
+        mockPolylines.push(polyline as never);
+        return polyline;
+      },
+      removeAll: () => {
+        mockPolylineRemoveAll();
+        mockPolylines.length = 0;
+      },
+      show: true,
+    })),
+    Cartesian3: MockCartesian3,
+    Color: {
+      WHITE: { withAlpha: (a: number) => ({ r: 1, g: 1, b: 1, alpha: a }) },
+      fromCssColorString: vi.fn().mockReturnValue({
+        withAlpha: (a: number) => ({ alpha: a }),
+      }),
+    },
+    Math: { toRadians: (d: number) => (d * Math.PI) / 180 },
+    Transforms: {
+      eastNorthUpToFixedFrame: vi
+        .fn()
+        .mockReturnValue([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]),
+    },
+    Matrix4: {
+      multiplyByPoint: vi.fn().mockReturnValue({ x: 10, y: 20, z: 30 }),
+    },
+    Material: {
+      fromType: vi.fn().mockReturnValue(mockMaterial),
+    },
+  };
+});
+
+function makeMockScene() {
+  return { primitives: { add: vi.fn() } };
+}
+
+const SAMPLE_POINTS: HorizontalCoord[] = [
+  { alt: 45, az: 180 },
+  { alt: 40, az: 170 },
+  { alt: 35, az: 160 },
+  { alt: 30, az: 150 },
+];
+
+beforeEach(() => {
+  mockPolylineAdd.mockClear();
+  mockPolylineRemoveAll.mockClear();
+  mockPolylines.length = 0;
+});
+
+describe("createEclipticLayer", () => {
+  it("returns an object with update and setOpacity methods", () => {
+    const layer = createEclipticLayer(makeMockScene() as never);
+    expect(layer).toHaveProperty("update");
+    expect(layer).toHaveProperty("setOpacity");
+  });
+
+  it("registers PolylineCollection with scene.primitives", () => {
+    const scene = makeMockScene();
+    createEclipticLayer(scene as never);
+    expect(scene.primitives.add).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("EclipticLayer.update", () => {
+  it("adds a single polyline for the ecliptic points", () => {
+    const layer = createEclipticLayer(makeMockScene() as never);
+    layer.update(SAMPLE_POINTS, 33, -117);
+    expect(mockPolylineRemoveAll).toHaveBeenCalledOnce();
+    expect(mockPolylineAdd).toHaveBeenCalledTimes(1);
+  });
+
+  it("works with empty points array", () => {
+    const layer = createEclipticLayer(makeMockScene() as never);
+    layer.update([], 0, 0);
+    expect(mockPolylineRemoveAll).toHaveBeenCalledOnce();
+    expect(mockPolylineAdd).not.toHaveBeenCalled();
+  });
+
+  it("does not add a polyline for a single point", () => {
+    const layer = createEclipticLayer(makeMockScene() as never);
+    layer.update([{ alt: 45, az: 180 }], 33, -117);
+    expect(mockPolylineAdd).not.toHaveBeenCalled();
+  });
+
+  it("clears previous polylines before adding new ones", () => {
+    const layer = createEclipticLayer(makeMockScene() as never);
+    layer.update(SAMPLE_POINTS, 33, -117);
+    mockPolylineAdd.mockClear();
+    mockPolylineRemoveAll.mockClear();
+    layer.update(SAMPLE_POINTS.slice(0, 3), 33, -117);
+    expect(mockPolylineRemoveAll).toHaveBeenCalledOnce();
+    expect(mockPolylineAdd).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("EclipticLayer.setOpacity", () => {
+  it("does not throw when setOpacity is called", () => {
+    const layer = createEclipticLayer(makeMockScene() as never);
+    layer.update(SAMPLE_POINTS, 33, -117);
+    expect(() => layer.setOpacity(0.5)).not.toThrow();
+  });
+
+  it("hides polylines when opacity is 0", () => {
+    const layer = createEclipticLayer(makeMockScene() as never);
+    layer.update(SAMPLE_POINTS, 33, -117);
+    expect(() => layer.setOpacity(0)).not.toThrow();
+  });
+
+  it("does not throw when called before update", () => {
+    const layer = createEclipticLayer(makeMockScene() as never);
+    expect(() => layer.setOpacity(0.4)).not.toThrow();
+  });
+});

--- a/src/scene/ecliptic.ts
+++ b/src/scene/ecliptic.ts
@@ -1,0 +1,51 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { PolylineCollection, Color, Material } from "cesium";
+import type { Scene } from "cesium";
+import type { HorizontalCoord } from "../astro/coords";
+import { altAzToCartesian } from "./stars";
+
+export type EclipticLayer = {
+  update: (points: HorizontalCoord[], lat: number, lon: number) => void;
+  setOpacity: (opacity: number) => void;
+};
+
+// Ecliptic color: warm yellow
+const ECLIPTIC_COLOR = Color.fromCssColorString("#FFD700");
+
+export function createEclipticLayer(scene: Scene): EclipticLayer {
+  const polylines = new PolylineCollection();
+  scene.primitives.add(polylines);
+
+  const addedPolylines: Array<{ material: { uniforms: { color: { alpha: number } } } }> = [];
+  let currentOpacity = 0.4;
+
+  function update(points: HorizontalCoord[], lat: number, lon: number): void {
+    polylines.removeAll();
+    addedPolylines.length = 0;
+
+    if (points.length < 2) return;
+
+    const positions = points.map((pt) => altAzToCartesian(pt.alt, pt.az, lat, lon));
+    const pl = polylines.add({
+      positions,
+      width: 2,
+      material: Material.fromType("Color", {
+        color: ECLIPTIC_COLOR.withAlpha(currentOpacity),
+      }),
+    });
+    addedPolylines.push(pl as never);
+  }
+
+  function setOpacity(opacity: number): void {
+    currentOpacity = opacity;
+    const show = opacity > 0;
+    (polylines as unknown as { show: boolean }).show = show;
+    for (const pl of addedPolylines) {
+      if (pl?.material?.uniforms?.color !== undefined) {
+        pl.material.uniforms.color.alpha = opacity;
+      }
+    }
+  }
+
+  return { update, setOpacity };
+}

--- a/src/scene/grid.test.ts
+++ b/src/scene/grid.test.ts
@@ -1,0 +1,165 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createGridLayer } from "./grid";
+import type { GridData } from "../astro/grid";
+
+const mockPolylineAdd = vi.fn();
+const mockPolylineRemoveAll = vi.fn();
+const mockPolylines: Array<{ material: { uniforms: { color: { alpha: number } } } }> = [];
+
+vi.mock("cesium", () => {
+  const MockCartesian3 = vi.fn().mockImplementation((x: number, y: number, z: number) => ({
+    x,
+    y,
+    z,
+  }));
+  (MockCartesian3 as unknown as { fromDegrees: ReturnType<typeof vi.fn> }).fromDegrees = vi
+    .fn()
+    .mockReturnValue({ x: 1, y: 2, z: 3 });
+
+  const mockMaterial = { uniforms: { color: { alpha: 1 } } };
+
+  return {
+    PolylineCollection: vi.fn().mockImplementation(() => ({
+      add: (opts: Record<string, unknown>) => {
+        mockPolylineAdd(opts);
+        const polyline = { material: mockMaterial, ...opts };
+        mockPolylines.push(polyline as never);
+        return polyline;
+      },
+      removeAll: () => {
+        mockPolylineRemoveAll();
+        mockPolylines.length = 0;
+      },
+      show: true,
+    })),
+    Cartesian3: MockCartesian3,
+    Color: {
+      WHITE: { withAlpha: (a: number) => ({ r: 1, g: 1, b: 1, alpha: a }) },
+      fromCssColorString: vi.fn().mockReturnValue({
+        withAlpha: (a: number) => ({ alpha: a }),
+      }),
+    },
+    Math: { toRadians: (d: number) => (d * Math.PI) / 180 },
+    Transforms: {
+      eastNorthUpToFixedFrame: vi
+        .fn()
+        .mockReturnValue([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]),
+    },
+    Matrix4: {
+      multiplyByPoint: vi.fn().mockReturnValue({ x: 10, y: 20, z: 30 }),
+    },
+    Material: {
+      fromType: vi.fn().mockReturnValue(mockMaterial),
+    },
+  };
+});
+
+function makeMockScene() {
+  return { primitives: { add: vi.fn() } };
+}
+
+const SAMPLE_GRID: GridData = {
+  raLines: [
+    [
+      { alt: 45, az: 180 },
+      { alt: 30, az: 170 },
+      { alt: 20, az: 165 },
+    ],
+    [
+      { alt: 60, az: 200 },
+      { alt: 50, az: 190 },
+    ],
+  ],
+  decLines: [
+    [
+      { alt: 40, az: 90 },
+      { alt: 35, az: 100 },
+      { alt: 30, az: 110 },
+    ],
+  ],
+};
+
+beforeEach(() => {
+  mockPolylineAdd.mockClear();
+  mockPolylineRemoveAll.mockClear();
+  mockPolylines.length = 0;
+});
+
+describe("createGridLayer", () => {
+  it("returns an object with update and setOpacity methods", () => {
+    const layer = createGridLayer(makeMockScene() as never);
+    expect(layer).toHaveProperty("update");
+    expect(layer).toHaveProperty("setOpacity");
+  });
+
+  it("registers PolylineCollection with scene.primitives", () => {
+    const scene = makeMockScene();
+    createGridLayer(scene as never);
+    expect(scene.primitives.add).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("GridLayer.update", () => {
+  it("adds a polyline for each RA and Dec line", () => {
+    const layer = createGridLayer(makeMockScene() as never);
+    layer.update(SAMPLE_GRID, 33, -117);
+    expect(mockPolylineRemoveAll).toHaveBeenCalledOnce();
+    // 2 RA lines + 1 Dec line = 3 polylines
+    expect(mockPolylineAdd).toHaveBeenCalledTimes(3);
+  });
+
+  it("works with empty grid data", () => {
+    const layer = createGridLayer(makeMockScene() as never);
+    layer.update({ raLines: [], decLines: [] }, 0, 0);
+    expect(mockPolylineRemoveAll).toHaveBeenCalledOnce();
+    expect(mockPolylineAdd).not.toHaveBeenCalled();
+  });
+
+  it("clears previous polylines before adding new ones", () => {
+    const layer = createGridLayer(makeMockScene() as never);
+    layer.update(SAMPLE_GRID, 33, -117);
+    mockPolylineAdd.mockClear();
+    mockPolylineRemoveAll.mockClear();
+    layer.update({ raLines: [SAMPLE_GRID.raLines[0]!], decLines: [] }, 33, -117);
+    expect(mockPolylineRemoveAll).toHaveBeenCalledOnce();
+    expect(mockPolylineAdd).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips lines with fewer than 2 points", () => {
+    const gridWithShortLine: GridData = {
+      raLines: [[{ alt: 45, az: 180 }]], // only 1 point — should be skipped
+      decLines: [
+        [
+          { alt: 30, az: 90 },
+          { alt: 25, az: 100 },
+        ],
+      ],
+    };
+    const layer = createGridLayer(makeMockScene() as never);
+    layer.update(gridWithShortLine, 33, -117);
+    // Only the decLine with 2 points should be added
+    expect(mockPolylineAdd).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("GridLayer.setOpacity", () => {
+  it("does not throw when setOpacity is called", () => {
+    const layer = createGridLayer(makeMockScene() as never);
+    layer.update(SAMPLE_GRID, 33, -117);
+    expect(() => layer.setOpacity(0.5)).not.toThrow();
+  });
+
+  it("hides polylines when opacity is 0", () => {
+    const layer = createGridLayer(makeMockScene() as never);
+    layer.update(SAMPLE_GRID, 33, -117);
+    expect(() => layer.setOpacity(0)).not.toThrow();
+  });
+
+  it("shows polylines when opacity is restored above 0", () => {
+    const layer = createGridLayer(makeMockScene() as never);
+    layer.update(SAMPLE_GRID, 33, -117);
+    layer.setOpacity(0);
+    expect(() => layer.setOpacity(0.3)).not.toThrow();
+  });
+});

--- a/src/scene/grid.ts
+++ b/src/scene/grid.ts
@@ -1,0 +1,52 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { PolylineCollection, Color, Material } from "cesium";
+import type { Scene } from "cesium";
+import type { GridData } from "../astro/grid";
+import { altAzToCartesian } from "./stars";
+
+export type GridLayer = {
+  update: (gridData: GridData, lat: number, lon: number) => void;
+  setOpacity: (opacity: number) => void;
+};
+
+export function createGridLayer(scene: Scene): GridLayer {
+  const polylines = new PolylineCollection();
+  scene.primitives.add(polylines);
+
+  const addedPolylines: Array<{ material: { uniforms: { color: { alpha: number } } } }> = [];
+  let currentOpacity = 0.2;
+
+  function update(gridData: GridData, lat: number, lon: number): void {
+    polylines.removeAll();
+    addedPolylines.length = 0;
+
+    const allLines = [...gridData.raLines, ...gridData.decLines];
+
+    for (const line of allLines) {
+      if (line.length < 2) continue;
+
+      const positions = line.map((pt) => altAzToCartesian(pt.alt, pt.az, lat, lon));
+      const pl = polylines.add({
+        positions,
+        width: 1,
+        material: Material.fromType("Color", {
+          color: Color.WHITE.withAlpha(currentOpacity),
+        }),
+      });
+      addedPolylines.push(pl as never);
+    }
+  }
+
+  function setOpacity(opacity: number): void {
+    currentOpacity = opacity;
+    const show = opacity > 0;
+    (polylines as unknown as { show: boolean }).show = show;
+    for (const pl of addedPolylines) {
+      if (pl?.material?.uniforms?.color !== undefined) {
+        pl.material.uniforms.color.alpha = opacity;
+      }
+    }
+  }
+
+  return { update, setOpacity };
+}

--- a/src/scene/index.ts
+++ b/src/scene/index.ts
@@ -8,3 +8,5 @@ export { type ConstellationLayer, createConstellationLayer } from "./constellati
 export { type CompassLayer, createCompassLayer } from "./compass";
 export { type SatelliteLayer, createSatelliteLayer } from "./satellites";
 export { type BoundaryLayer, createBoundaryLayer } from "./boundaries";
+export { type GridLayer, createGridLayer } from "./grid";
+export { type EclipticLayer, createEclipticLayer } from "./ecliptic";

--- a/src/state/state.test.ts
+++ b/src/state/state.test.ts
@@ -75,13 +75,11 @@ describe("AppState — serialize", () => {
 });
 
 describe("LayerVisibility — defaults", () => {
-  it("all layers visible by default", () => {
+  it("toggle layers visible by default (stars, planets, satellites, compass)", () => {
     const s = expectOk(parseStateFromSearchParams(new URLSearchParams()));
     expect(s.layers.stars).toBe(true);
     expect(s.layers.planets).toBe(true);
     expect(s.layers.satellites).toBe(true);
-    expect(s.layers.constellationLines).toBe(true);
-    expect(s.layers.constellationBoundaries).toBe(true);
     expect(s.layers.compass).toBe(true);
   });
 });
@@ -94,8 +92,6 @@ describe("LayerVisibility — parse from URL", () => {
     expect(s.layers.planets).toBe(true);
     expect(s.layers.compass).toBe(true);
     expect(s.layers.satellites).toBe(false);
-    expect(s.layers.constellationLines).toBe(false);
-    expect(s.layers.constellationBoundaries).toBe(false);
   });
 
   it("treats 'layers' param absence as all visible", () => {
@@ -107,11 +103,17 @@ describe("LayerVisibility — parse from URL", () => {
 });
 
 describe("LayerOpacity — defaults", () => {
-  it("all opacities default to 1.0", () => {
+  it("constellation/satellite opacities default to 1.0", () => {
     const s = expectOk(parseStateFromSearchParams(new URLSearchParams()));
     expect(s.opacity.constellationLines).toBe(1.0);
     expect(s.opacity.constellationBoundaries).toBe(1.0);
     expect(s.opacity.satelliteTrails).toBe(1.0);
+  });
+
+  it("raDecGrid defaults to 0.2 and ecliptic to 0.4", () => {
+    const s = expectOk(parseStateFromSearchParams(new URLSearchParams()));
+    expect(s.opacity.raDecGrid).toBeCloseTo(0.2);
+    expect(s.opacity.ecliptic).toBeCloseTo(0.4);
   });
 });
 
@@ -122,6 +124,13 @@ describe("LayerOpacity — parse from URL", () => {
     expect(s.opacity.constellationLines).toBeCloseTo(0.5);
     expect(s.opacity.constellationBoundaries).toBeCloseTo(0.25);
     expect(s.opacity.satelliteTrails).toBeCloseTo(0.75);
+  });
+
+  it("parses opacity params op_grid and op_ecl as 0–1 fractions", () => {
+    const params = new URLSearchParams({ op_grid: "30", op_ecl: "60" });
+    const s = expectOk(parseStateFromSearchParams(params));
+    expect(s.opacity.raDecGrid).toBeCloseTo(0.3);
+    expect(s.opacity.ecliptic).toBeCloseTo(0.6);
   });
 
   it("clamps opacity to [0, 1]", () => {
@@ -142,6 +151,8 @@ describe("AppState — serialize round-trip with layer fields", () => {
       op_cl: "60",
       op_cb: "30",
       op_st: "80",
+      op_grid: "50",
+      op_ecl: "70",
     });
     const s = expectOk(parseStateFromSearchParams(params));
     const out = serializeStateToSearchParams(s);
@@ -152,5 +163,15 @@ describe("AppState — serialize round-trip with layer fields", () => {
     expect(s2.opacity.constellationLines).toBeCloseTo(0.6);
     expect(s2.opacity.constellationBoundaries).toBeCloseTo(0.3);
     expect(s2.opacity.satelliteTrails).toBeCloseTo(0.8);
+    expect(s2.opacity.raDecGrid).toBeCloseTo(0.5);
+    expect(s2.opacity.ecliptic).toBeCloseTo(0.7);
+  });
+
+  it("does not write op_grid and op_ecl when at defaults", () => {
+    const params = new URLSearchParams({ lat: "33", lon: "-117", t: "2026-06-01T00:00:00Z" });
+    const s = expectOk(parseStateFromSearchParams(params));
+    const out = serializeStateToSearchParams(s);
+    expect(out.has("op_grid")).toBe(false);
+    expect(out.has("op_ecl")).toBe(false);
   });
 });

--- a/src/state/state.ts
+++ b/src/state/state.ts
@@ -7,8 +7,6 @@ export type LayerVisibility = {
   readonly stars: boolean;
   readonly planets: boolean;
   readonly satellites: boolean;
-  readonly constellationLines: boolean;
-  readonly constellationBoundaries: boolean;
   readonly compass: boolean;
 };
 
@@ -16,6 +14,8 @@ export type LayerOpacity = {
   readonly constellationLines: number; // 0–1
   readonly constellationBoundaries: number; // 0–1
   readonly satelliteTrails: number; // 0–1
+  readonly raDecGrid: number; // 0–1
+  readonly ecliptic: number; // 0–1
 };
 
 export type AppState = {
@@ -36,8 +36,6 @@ const ALL_LAYER_KEYS: readonly (keyof LayerVisibility)[] = [
   "stars",
   "planets",
   "satellites",
-  "constellationLines",
-  "constellationBoundaries",
   "compass",
 ];
 
@@ -45,8 +43,6 @@ export const DEFAULT_LAYERS: LayerVisibility = {
   stars: true,
   planets: true,
   satellites: true,
-  constellationLines: true,
-  constellationBoundaries: true,
   compass: true,
 };
 
@@ -54,6 +50,8 @@ export const DEFAULT_OPACITY: LayerOpacity = {
   constellationLines: 1.0,
   constellationBoundaries: 1.0,
   satelliteTrails: 1.0,
+  raDecGrid: 0.2,
+  ecliptic: 0.4,
 };
 
 export const DEFAULT_STATE: AppState = {
@@ -90,8 +88,6 @@ function parseLayerVisibility(raw: string | null): LayerVisibility {
     stars: keys.has("stars"),
     planets: keys.has("planets"),
     satellites: keys.has("satellites"),
-    constellationLines: keys.has("constellationLines"),
-    constellationBoundaries: keys.has("constellationBoundaries"),
     compass: keys.has("compass"),
   };
 }
@@ -140,6 +136,8 @@ export function parseStateFromSearchParams(
       DEFAULT_OPACITY.constellationBoundaries,
     ),
     satelliteTrails: parseOpacity(params.get("op_st"), DEFAULT_OPACITY.satelliteTrails),
+    raDecGrid: parseOpacity(params.get("op_grid"), DEFAULT_OPACITY.raDecGrid),
+    ecliptic: parseOpacity(params.get("op_ecl"), DEFAULT_OPACITY.ecliptic),
   };
 
   return ok({ observer: { lat, lon }, timeUtc, layers, opacity });
@@ -165,6 +163,12 @@ export function serializeStateToSearchParams(state: AppState): URLSearchParams {
   }
   if (state.opacity.satelliteTrails !== 1.0) {
     params.set("op_st", String(Math.round(state.opacity.satelliteTrails * 100)));
+  }
+  if (state.opacity.raDecGrid !== DEFAULT_OPACITY.raDecGrid) {
+    params.set("op_grid", String(Math.round(state.opacity.raDecGrid * 100)));
+  }
+  if (state.opacity.ecliptic !== DEFAULT_OPACITY.ecliptic) {
+    params.set("op_ecl", String(Math.round(state.opacity.ecliptic * 100)));
   }
 
   return params;

--- a/src/ui/layer-controls.test.ts
+++ b/src/ui/layer-controls.test.ts
@@ -8,8 +8,6 @@ const DEFAULT_VISIBILITY: LayerVisibility = {
   stars: true,
   planets: true,
   satellites: true,
-  constellationLines: true,
-  constellationBoundaries: true,
   compass: true,
 };
 
@@ -17,6 +15,8 @@ const DEFAULT_OPACITY: LayerOpacity = {
   constellationLines: 1.0,
   constellationBoundaries: 1.0,
   satelliteTrails: 1.0,
+  raDecGrid: 0.2,
+  ecliptic: 0.4,
 };
 
 describe("createLayerControls", () => {
@@ -32,12 +32,12 @@ describe("createLayerControls", () => {
     expect(el).toBeInstanceOf(HTMLElement);
   });
 
-  it("renders a toggle for each layer", () => {
+  it("renders a toggle checkbox for each toggle layer (stars, planets, satellites, compass)", () => {
     const toggles = el.querySelectorAll("input[type='checkbox']");
-    expect(toggles.length).toBe(6);
+    expect(toggles.length).toBe(4);
   });
 
-  it("toggles reflect initial visibility state", () => {
+  it("toggle checkboxes reflect initial visibility state (all true)", () => {
     const checkboxes = [...el.querySelectorAll<HTMLInputElement>("input[type='checkbox']")];
     expect(checkboxes.every((cb) => cb.checked)).toBe(true);
   });
@@ -54,14 +54,36 @@ describe("createLayerControls", () => {
     }
   });
 
-  it("renders opacity sliders for dimmable layers", () => {
+  it("renders opacity sliders for all 5 line layers", () => {
     const sliders = el.querySelectorAll("input[type='range']");
-    expect(sliders.length).toBe(3);
+    expect(sliders.length).toBe(5);
   });
 
-  it("opacity sliders reflect initial opacity (100%)", () => {
-    const sliders = [...el.querySelectorAll<HTMLInputElement>("input[type='range']")];
-    expect(sliders.every((s) => Number(s.value) === 100)).toBe(true);
+  it("has opacity slider for constellationLines", () => {
+    const slider = el.querySelector<HTMLInputElement>("input[data-opacity='constellationLines']");
+    expect(slider).not.toBeNull();
+  });
+
+  it("has opacity slider for constellationBoundaries", () => {
+    const slider = el.querySelector<HTMLInputElement>(
+      "input[data-opacity='constellationBoundaries']",
+    );
+    expect(slider).not.toBeNull();
+  });
+
+  it("has opacity slider for satelliteTrails", () => {
+    const slider = el.querySelector<HTMLInputElement>("input[data-opacity='satelliteTrails']");
+    expect(slider).not.toBeNull();
+  });
+
+  it("has opacity slider for raDecGrid", () => {
+    const slider = el.querySelector<HTMLInputElement>("input[data-opacity='raDecGrid']");
+    expect(slider).not.toBeNull();
+  });
+
+  it("has opacity slider for ecliptic", () => {
+    const slider = el.querySelector<HTMLInputElement>("input[data-opacity='ecliptic']");
+    expect(slider).not.toBeNull();
   });
 
   it("moving an opacity slider dispatches set-opacity intent", () => {
@@ -77,23 +99,42 @@ describe("createLayerControls", () => {
     }
   });
 
-  it("opacity slider is hidden when parent layer toggle is off", () => {
-    // Start with constellationLines off
-    const offVisibility: LayerVisibility = { ...DEFAULT_VISIBILITY, constellationLines: false };
-    const el2 = createLayerControls(offVisibility, DEFAULT_OPACITY, vi.fn());
-    const sliderRow = el2.querySelector<HTMLElement>("[data-opacity-row='constellationLines']")!;
-    expect(sliderRow.style.display).toBe("none");
+  it("raDecGrid slider dispatches set-opacity with raDecGrid key", () => {
+    const slider = el.querySelector<HTMLInputElement>("input[data-opacity='raDecGrid']")!;
+    slider.value = "30";
+    slider.dispatchEvent(new Event("input"));
+    const intent = dispatch.mock.calls[0]![0] as UIIntent;
+    expect(intent.type).toBe("set-opacity");
+    if (intent.type === "set-opacity") {
+      expect(intent.layer).toBe("raDecGrid");
+      expect(intent.value).toBeCloseTo(0.3);
+    }
   });
 
-  it("opacity slider becomes visible when parent layer is toggled on", () => {
-    const toggle = el.querySelector<HTMLInputElement>("input[data-layer='constellationLines']")!;
-    const sliderRow = el.querySelector<HTMLElement>("[data-opacity-row='constellationLines']")!;
-    // Currently visible; toggle off then on
-    toggle.checked = false;
-    toggle.dispatchEvent(new Event("change"));
-    expect(sliderRow.style.display).toBe("none");
-    toggle.checked = true;
-    toggle.dispatchEvent(new Event("change"));
-    expect(sliderRow.style.display).not.toBe("none");
+  it("ecliptic slider dispatches set-opacity with ecliptic key", () => {
+    const slider = el.querySelector<HTMLInputElement>("input[data-opacity='ecliptic']")!;
+    slider.value = "60";
+    slider.dispatchEvent(new Event("input"));
+    const intent = dispatch.mock.calls[0]![0] as UIIntent;
+    expect(intent.type).toBe("set-opacity");
+    if (intent.type === "set-opacity") {
+      expect(intent.layer).toBe("ecliptic");
+      expect(intent.value).toBeCloseTo(0.6);
+    }
+  });
+
+  it("line layer sliders are always visible (no parent toggle)", () => {
+    // Since line layers have no toggle, their slider rows are always present
+    const rows = el.querySelectorAll<HTMLElement>("[data-opacity-row]");
+    for (const row of rows) {
+      expect(row.style.display).not.toBe("none");
+    }
+  });
+
+  it("does not render checkboxes for constellationLines or constellationBoundaries", () => {
+    const clCheckbox = el.querySelector("input[data-layer='constellationLines']");
+    const cbCheckbox = el.querySelector("input[data-layer='constellationBoundaries']");
+    expect(clCheckbox).toBeNull();
+    expect(cbCheckbox).toBeNull();
   });
 });

--- a/src/ui/layer-controls.ts
+++ b/src/ui/layer-controls.ts
@@ -8,33 +8,25 @@ type LayerDef = {
   label: string;
 };
 
-type OpacityDef = {
+type LineDef = {
   key: keyof LayerOpacity;
   label: string;
-  parentLayer: keyof LayerVisibility;
+  defaultPct: number;
 };
 
-const LAYERS: LayerDef[] = [
+const TOGGLE_LAYERS: LayerDef[] = [
   { key: "stars", label: "Stars ☆" },
   { key: "planets", label: "Planets ☾" },
   { key: "satellites", label: "Satellites 🛰" },
-  { key: "constellationLines", label: "Constellation Lines ╱" },
-  { key: "constellationBoundaries", label: "Constellation Boundaries ⬡" },
   { key: "compass", label: "Compass ◎" },
 ];
 
-const OPACITY_CONTROLS: OpacityDef[] = [
-  {
-    key: "constellationLines",
-    label: "Constellation Lines opacity",
-    parentLayer: "constellationLines",
-  },
-  {
-    key: "constellationBoundaries",
-    label: "Constellation Boundaries opacity",
-    parentLayer: "constellationBoundaries",
-  },
-  { key: "satelliteTrails", label: "Satellite Trails opacity", parentLayer: "satellites" },
+const LINE_LAYERS: LineDef[] = [
+  { key: "constellationLines", label: "Constellation Lines", defaultPct: 25 },
+  { key: "constellationBoundaries", label: "Constellation Boundaries", defaultPct: 15 },
+  { key: "satelliteTrails", label: "Satellite Trails", defaultPct: 30 },
+  { key: "raDecGrid", label: "RA/Dec Grid", defaultPct: 20 },
+  { key: "ecliptic", label: "Ecliptic", defaultPct: 40 },
 ];
 
 export function createLayerControls(
@@ -55,11 +47,8 @@ export function createLayerControls(
   applyBaseText(layersHeading);
   section.appendChild(layersHeading);
 
-  // Map from layer key → opacity slider row element, for show/hide
-  const opacityRowMap = new Map<string, HTMLElement>();
-
-  // Build each layer toggle row
-  for (const layer of LAYERS) {
+  // Build each toggle layer row (stars, planets, satellites, compass)
+  for (const layer of TOGGLE_LAYERS) {
     const row = document.createElement("div");
     row.style.display = "flex";
     row.style.alignItems = "center";
@@ -77,7 +66,6 @@ export function createLayerControls(
     checkbox.type = "checkbox";
     checkbox.dataset.layer = layer.key;
     checkbox.checked = visibility[layer.key];
-    // Style as toggle-like accent checkbox
     checkbox.style.accentColor = ACCENT_COLOR;
     checkbox.style.width = "16px";
     checkbox.style.height = "16px";
@@ -91,54 +79,44 @@ export function createLayerControls(
 
     checkbox.addEventListener("change", () => {
       visibility[layer.key] = checkbox.checked;
-      // Show/hide associated opacity row if any
-      for (const od of OPACITY_CONTROLS) {
-        if (od.parentLayer === layer.key) {
-          const opRow = opacityRowMap.get(od.key);
-          if (opRow) opRow.style.display = checkbox.checked ? "" : "none";
-        }
-      }
       dispatch({ type: "toggle-layer", layer: layer.key });
     });
   }
 
-  // Opacity heading
-  const opacityHeading = document.createElement("div");
-  opacityHeading.textContent = "Opacity";
-  opacityHeading.style.fontWeight = "bold";
-  opacityHeading.style.marginTop = "8px";
-  opacityHeading.style.marginBottom = GAP;
-  applyBaseText(opacityHeading);
-  section.appendChild(opacityHeading);
+  // Line Layers heading
+  const lineHeading = document.createElement("div");
+  lineHeading.textContent = "Line Layers";
+  lineHeading.style.fontWeight = "bold";
+  lineHeading.style.marginTop = "8px";
+  lineHeading.style.marginBottom = GAP;
+  applyBaseText(lineHeading);
+  section.appendChild(lineHeading);
 
-  // Build each opacity slider row
-  for (const od of OPACITY_CONTROLS) {
+  // Build each line-layer opacity slider (no toggle, slider to 0 = off)
+  for (const ld of LINE_LAYERS) {
     const row = document.createElement("div");
-    row.dataset.opacityRow = od.key;
+    row.dataset.opacityRow = ld.key;
     row.style.marginBottom = "6px";
-    // Hidden if parent layer is off
-    if (!visibility[od.parentLayer]) row.style.display = "none";
-    opacityRowMap.set(od.key, row);
 
     const lbl = document.createElement("div");
-    lbl.textContent = od.label;
+    lbl.textContent = ld.label;
     applyBaseText(lbl);
     lbl.style.fontSize = "12px";
     lbl.style.marginBottom = "2px";
 
     const slider = document.createElement("input");
     slider.type = "range";
-    slider.dataset.opacity = od.key;
+    slider.dataset.opacity = ld.key;
     slider.min = "0";
     slider.max = "100";
     slider.step = "1";
-    slider.value = String(Math.round(initialOpacity[od.key] * 100));
+    slider.value = String(Math.round(initialOpacity[ld.key] * 100));
     slider.style.width = "100%";
     slider.style.accentColor = ACCENT_COLOR;
 
     slider.addEventListener("input", () => {
       const value = Number(slider.value) / 100;
-      dispatch({ type: "set-opacity", layer: od.key, value });
+      dispatch({ type: "set-opacity", layer: ld.key, value });
     });
 
     row.appendChild(lbl);


### PR DESCRIPTION
## Summary
- RA/Dec equatorial coordinate grid (24 RA + 17 Dec lines) computed via `computeRaDecGrid` and rendered by `GridLayer` (white, 1px, default opacity 0.2)
- Ecliptic line (warm yellow #FFD700, 2px arc) computed via `computeEclipticLine` using ecliptic→equatorial math with obliquity ε=23.4393°, rendered by `EclipticLayer` (default opacity 0.4)
- UI simplification: constellation lines, constellation boundaries, satellite trails, RA/Dec grid, and ecliptic are now in a "Line Layers" section with opacity-only sliders — no toggle checkboxes; sliding to 0 hides the layer
- Removed `constellationLines` and `constellationBoundaries` from `LayerVisibility`; they remain in `LayerOpacity`
- New URL params: `op_grid` and `op_ecl` for persisting grid/ecliptic opacity

## Test plan
- [ ] All 258 tests pass across 32 test files
- [ ] `pnpm typecheck` — clean
- [ ] `pnpm format:check` — clean
- [ ] `pnpm lint` — clean (no `as any`, SPDX headers OK)
- [ ] `pnpm build` — 480KB bundle, no errors
- [ ] New test files: `src/astro/grid.test.ts`, `src/astro/ecliptic.test.ts`, `src/scene/grid.test.ts`, `src/scene/ecliptic.test.ts`
- [ ] Updated test files: `src/state/state.test.ts`, `src/ui/layer-controls.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)