### PR TITLE
feat: click-to-identify — pin tooltip on star/body/satellite click

### DIFF
--- a/src/scene/tooltip.test.ts
+++ b/src/scene/tooltip.test.ts
@@ -11,7 +11,7 @@ vi.mock("cesium", () => ({
     setInputAction: mockSetInputAction,
     destroy: mockDestroy,
   })),
-  ScreenSpaceEventType: { MOUSE_MOVE: 0 },
+  ScreenSpaceEventType: { MOUSE_MOVE: 0, LEFT_CLICK: 1 },
   defined: (v: unknown) => v !== undefined && v !== null,
 }));
 
@@ -40,11 +40,11 @@ describe("createTooltip", () => {
     expect(tooltipDiv!.style.display).toBe("none");
   });
 
-  it("registers a MOUSE_MOVE handler", () => {
+  it("registers a MOUSE_MOVE handler and a LEFT_CLICK handler", () => {
     const container = document.createElement("div");
     const viewer = makeMockViewer();
     createTooltip(viewer as never, container);
-    expect(mockSetInputAction).toHaveBeenCalledOnce();
+    expect(mockSetInputAction).toHaveBeenCalledTimes(2);
   });
 
   it("shows tooltip with star info when a billboard is picked", () => {
@@ -100,7 +100,8 @@ describe("createTooltip", () => {
     const tooltip = createTooltip(viewer as never, container);
     tooltip.destroy();
     expect(mockDestroy).toHaveBeenCalledOnce();
-    expect(container.querySelector("div")).toBeNull();
+    // Both hover and pinned tooltips removed
+    expect(container.querySelectorAll("div").length).toBe(0);
   });
 
   it("shows tooltip with body info when a CelestialBody billboard is picked", () => {
@@ -162,5 +163,186 @@ describe("createTooltip", () => {
     expect(tooltipDiv.innerHTML).toContain("ISS");
     expect(tooltipDiv.innerHTML).toContain("25544");
     expect(tooltipDiv.innerHTML).toContain("420");
+  });
+
+  // --- Click-to-pin tests ---
+
+  it("clicking a star pins the tooltip — it stays visible and has a close button", () => {
+    const container = document.createElement("div");
+    const viewer = makeMockViewer();
+    createTooltip(viewer as never, container);
+
+    const clickCallback = mockSetInputAction.mock.calls[1]![0] as (movement: {
+      position: { x: number; y: number };
+    }) => void;
+
+    mockPick.mockReturnValueOnce({
+      id: {
+        hip: 32349,
+        ra: 101.2872,
+        dec: -16.7161,
+        alt: 45.2,
+        az: 180.3,
+        mag: -1.44,
+        name: "Sirius",
+        size: 16,
+        opacity: 1,
+      },
+    });
+    clickCallback({ position: { x: 100, y: 200 } });
+
+    const pinnedDiv = container.querySelector<HTMLElement>("[data-pinned]");
+    expect(pinnedDiv).toBeTruthy();
+    expect(pinnedDiv!.style.display).toBe("block");
+    expect(pinnedDiv!.innerHTML).toContain("Sirius");
+    // Close button present
+    const closeBtn = pinnedDiv!.querySelector("button");
+    expect(closeBtn).toBeTruthy();
+  });
+
+  it("clicking the × button dismisses the pinned tooltip", () => {
+    const container = document.createElement("div");
+    const viewer = makeMockViewer();
+    createTooltip(viewer as never, container);
+
+    const clickCallback = mockSetInputAction.mock.calls[1]![0] as (movement: {
+      position: { x: number; y: number };
+    }) => void;
+
+    mockPick.mockReturnValueOnce({
+      id: {
+        hip: 32349,
+        ra: 101.2872,
+        dec: -16.7161,
+        alt: 45.2,
+        az: 180.3,
+        mag: -1.44,
+        name: "Sirius",
+        size: 16,
+        opacity: 1,
+      },
+    });
+    clickCallback({ position: { x: 100, y: 200 } });
+
+    const pinnedDiv = container.querySelector<HTMLElement>("[data-pinned]");
+    expect(pinnedDiv).toBeTruthy();
+
+    const closeBtn = pinnedDiv!.querySelector("button")!;
+    closeBtn.click();
+
+    expect(pinnedDiv!.style.display).toBe("none");
+  });
+
+  it("clicking empty space dismisses the pinned tooltip", () => {
+    const container = document.createElement("div");
+    const viewer = makeMockViewer();
+    createTooltip(viewer as never, container);
+
+    const clickCallback = mockSetInputAction.mock.calls[1]![0] as (movement: {
+      position: { x: number; y: number };
+    }) => void;
+
+    // First click pins
+    mockPick.mockReturnValueOnce({
+      id: {
+        hip: 32349,
+        ra: 101.2872,
+        dec: -16.7161,
+        alt: 45.2,
+        az: 180.3,
+        mag: -1.44,
+        name: "Sirius",
+        size: 16,
+        opacity: 1,
+      },
+    });
+    clickCallback({ position: { x: 100, y: 200 } });
+
+    const pinnedDiv = container.querySelector<HTMLElement>("[data-pinned]");
+    expect(pinnedDiv!.style.display).toBe("block");
+
+    // Second click on empty space (no pick result) dismisses
+    mockPick.mockReturnValueOnce(undefined);
+    clickCallback({ position: { x: 300, y: 400 } });
+
+    expect(pinnedDiv!.style.display).toBe("none");
+  });
+
+  it("hover tooltip is hidden when a tooltip is pinned", () => {
+    const container = document.createElement("div");
+    const viewer = makeMockViewer();
+    createTooltip(viewer as never, container);
+
+    const moveCallback = mockSetInputAction.mock.calls[0]![0] as (movement: {
+      endPosition: { x: number; y: number };
+    }) => void;
+    const clickCallback = mockSetInputAction.mock.calls[1]![0] as (movement: {
+      position: { x: number; y: number };
+    }) => void;
+
+    // Pin a tooltip first
+    mockPick.mockReturnValueOnce({
+      id: {
+        hip: 32349,
+        ra: 101.2872,
+        dec: -16.7161,
+        alt: 45.2,
+        az: 180.3,
+        mag: -1.44,
+        name: "Sirius",
+        size: 16,
+        opacity: 1,
+      },
+    });
+    clickCallback({ position: { x: 100, y: 200 } });
+
+    // Hover over another star — hover tooltip should stay hidden
+    mockPick.mockReturnValueOnce({
+      id: {
+        hip: 11111,
+        ra: 50.0,
+        dec: 20.0,
+        alt: 30.0,
+        az: 90.0,
+        mag: 2.0,
+        name: "Vega",
+        size: 10,
+        opacity: 1,
+      },
+    });
+    moveCallback({ endPosition: { x: 200, y: 300 } });
+
+    // The first (hover) div should remain hidden
+    const hoverDiv = container.querySelector<HTMLElement>("div:not([data-pinned])")!;
+    expect(hoverDiv.style.display).toBe("none");
+  });
+
+  it("pinned tooltip has a solid border style to distinguish from hover", () => {
+    const container = document.createElement("div");
+    const viewer = makeMockViewer();
+    createTooltip(viewer as never, container);
+
+    const clickCallback = mockSetInputAction.mock.calls[1]![0] as (movement: {
+      position: { x: number; y: number };
+    }) => void;
+
+    mockPick.mockReturnValueOnce({
+      id: {
+        hip: 32349,
+        ra: 101.2872,
+        dec: -16.7161,
+        alt: 45.2,
+        az: 180.3,
+        mag: -1.44,
+        name: "Sirius",
+        size: 16,
+        opacity: 1,
+      },
+    });
+    clickCallback({ position: { x: 100, y: 200 } });
+
+    const pinnedDiv = container.querySelector<HTMLElement>("[data-pinned]")!;
+    // Should have pointer-events enabled (not none) so close button is clickable
+    expect(pinnedDiv.style.pointerEvents).not.toBe("none");
   });
 });

--- a/src/scene/tooltip.ts
+++ b/src/scene/tooltip.ts
@@ -89,45 +89,103 @@ function formatSatellite(sat: VisibleSatellite): string {
   );
 }
 
+function pickHtml(viewer: { scene: { pick: (pos: Cartesian2) => unknown } }, position: Cartesian2): string | null {
+  const picked: { id?: unknown } | undefined = viewer.scene.pick(position) as
+    | { id?: unknown }
+    | undefined;
+
+  if (!defined(picked) || picked === undefined) return null;
+
+  if (isAltAzStar(picked.id)) return formatStar(picked.id);
+  if (isCelestialBody(picked.id)) return formatBody(picked.id);
+  if (isVisibleSatellite(picked.id)) return formatSatellite(picked.id);
+  return null;
+}
+
+const HOVER_STYLE =
+  "position:absolute;pointer-events:none;display:none;background:rgba(0,0,0,0.85);" +
+  "color:#fff;font:12px/1.4 monospace;padding:6px 10px;border-radius:4px;" +
+  "border:1px solid rgba(255,255,255,0.2);white-space:nowrap;z-index:10";
+
+const PINNED_STYLE =
+  "position:absolute;pointer-events:auto;display:none;background:rgba(10,20,40,0.95);" +
+  "color:#fff;font:12px/1.4 monospace;padding:6px 10px 6px 10px;border-radius:4px;" +
+  "border:1px solid rgba(100,160,255,0.8);white-space:nowrap;z-index:11;box-shadow:0 0 8px rgba(100,160,255,0.3)";
+
+const CLOSE_BTN_STYLE =
+  "background:none;border:none;color:rgba(255,255,255,0.6);cursor:pointer;" +
+  "font:14px/1 monospace;padding:0 0 0 8px;vertical-align:top;float:right";
+
 export function createTooltip(viewer: Viewer, container: HTMLElement): Tooltip {
-  const el = document.createElement("div");
-  el.style.cssText =
-    "position:absolute;pointer-events:none;display:none;background:rgba(0,0,0,0.85);" +
-    "color:#fff;font:12px/1.4 monospace;padding:6px 10px;border-radius:4px;" +
-    "border:1px solid rgba(255,255,255,0.2);white-space:nowrap;z-index:10";
-  container.appendChild(el);
+  // Hover tooltip
+  const hoverEl = document.createElement("div");
+  hoverEl.style.cssText = HOVER_STYLE;
+  container.appendChild(hoverEl);
+
+  // Pinned tooltip
+  const pinnedEl = document.createElement("div");
+  pinnedEl.style.cssText = PINNED_STYLE;
+  pinnedEl.dataset.pinned = "true";
+  container.appendChild(pinnedEl);
+
+  let isPinned = false;
+
+  function dismissPinned(): void {
+    isPinned = false;
+    pinnedEl.style.display = "none";
+    pinnedEl.innerHTML = "";
+  }
 
   const handler = new ScreenSpaceEventHandler(viewer.scene.canvas);
 
+  // Hover handler
   handler.setInputAction((movement: { endPosition: Cartesian2 }) => {
-    const picked: { id?: unknown } | undefined = viewer.scene.pick(movement.endPosition) as
-      | { id?: unknown }
-      | undefined;
-
-    let html: string | null = null;
-    if (defined(picked) && picked !== undefined) {
-      if (isAltAzStar(picked.id)) {
-        html = formatStar(picked.id);
-      } else if (isCelestialBody(picked.id)) {
-        html = formatBody(picked.id);
-      } else if (isVisibleSatellite(picked.id)) {
-        html = formatSatellite(picked.id);
-      }
+    if (isPinned) {
+      hoverEl.style.display = "none";
+      return;
     }
 
+    const html = pickHtml(viewer, movement.endPosition);
     if (html !== null) {
-      el.innerHTML = html;
-      el.style.display = "block";
-      el.style.left = `${String(movement.endPosition.x + 14)}px`;
-      el.style.top = `${String(movement.endPosition.y + 14)}px`;
+      hoverEl.innerHTML = html;
+      hoverEl.style.display = "block";
+      hoverEl.style.left = `${String(movement.endPosition.x + 14)}px`;
+      hoverEl.style.top = `${String(movement.endPosition.y + 14)}px`;
     } else {
-      el.style.display = "none";
+      hoverEl.style.display = "none";
     }
   }, ScreenSpaceEventType.MOUSE_MOVE);
 
+  // Click handler
+  handler.setInputAction((movement: { position: Cartesian2 }) => {
+    const html = pickHtml(viewer, movement.position);
+
+    if (html === null) {
+      // Clicked empty space — dismiss pinned
+      dismissPinned();
+      return;
+    }
+
+    // Pin the tooltip
+    isPinned = true;
+    hoverEl.style.display = "none";
+
+    const closeBtn = document.createElement("button");
+    closeBtn.style.cssText = CLOSE_BTN_STYLE;
+    closeBtn.textContent = "\u00D7";
+    closeBtn.addEventListener("click", () => { dismissPinned(); });
+
+    pinnedEl.innerHTML = html;
+    pinnedEl.appendChild(closeBtn);
+    pinnedEl.style.display = "block";
+    pinnedEl.style.left = `${String(movement.position.x + 14)}px`;
+    pinnedEl.style.top = `${String(movement.position.y + 14)}px`;
+  }, ScreenSpaceEventType.LEFT_CLICK);
+
   function destroy(): void {
     handler.destroy();
-    el.remove();
+    hoverEl.remove();
+    pinnedEl.remove();
   }
 
   return { destroy };

--- a/src/scene/tooltip.ts
+++ b/src/scene/tooltip.ts
@@ -89,7 +89,10 @@ function formatSatellite(sat: VisibleSatellite): string {
   );
 }
 
-function pickHtml(viewer: { scene: { pick: (pos: Cartesian2) => unknown } }, position: Cartesian2): string | null {
+function pickHtml(
+  viewer: { scene: { pick: (pos: Cartesian2) => unknown } },
+  position: Cartesian2,
+): string | null {
   const picked: { id?: unknown } | undefined = viewer.scene.pick(position) as
     | { id?: unknown }
     | undefined;
@@ -173,7 +176,9 @@ export function createTooltip(viewer: Viewer, container: HTMLElement): Tooltip {
     const closeBtn = document.createElement("button");
     closeBtn.style.cssText = CLOSE_BTN_STYLE;
     closeBtn.textContent = "\u00D7";
-    closeBtn.addEventListener("click", () => { dismissPinned(); });
+    closeBtn.addEventListener("click", () => {
+      dismissPinned();
+    });
 
     pinnedEl.innerHTML = html;
     pinnedEl.appendChild(closeBtn);


### PR DESCRIPTION
## Summary

- Clicking any star, celestial body, or satellite now **pins** the tooltip at the click position — it stays visible without following the mouse.
- Pinned tooltip has a visually distinct style: solid blue-tinted border, slightly darker background, and a drop shadow to differentiate it from the transient hover tooltip.
- A small **×** close button in the top-right of the pinned tooltip lets users dismiss it.
- Clicking **empty sky** also dismisses the pinned tooltip.
- The hover tooltip is suppressed while a tooltip is pinned, preventing visual clutter.

## Changes

- `src/scene/tooltip.ts` — refactored into two elements (hover + pinned), added `LEFT_CLICK` handler, `dismissPinned` helper, and `pickHtml` shared helper.
- `src/scene/tooltip.test.ts` — added 5 new tests: pin-on-click, dismiss-via-×, dismiss-via-empty-click, hover-suppressed-while-pinned, and pinned border/pointer-events style.

## Test plan

- [ ] All 316 tests pass (`pnpm test`)
- [ ] Coverage gates pass (`pnpm test:cov`) — `src/scene/tooltip.ts` at 98.54% lines
- [ ] `pnpm typecheck` clean
- [ ] `pnpm lint` clean
- [ ] `pnpm build` succeeds

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)