### PR TITLE
feat: Milky Way band overlay

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -11,6 +11,7 @@ import {
   filterVisibleBoundaries,
   computeRaDecGrid,
   computeEclipticLine,
+  computeMilkyWayPoints,
 } from "./astro";
 import type { StarRecord } from "./astro";
 import { AstroWorkerClient } from "./workers/astro-worker-client";
@@ -28,6 +29,7 @@ import {
   createBoundaryLayer,
   createGridLayer,
   createEclipticLayer,
+  createMilkyWayLayer,
   setCameraView,
 } from "./scene";
 import type {
@@ -39,6 +41,7 @@ import type {
   CompassLayer,
   GridLayer,
   EclipticLayer,
+  MilkyWayLayer,
 } from "./scene";
 import { fetchTle, parseTle, propagateSatellites } from "./sat";
 import type { SatelliteRecord, TleParseError } from "./sat";
@@ -65,6 +68,7 @@ type Layers = {
   compass: CompassLayer;
   grid: GridLayer;
   ecliptic: EclipticLayer;
+  milkyWay: MilkyWayLayer;
 };
 
 function applyLayerVisibility(layers: Layers, visibility: LayerVisibility): void {
@@ -143,6 +147,9 @@ function doRerender(state: AppState, layers: Layers, data: ParsedData): void {
   const eclipticPoints = computeEclipticLine(observer.lat, observer.lon, timeUtc);
   layers.ecliptic.update(eclipticPoints, observer.lat, observer.lon);
 
+  const milkyWayPoints = computeMilkyWayPoints(observer.lat, observer.lon, timeUtc);
+  layers.milkyWay.update(milkyWayPoints, observer.lat, observer.lon);
+
   layers.compass.update(observer.lat, observer.lon);
 
   applyLayerVisibility(layers, state.layers);
@@ -150,6 +157,7 @@ function doRerender(state: AppState, layers: Layers, data: ParsedData): void {
   layers.boundary.setOpacity(state.opacity.constellationBoundaries * 0.15);
   layers.grid.setOpacity(state.opacity.raDecGrid);
   layers.ecliptic.setOpacity(state.opacity.ecliptic);
+  layers.milkyWay.setOpacity(state.opacity.milkyWay);
   if (layers.satellite) layers.satellite.setOpacity(state.opacity.satelliteTrails * 0.3);
 }
 
@@ -187,6 +195,9 @@ async function doRerenderWithWorker(
   const eclipticPoints = computeEclipticLine(observer.lat, observer.lon, timeUtc);
   layers.ecliptic.update(eclipticPoints, observer.lat, observer.lon);
 
+  const milkyWayPoints = computeMilkyWayPoints(observer.lat, observer.lon, timeUtc);
+  layers.milkyWay.update(milkyWayPoints, observer.lat, observer.lon);
+
   if (data.boundaries.ok) {
     const visibleBoundaries = filterVisibleBoundaries(
       data.boundaries.value,
@@ -205,6 +216,7 @@ async function doRerenderWithWorker(
   layers.boundary.setOpacity(capturedState.opacity.constellationBoundaries * 0.15);
   layers.grid.setOpacity(capturedState.opacity.raDecGrid);
   layers.ecliptic.setOpacity(capturedState.opacity.ecliptic);
+  layers.milkyWay.setOpacity(capturedState.opacity.milkyWay);
   if (layers.satellite) layers.satellite.setOpacity(capturedState.opacity.satelliteTrails * 0.3);
 
   // Wait for worker result, then update stars + constellations
@@ -289,6 +301,7 @@ export async function bootstrap(
     compass: createCompassLayer(viewer.scene),
     grid: createGridLayer(viewer.scene),
     ecliptic: createEclipticLayer(viewer.scene),
+    milkyWay: createMilkyWayLayer(viewer.scene),
   };
 
   // Parse static data once
@@ -398,6 +411,7 @@ export async function bootstrap(
         layers.boundary.setOpacity(state.opacity.constellationBoundaries * 0.15);
         layers.grid.setOpacity(state.opacity.raDecGrid);
         layers.ecliptic.setOpacity(state.opacity.ecliptic);
+        layers.milkyWay.setOpacity(state.opacity.milkyWay);
         if (layers.satellite) layers.satellite.setOpacity(state.opacity.satelliteTrails * 0.3);
         updateUrl(state);
         break;

--- a/src/astro/index.ts
+++ b/src/astro/index.ts
@@ -23,4 +23,5 @@ export {
 } from "./boundaries";
 export { type GridData, computeRaDecGrid } from "./grid";
 export { computeEclipticLine } from "./ecliptic";
+export { computeMilkyWayPoints } from "./milkyway";
 export { bvToRgb } from "./star-color";

--- a/src/astro/milkyway.test.ts
+++ b/src/astro/milkyway.test.ts
@@ -1,0 +1,87 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { describe, expect, it } from "vitest";
+import { computeMilkyWayPoints } from "./milkyway";
+
+const LAT = 37.77; // San Francisco
+const LON = -122.42;
+const TIME = new Date("2026-04-15T03:00:00Z");
+
+describe("computeMilkyWayPoints", () => {
+  it("returns an array", () => {
+    const points = computeMilkyWayPoints(LAT, LON, TIME);
+    expect(Array.isArray(points)).toBe(true);
+  });
+
+  it("returns at most the number of predefined Milky Way key points above the horizon", () => {
+    const points = computeMilkyWayPoints(LAT, LON, TIME);
+    // At most as many points as we have predefined key points
+    expect(points.length).toBeLessThanOrEqual(50);
+  });
+
+  it("returns at least some points above the horizon for a mid-latitude observer", () => {
+    const points = computeMilkyWayPoints(LAT, LON, TIME);
+    expect(points.length).toBeGreaterThan(0);
+  });
+
+  it("all returned points are above the horizon (alt >= 0)", () => {
+    const points = computeMilkyWayPoints(LAT, LON, TIME);
+    for (const pt of points) {
+      expect(pt.alt).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it("all points have valid alt range [0, 90]", () => {
+    const points = computeMilkyWayPoints(LAT, LON, TIME);
+    for (const pt of points) {
+      expect(pt.alt).toBeGreaterThanOrEqual(0);
+      expect(pt.alt).toBeLessThanOrEqual(90);
+    }
+  });
+
+  it("all points have valid az range [0, 360)", () => {
+    const points = computeMilkyWayPoints(LAT, LON, TIME);
+    for (const pt of points) {
+      expect(pt.az).toBeGreaterThanOrEqual(0);
+      expect(pt.az).toBeLessThan(360);
+    }
+  });
+
+  it("all points have finite numeric alt and az", () => {
+    const points = computeMilkyWayPoints(LAT, LON, TIME);
+    for (const pt of points) {
+      expect(typeof pt.alt).toBe("number");
+      expect(typeof pt.az).toBe("number");
+      expect(Number.isFinite(pt.alt)).toBe(true);
+      expect(Number.isFinite(pt.az)).toBe(true);
+    }
+  });
+
+  it("works for equatorial observer", () => {
+    const points = computeMilkyWayPoints(0, 0, TIME);
+    expect(Array.isArray(points)).toBe(true);
+    expect(points.length).toBeGreaterThan(0);
+  });
+
+  it("works for polar observer", () => {
+    const points = computeMilkyWayPoints(89, 0, TIME);
+    expect(Array.isArray(points)).toBe(true);
+  });
+
+  it("returns different results for different times", () => {
+    const points1 = computeMilkyWayPoints(LAT, LON, new Date("2026-04-15T00:00:00Z"));
+    const points2 = computeMilkyWayPoints(LAT, LON, new Date("2026-04-15T12:00:00Z"));
+    // At least one property should differ (Milky Way rotates with time)
+    const count1 = points1.length;
+    const count2 = points2.length;
+    // Different times may yield different counts of visible points
+    // At minimum both should be valid arrays
+    expect(Array.isArray(points1)).toBe(true);
+    expect(Array.isArray(points2)).toBe(true);
+    // Either counts differ or some coordinate differs
+    if (count1 === count2 && count1 > 0) {
+      const azSum1 = points1.reduce((s, p) => s + p.az, 0);
+      const azSum2 = points2.reduce((s, p) => s + p.az, 0);
+      expect(Math.abs(azSum1 - azSum2)).toBeGreaterThan(0.1);
+    }
+  });
+});

--- a/src/astro/milkyway.ts
+++ b/src/astro/milkyway.ts
@@ -1,0 +1,65 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import type { HorizontalCoord } from "./coords";
+import { fastRaDecToAltAz } from "./fast-coords";
+
+/**
+ * Key points along the Milky Way centerline, stored as RA/Dec (J2000, degrees).
+ * These trace the bright band of the galactic plane as seen from Earth.
+ * Listed in order roughly following the galactic plane around the sky.
+ */
+const MILKY_WAY_POINTS: ReadonlyArray<{ ra: number; dec: number }> = [
+  { ra: 266, dec: -29 }, // Sagittarius (galactic center)
+  { ra: 275, dec: -20 }, // Sagittarius/Scutum
+  { ra: 284, dec: -10 }, // Scutum/Aquila
+  { ra: 297, dec: 10 }, // Aquila
+  { ra: 303, dec: 20 }, // Aquila/Sagitta
+  { ra: 310, dec: 42 }, // Cygnus
+  { ra: 320, dec: 55 }, // Cygnus/Lacerta
+  { ra: 335, dec: 60 }, // Cassiopeia approach
+  { ra: 15, dec: 60 }, // Cassiopeia
+  { ra: 30, dec: 56 }, // Cassiopeia/Perseus
+  { ra: 45, dec: 50 }, // Perseus
+  { ra: 55, dec: 45 }, // Perseus
+  { ra: 70, dec: 38 }, // Auriga/Perseus boundary
+  { ra: 80, dec: 35 }, // Auriga
+  { ra: 90, dec: 22 }, // Auriga/Gemini
+  { ra: 100, dec: 5 }, // Gemini/Monoceros
+  { ra: 110, dec: -5 }, // Monoceros
+  { ra: 120, dec: -20 }, // Monoceros/Puppis
+  { ra: 130, dec: -45 }, // Puppis/Vela
+  { ra: 145, dec: -55 }, // Vela/Carina
+  { ra: 160, dec: -60 }, // Carina
+  { ra: 175, dec: -62 }, // Carina/Crux approach
+  { ra: 190, dec: -60 }, // Crux
+  { ra: 205, dec: -55 }, // Crux/Centaurus
+  { ra: 210, dec: -50 }, // Centaurus
+  { ra: 222, dec: -45 }, // Centaurus/Lupus
+  { ra: 235, dec: -40 }, // Lupus/Scorpius
+  { ra: 248, dec: -25 }, // Scorpius
+  { ra: 258, dec: -30 }, // Scorpius/Sagittarius boundary
+];
+
+/**
+ * Compute Milky Way band points visible above the horizon.
+ *
+ * Uses a predefined set of RA/Dec key points tracing the galactic plane,
+ * converts each to Alt/Az at the given observer position and time,
+ * and returns only those above the horizon.
+ *
+ * @param lat - Observer latitude in degrees
+ * @param lon - Observer longitude in degrees
+ * @param time - Observation time (UTC)
+ * @returns Array of { alt, az } points above the horizon (alt >= 0)
+ */
+export function computeMilkyWayPoints(lat: number, lon: number, time: Date): HorizontalCoord[] {
+  const points: HorizontalCoord[] = [];
+
+  for (const { ra, dec } of MILKY_WAY_POINTS) {
+    const coord = fastRaDecToAltAz(ra, dec, lat, lon, time);
+    if (coord.alt >= 0) {
+      points.push(coord);
+    }
+  }
+
+  return points;
+}

--- a/src/scene/index.ts
+++ b/src/scene/index.ts
@@ -10,3 +10,4 @@ export { type SatelliteLayer, createSatelliteLayer } from "./satellites";
 export { type BoundaryLayer, createBoundaryLayer } from "./boundaries";
 export { type GridLayer, createGridLayer } from "./grid";
 export { type EclipticLayer, createEclipticLayer } from "./ecliptic";
+export { type MilkyWayLayer, createMilkyWayLayer } from "./milkyway";

--- a/src/scene/milkyway.test.ts
+++ b/src/scene/milkyway.test.ts
@@ -1,0 +1,145 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createMilkyWayLayer } from "./milkyway";
+import type { HorizontalCoord } from "../astro/coords";
+
+const mockPolylineAdd = vi.fn();
+const mockPolylineRemoveAll = vi.fn();
+const mockPolylines: Array<{ material: { uniforms: { color: { alpha: number } } } }> = [];
+
+vi.mock("cesium", () => {
+  const MockCartesian3 = vi.fn().mockImplementation((x: number, y: number, z: number) => ({
+    x,
+    y,
+    z,
+  }));
+  (MockCartesian3 as unknown as { fromDegrees: ReturnType<typeof vi.fn> }).fromDegrees = vi
+    .fn()
+    .mockReturnValue({ x: 1, y: 2, z: 3 });
+
+  const mockMaterial = { uniforms: { color: { alpha: 1 } } };
+
+  return {
+    PolylineCollection: vi.fn().mockImplementation(() => ({
+      add: (opts: Record<string, unknown>) => {
+        mockPolylineAdd(opts);
+        const polyline = { material: mockMaterial, ...opts };
+        mockPolylines.push(polyline as never);
+        return polyline;
+      },
+      removeAll: () => {
+        mockPolylineRemoveAll();
+        mockPolylines.length = 0;
+      },
+      show: true,
+    })),
+    Cartesian3: MockCartesian3,
+    Color: {
+      WHITE: { withAlpha: (a: number) => ({ r: 1, g: 1, b: 1, alpha: a }) },
+      fromCssColorString: vi.fn().mockReturnValue({
+        withAlpha: (a: number) => ({ alpha: a }),
+      }),
+    },
+    Math: { toRadians: (d: number) => (d * Math.PI) / 180 },
+    Transforms: {
+      eastNorthUpToFixedFrame: vi
+        .fn()
+        .mockReturnValue([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]),
+    },
+    Matrix4: {
+      multiplyByPoint: vi.fn().mockReturnValue({ x: 10, y: 20, z: 30 }),
+    },
+    Material: {
+      fromType: vi.fn().mockReturnValue(mockMaterial),
+    },
+  };
+});
+
+function makeMockScene() {
+  return { primitives: { add: vi.fn() } };
+}
+
+const SAMPLE_POINTS: HorizontalCoord[] = [
+  { alt: 45, az: 180 },
+  { alt: 40, az: 170 },
+  { alt: 35, az: 160 },
+  { alt: 30, az: 150 },
+];
+
+beforeEach(() => {
+  mockPolylineAdd.mockClear();
+  mockPolylineRemoveAll.mockClear();
+  mockPolylines.length = 0;
+});
+
+describe("createMilkyWayLayer", () => {
+  it("returns an object with update and setOpacity methods", () => {
+    const layer = createMilkyWayLayer(makeMockScene() as never);
+    expect(layer).toHaveProperty("update");
+    expect(layer).toHaveProperty("setOpacity");
+  });
+
+  it("registers PolylineCollection with scene.primitives", () => {
+    const scene = makeMockScene();
+    createMilkyWayLayer(scene as never);
+    expect(scene.primitives.add).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("MilkyWayLayer.update", () => {
+  it("adds a single polyline for the milky way points", () => {
+    const layer = createMilkyWayLayer(makeMockScene() as never);
+    layer.update(SAMPLE_POINTS, 33, -117);
+    expect(mockPolylineRemoveAll).toHaveBeenCalledOnce();
+    expect(mockPolylineAdd).toHaveBeenCalledTimes(1);
+  });
+
+  it("works with empty points array", () => {
+    const layer = createMilkyWayLayer(makeMockScene() as never);
+    layer.update([], 0, 0);
+    expect(mockPolylineRemoveAll).toHaveBeenCalledOnce();
+    expect(mockPolylineAdd).not.toHaveBeenCalled();
+  });
+
+  it("does not add a polyline for a single point", () => {
+    const layer = createMilkyWayLayer(makeMockScene() as never);
+    layer.update([{ alt: 45, az: 180 }], 33, -117);
+    expect(mockPolylineAdd).not.toHaveBeenCalled();
+  });
+
+  it("clears previous polylines before adding new ones", () => {
+    const layer = createMilkyWayLayer(makeMockScene() as never);
+    layer.update(SAMPLE_POINTS, 33, -117);
+    mockPolylineAdd.mockClear();
+    mockPolylineRemoveAll.mockClear();
+    layer.update(SAMPLE_POINTS.slice(0, 3), 33, -117);
+    expect(mockPolylineRemoveAll).toHaveBeenCalledOnce();
+    expect(mockPolylineAdd).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses width of 3 for the polyline", () => {
+    const layer = createMilkyWayLayer(makeMockScene() as never);
+    layer.update(SAMPLE_POINTS, 33, -117);
+    const callArg = mockPolylineAdd.mock.calls[0]![0] as { width: number };
+    expect(callArg.width).toBe(3);
+  });
+});
+
+describe("MilkyWayLayer.setOpacity", () => {
+  it("does not throw when setOpacity is called", () => {
+    const layer = createMilkyWayLayer(makeMockScene() as never);
+    layer.update(SAMPLE_POINTS, 33, -117);
+    expect(() => layer.setOpacity(0.5)).not.toThrow();
+  });
+
+  it("hides polylines when opacity is 0", () => {
+    const layer = createMilkyWayLayer(makeMockScene() as never);
+    layer.update(SAMPLE_POINTS, 33, -117);
+    expect(() => layer.setOpacity(0)).not.toThrow();
+  });
+
+  it("does not throw when called before update", () => {
+    const layer = createMilkyWayLayer(makeMockScene() as never);
+    expect(() => layer.setOpacity(0.3)).not.toThrow();
+  });
+});

--- a/src/scene/milkyway.ts
+++ b/src/scene/milkyway.ts
@@ -1,0 +1,51 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { PolylineCollection, Color, Material } from "cesium";
+import type { Scene } from "cesium";
+import type { HorizontalCoord } from "../astro/coords";
+import { altAzToCartesian } from "./stars";
+
+export type MilkyWayLayer = {
+  update: (points: HorizontalCoord[], lat: number, lon: number) => void;
+  setOpacity: (opacity: number) => void;
+};
+
+// Milky Way color: soft blue-white
+const MILKY_WAY_COLOR = Color.fromCssColorString("#B0C4DE");
+
+export function createMilkyWayLayer(scene: Scene): MilkyWayLayer {
+  const polylines = new PolylineCollection();
+  scene.primitives.add(polylines);
+
+  const addedPolylines: Array<{ material: { uniforms: { color: { alpha: number } } } }> = [];
+  let currentOpacity = 0.3;
+
+  function update(points: HorizontalCoord[], lat: number, lon: number): void {
+    polylines.removeAll();
+    addedPolylines.length = 0;
+
+    if (points.length < 2) return;
+
+    const positions = points.map((pt) => altAzToCartesian(pt.alt, pt.az, lat, lon));
+    const pl = polylines.add({
+      positions,
+      width: 3,
+      material: Material.fromType("Color", {
+        color: MILKY_WAY_COLOR.withAlpha(currentOpacity),
+      }),
+    });
+    addedPolylines.push(pl as never);
+  }
+
+  function setOpacity(opacity: number): void {
+    currentOpacity = opacity;
+    const show = opacity > 0;
+    (polylines as unknown as { show: boolean }).show = show;
+    for (const pl of addedPolylines) {
+      if (pl?.material?.uniforms?.color !== undefined) {
+        pl.material.uniforms.color.alpha = opacity;
+      }
+    }
+  }
+
+  return { update, setOpacity };
+}

--- a/src/state/state.test.ts
+++ b/src/state/state.test.ts
@@ -167,11 +167,48 @@ describe("AppState — serialize round-trip with layer fields", () => {
     expect(s2.opacity.ecliptic).toBeCloseTo(0.7);
   });
 
-  it("does not write op_grid and op_ecl when at defaults", () => {
+  it("does not write op_grid, op_ecl, or op_mw when at defaults", () => {
     const params = new URLSearchParams({ lat: "33", lon: "-117", t: "2026-06-01T00:00:00Z" });
     const s = expectOk(parseStateFromSearchParams(params));
     const out = serializeStateToSearchParams(s);
     expect(out.has("op_grid")).toBe(false);
     expect(out.has("op_ecl")).toBe(false);
+    expect(out.has("op_mw")).toBe(false);
+  });
+});
+
+describe("LayerOpacity — milkyWay field", () => {
+  it("milkyWay opacity defaults to 0.3", () => {
+    const s = expectOk(parseStateFromSearchParams(new URLSearchParams()));
+    expect(s.opacity.milkyWay).toBeCloseTo(0.3);
+  });
+
+  it("parses op_mw param as 0–1 fraction", () => {
+    const params = new URLSearchParams({ op_mw: "50" });
+    const s = expectOk(parseStateFromSearchParams(params));
+    expect(s.opacity.milkyWay).toBeCloseTo(0.5);
+  });
+
+  it("clamps op_mw to [0, 1]", () => {
+    const paramsHigh = new URLSearchParams({ op_mw: "200" });
+    expect(expectOk(parseStateFromSearchParams(paramsHigh)).opacity.milkyWay).toBe(1.0);
+    const paramsLow = new URLSearchParams({ op_mw: "-10" });
+    expect(expectOk(parseStateFromSearchParams(paramsLow)).opacity.milkyWay).toBe(0.0);
+  });
+
+  it("round-trips op_mw through serialize/parse", () => {
+    const params = new URLSearchParams({ op_mw: "45" });
+    const s = expectOk(parseStateFromSearchParams(params));
+    const out = serializeStateToSearchParams(s);
+    const s2 = expectOk(parseStateFromSearchParams(out));
+    expect(s2.opacity.milkyWay).toBeCloseTo(0.45);
+  });
+
+  it("writes op_mw to URL when not at default", () => {
+    const params = new URLSearchParams({ op_mw: "60" });
+    const s = expectOk(parseStateFromSearchParams(params));
+    const out = serializeStateToSearchParams(s);
+    expect(out.has("op_mw")).toBe(true);
+    expect(out.get("op_mw")).toBe("60");
   });
 });

--- a/src/state/state.ts
+++ b/src/state/state.ts
@@ -16,6 +16,7 @@ export type LayerOpacity = {
   readonly satelliteTrails: number; // 0–1
   readonly raDecGrid: number; // 0–1
   readonly ecliptic: number; // 0–1
+  readonly milkyWay: number; // 0–1
 };
 
 export type ViewDirection = {
@@ -58,6 +59,7 @@ export const DEFAULT_OPACITY: LayerOpacity = {
   satelliteTrails: 1.0,
   raDecGrid: 0.2,
   ecliptic: 0.4,
+  milkyWay: 0.3,
 };
 
 export const DEFAULT_VIEW: ViewDirection = { az: 0, alt: 89.9 };
@@ -147,6 +149,7 @@ export function parseStateFromSearchParams(
     satelliteTrails: parseOpacity(params.get("op_st"), DEFAULT_OPACITY.satelliteTrails),
     raDecGrid: parseOpacity(params.get("op_grid"), DEFAULT_OPACITY.raDecGrid),
     ecliptic: parseOpacity(params.get("op_ecl"), DEFAULT_OPACITY.ecliptic),
+    milkyWay: parseOpacity(params.get("op_mw"), DEFAULT_OPACITY.milkyWay),
   };
 
   const rawVaz = params.get("vaz");
@@ -191,6 +194,9 @@ export function serializeStateToSearchParams(state: AppState): URLSearchParams {
   }
   if (state.opacity.ecliptic !== DEFAULT_OPACITY.ecliptic) {
     params.set("op_ecl", String(Math.round(state.opacity.ecliptic * 100)));
+  }
+  if (state.opacity.milkyWay !== DEFAULT_OPACITY.milkyWay) {
+    params.set("op_mw", String(Math.round(state.opacity.milkyWay * 100)));
   }
 
   if (state.view.az !== DEFAULT_VIEW.az || state.view.alt !== DEFAULT_VIEW.alt) {

--- a/src/ui/layer-controls.test.ts
+++ b/src/ui/layer-controls.test.ts
@@ -17,6 +17,7 @@ const DEFAULT_OPACITY: LayerOpacity = {
   satelliteTrails: 1.0,
   raDecGrid: 0.2,
   ecliptic: 0.4,
+  milkyWay: 0.3,
 };
 
 describe("createLayerControls", () => {
@@ -54,9 +55,9 @@ describe("createLayerControls", () => {
     }
   });
 
-  it("renders opacity sliders for all 5 line layers", () => {
+  it("renders opacity sliders for all 6 line layers", () => {
     const sliders = el.querySelectorAll("input[type='range']");
-    expect(sliders.length).toBe(5);
+    expect(sliders.length).toBe(6);
   });
 
   it("has opacity slider for constellationLines", () => {
@@ -120,6 +121,23 @@ describe("createLayerControls", () => {
     if (intent.type === "set-opacity") {
       expect(intent.layer).toBe("ecliptic");
       expect(intent.value).toBeCloseTo(0.6);
+    }
+  });
+
+  it("has opacity slider for milkyWay", () => {
+    const slider = el.querySelector<HTMLInputElement>("input[data-opacity='milkyWay']");
+    expect(slider).not.toBeNull();
+  });
+
+  it("milkyWay slider dispatches set-opacity with milkyWay key", () => {
+    const slider = el.querySelector<HTMLInputElement>("input[data-opacity='milkyWay']")!;
+    slider.value = "50";
+    slider.dispatchEvent(new Event("input"));
+    const intent = dispatch.mock.calls[0]![0] as UIIntent;
+    expect(intent.type).toBe("set-opacity");
+    if (intent.type === "set-opacity") {
+      expect(intent.layer).toBe("milkyWay");
+      expect(intent.value).toBeCloseTo(0.5);
     }
   });
 

--- a/src/ui/layer-controls.ts
+++ b/src/ui/layer-controls.ts
@@ -27,6 +27,7 @@ const LINE_LAYERS: LineDef[] = [
   { key: "satelliteTrails", label: "Satellite Trails", defaultPct: 30 },
   { key: "raDecGrid", label: "RA/Dec Grid", defaultPct: 20 },
   { key: "ecliptic", label: "Ecliptic", defaultPct: 40 },
+  { key: "milkyWay", label: "Milky Way", defaultPct: 30 },
 ];
 
 export function createLayerControls(


### PR DESCRIPTION
## Summary

- Adds `src/astro/milkyway.ts` with `computeMilkyWayPoints()` — converts 29 predefined RA/Dec key points along the galactic plane to Alt/Az using `fastRaDecToAltAz`, filtering to above-horizon points only
- Adds `src/scene/milkyway.ts` with `MilkyWayLayer` — renders a soft blue-white (`#B0C4DE`) polyline at width 3px with opacity control
- Adds "Milky Way" opacity slider to the line layers section in `layer-controls.ts`
- Adds `milkyWay: number` to `LayerOpacity` with default `0.3`, URL param `op_mw`
- Wires everything into `app.ts` (both sync `doRerender` and worker-accelerated `doRerenderWithWorker` paths)
- Barrel exports in `astro/index.ts` and `scene/index.ts`

## Test plan

- [x] `src/astro/milkyway.test.ts` — 10 tests for point computation (alt/az validity, horizon filter, time-dependence)
- [x] `src/scene/milkyway.test.ts` — 10 tests for layer rendering (polyline width=3, opacity, empty/single point edge cases)
- [x] `src/state/state.test.ts` — 5 new tests for `milkyWay` field default, parse, clamp, round-trip, URL serialization
- [x] `src/ui/layer-controls.test.ts` — 2 new tests for Milky Way slider presence and dispatch
- [x] All 373 tests pass; all gates green (`format`, `typecheck`, `format:check`, `lint`, `test:cov`, `build`)

Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)