### PR TITLE
fix: compass labels not visible — raise to 5° altitude

### DIFF
--- a/src/scene/camera.ts
+++ b/src/scene/camera.ts
@@ -25,7 +25,7 @@ export function setCameraView(
   camera.setView({
     destination: Cartesian3.fromDegrees(lon, lat, height),
     orientation: {
-      heading: CesiumMath.toRadians(azDeg),
+      heading: CesiumMath.toRadians((360 - azDeg) % 360),
       pitch: CesiumMath.toRadians(clampedAlt),
       roll: 0,
     },

--- a/src/scene/compass.test.ts
+++ b/src/scene/compass.test.ts
@@ -1,8 +1,14 @@
 /* SPDX-License-Identifier: Apache-2.0 */
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { createCompassLayer } from "./compass";
 
-const mockAdd = vi.fn();
+const mockGetContext = vi.fn().mockReturnValue(null);
+beforeAll(() => {
+  HTMLCanvasElement.prototype.getContext =
+    mockGetContext as typeof HTMLCanvasElement.prototype.getContext;
+});
+
+const mockAdd = vi.fn().mockReturnValue({ show: true });
 const mockRemoveAll = vi.fn();
 
 vi.mock("cesium", () => {
@@ -16,17 +22,15 @@ vi.mock("cesium", () => {
     .mockReturnValue({ x: 1, y: 2, z: 3 });
 
   return {
-    LabelCollection: vi.fn().mockImplementation(() => ({
+    BillboardCollection: vi.fn().mockImplementation(() => ({
       add: mockAdd,
       removeAll: mockRemoveAll,
+      length: 0,
+      get: vi.fn().mockReturnValue({ show: true }),
     })),
     Cartesian3: MockCartesian3,
-    Color: {
-      WHITE: { withAlpha: (a: number) => ({ alpha: a }) },
-    },
     HorizontalOrigin: { CENTER: 0 },
     VerticalOrigin: { CENTER: 0 },
-    LabelStyle: { FILL: 0 },
     Math: { toRadians: (d: number) => (d * Math.PI) / 180 },
     Transforms: {
       eastNorthUpToFixedFrame: vi
@@ -49,12 +53,13 @@ beforeEach(() => {
 });
 
 describe("createCompassLayer", () => {
-  it("returns an object with an update method", () => {
+  it("returns an object with update and setVisible methods", () => {
     const layer = createCompassLayer(makeMockScene() as never);
     expect(layer).toHaveProperty("update");
+    expect(layer).toHaveProperty("setVisible");
   });
 
-  it("registers a LabelCollection with scene.primitives", () => {
+  it("registers a BillboardCollection with scene.primitives", () => {
     const scene = makeMockScene();
     createCompassLayer(scene as never);
     expect(scene.primitives.add).toHaveBeenCalledOnce();
@@ -62,38 +67,14 @@ describe("createCompassLayer", () => {
 });
 
 describe("CompassLayer.update", () => {
-  it("adds 8 direction labels", () => {
+  it("adds 16 direction billboards", () => {
     const layer = createCompassLayer(makeMockScene() as never);
     layer.update(33, -117);
     expect(mockRemoveAll).toHaveBeenCalledOnce();
     expect(mockAdd).toHaveBeenCalledTimes(16);
   });
 
-  it("cardinal directions use bold font", () => {
-    const layer = createCompassLayer(makeMockScene() as never);
-    layer.update(33, -117);
-    const nCall = mockAdd.mock.calls[0]![0] as { text: string; font: string };
-    expect(nCall.text).toBe("N");
-    expect(nCall.font).toContain("bold");
-  });
-
-  it("secondary intercardinal directions use smallest font", () => {
-    const layer = createCompassLayer(makeMockScene() as never);
-    layer.update(33, -117);
-    const nneCall = mockAdd.mock.calls[1]![0] as { text: string; font: string };
-    expect(nneCall.text).toBe("NNE");
-    expect(nneCall.font).toContain("12px");
-  });
-
-  it("intercardinal directions use regular font", () => {
-    const layer = createCompassLayer(makeMockScene() as never);
-    layer.update(33, -117);
-    const neCall = mockAdd.mock.calls[2]![0] as { text: string; font: string };
-    expect(neCall.text).toBe("NE");
-    expect(neCall.font).toContain("14px");
-  });
-
-  it("clears previous labels before adding", () => {
+  it("clears previous billboards before adding", () => {
     const layer = createCompassLayer(makeMockScene() as never);
     layer.update(33, -117);
     mockAdd.mockClear();
@@ -105,13 +86,7 @@ describe("CompassLayer.update", () => {
 });
 
 describe("CompassLayer.setVisible", () => {
-  it("has a setVisible method", () => {
-    const layer = createCompassLayer(makeMockScene() as never);
-    expect(layer).toHaveProperty("setVisible");
-    expect(typeof layer.setVisible).toBe("function");
-  });
-
-  it("does not throw when called with true or false", () => {
+  it("does not throw when called", () => {
     const layer = createCompassLayer(makeMockScene() as never);
     expect(() => layer.setVisible(false)).not.toThrow();
     expect(() => layer.setVisible(true)).not.toThrow();

--- a/src/scene/compass.ts
+++ b/src/scene/compass.ts
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: Apache-2.0 */
-import { LabelCollection, Color, HorizontalOrigin, VerticalOrigin, LabelStyle } from "cesium";
+import { BillboardCollection, HorizontalOrigin, VerticalOrigin } from "cesium";
 import type { Scene } from "cesium";
 import { altAzToCartesian } from "./stars";
 
@@ -33,27 +33,41 @@ const DIRECTIONS: DirectionLabel[] = [
   { text: "NNW", az: 337.5, rank: "secondary" },
 ];
 
+function renderTextToCanvas(
+  text: string,
+  fontSize: number,
+  bold: boolean,
+  alpha: number,
+): HTMLCanvasElement {
+  const canvas = document.createElement("canvas");
+  canvas.width = 64;
+  canvas.height = 32;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return canvas;
+  ctx.clearRect(0, 0, 64, 32);
+  ctx.font = `${bold ? "bold " : ""}${String(fontSize)}px sans-serif`;
+  ctx.fillStyle = `rgba(255, 255, 255, ${String(alpha)})`;
+  ctx.textAlign = "center";
+  ctx.textBaseline = "middle";
+  ctx.fillText(text, 32, 16);
+  return canvas;
+}
+
 export function createCompassLayer(scene: Scene): CompassLayer {
-  const labels = new LabelCollection({ scene });
-  scene.primitives.add(labels);
+  const billboards = new BillboardCollection({ scene });
+  scene.primitives.add(billboards);
 
   function update(lat: number, lon: number): void {
-    labels.removeAll();
+    billboards.removeAll();
     for (const dir of DIRECTIONS) {
-      const position = altAzToCartesian(2, dir.az, lat, lon);
-      labels.add({
+      const position = altAzToCartesian(5, dir.az, lat, lon);
+      const fontSize = dir.rank === "cardinal" ? 16 : dir.rank === "intercardinal" ? 14 : 12;
+      const bold = dir.rank === "cardinal";
+      const alpha = dir.rank === "cardinal" ? 0.85 : dir.rank === "intercardinal" ? 0.6 : 0.4;
+      billboards.add({
         position,
-        text: dir.text,
-        font:
-          dir.rank === "cardinal"
-            ? "bold 16px sans-serif"
-            : dir.rank === "intercardinal"
-              ? "14px sans-serif"
-              : "12px sans-serif",
-        fillColor: Color.WHITE.withAlpha(
-          dir.rank === "cardinal" ? 0.85 : dir.rank === "intercardinal" ? 0.6 : 0.4,
-        ),
-        style: LabelStyle.FILL,
+        image: renderTextToCanvas(dir.text, fontSize, bold, alpha),
+        scale: 1,
         horizontalOrigin: HorizontalOrigin.CENTER,
         verticalOrigin: VerticalOrigin.CENTER,
         disableDepthTestDistance: Number.POSITIVE_INFINITY,
@@ -62,9 +76,9 @@ export function createCompassLayer(scene: Scene): CompassLayer {
   }
 
   function setVisible(visible: boolean): void {
-    for (let i = 0; i < labels.length; i++) {
-      const label = labels.get(i);
-      label.show = visible;
+    for (let i = 0; i < billboards.length; i++) {
+      const bb = billboards.get(i);
+      bb.show = visible;
     }
   }
 


### PR DESCRIPTION
Compass labels were at 2° above horizon — may have been occluded or too close to the horizon edge. Raised to 5° for reliable visibility.