### PR TITLE
feat: clickable planet names in Planet Info panel

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -426,7 +426,9 @@ export async function bootstrap(
   function refreshPlanetInfo(s: AppState): void {
     const bodies = computeBodyPositions(s.observer.lat, s.observer.lon, s.timeUtc, false);
     planetInfoWrapper.replaceChildren(
-      createPlanetInfo(bodies, s.observer.lat, s.observer.lon, s.timeUtc),
+      createPlanetInfo(bodies, s.observer.lat, s.observer.lon, s.timeUtc, (az, alt) => {
+        handleIntent({ type: "set-view", az, alt });
+      }),
     );
   }
 

--- a/src/ui/planet-info.test.ts
+++ b/src/ui/planet-info.test.ts
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: Apache-2.0 */
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createPlanetInfo } from "./planet-info";
 import type { CelestialBody } from "../astro/bodies";
 
@@ -158,6 +158,49 @@ describe("createPlanetInfo", () => {
   describe("update", () => {
     it("createPlanetInfo accepts a different body list without throwing", () => {
       expect(() => createPlanetInfo(BODIES_MIXED, LAT, LON, TIME)).not.toThrow();
+    });
+  });
+
+  describe("clickable planet names (onSelect)", () => {
+    it("above-horizon body name has cursor: pointer and textDecoration: underline when onSelect is provided", () => {
+      const onSelect = vi.fn();
+      const el = createPlanetInfo(BODIES_ABOVE, LAT, LON, TIME, onSelect);
+      const rows = el.querySelectorAll("[data-testid='planet-info-row']");
+      const sunRow = [...rows].find((r) => {
+        return r.querySelector("[data-testid='planet-name']")?.textContent === "Sun";
+      });
+      expect(sunRow).toBeDefined();
+      const nameEl = sunRow!.querySelector<HTMLElement>("[data-testid='planet-name']")!;
+      expect(nameEl.style.cursor).toBe("pointer");
+      expect(nameEl.style.textDecoration).toBe("underline");
+    });
+
+    it("clicking above-horizon name calls onSelect with correct az/alt", () => {
+      const onSelect = vi.fn();
+      const el = createPlanetInfo(BODIES_ABOVE, LAT, LON, TIME, onSelect);
+      const rows = el.querySelectorAll("[data-testid='planet-info-row']");
+      const sunRow = [...rows].find((r) => {
+        return r.querySelector("[data-testid='planet-name']")?.textContent === "Sun";
+      });
+      const nameEl = sunRow!.querySelector<HTMLElement>("[data-testid='planet-name']")!;
+      nameEl.click();
+      expect(onSelect).toHaveBeenCalledOnce();
+      expect(onSelect).toHaveBeenCalledWith(180, 55);
+    });
+
+    it("below-horizon body name is not clickable (no underline)", () => {
+      const onSelect = vi.fn();
+      const el = createPlanetInfo(BODIES_MIXED, LAT, LON, TIME, onSelect);
+      const rows = el.querySelectorAll("[data-testid='planet-info-row']");
+      const venusRow = [...rows].find((r) => {
+        return r.querySelector("[data-testid='planet-name']")?.textContent === "Venus";
+      });
+      expect(venusRow).toBeDefined();
+      const nameEl = venusRow!.querySelector<HTMLElement>("[data-testid='planet-name']")!;
+      expect(nameEl.style.cursor).not.toBe("pointer");
+      expect(nameEl.style.textDecoration).not.toBe("underline");
+      nameEl.click();
+      expect(onSelect).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/ui/planet-info.ts
+++ b/src/ui/planet-info.ts
@@ -21,12 +21,15 @@ function formatAltAz(alt: number, az: number): string {
  *
  * Renders a row per body with current Alt/Az, rise time, and set time.
  * Bodies below the horizon are shown with a "below horizon" indicator.
+ * When onSelect is provided, above-horizon body names are clickable and call
+ * onSelect(az, alt) to point the view at that body.
  */
 export function createPlanetInfo(
   bodies: CelestialBody[],
   lat: number,
   lon: number,
   time: Date,
+  onSelect?: (az: number, alt: number) => void,
 ): HTMLElement {
   const section = document.createElement("div");
   section.style.marginBottom = GAP;
@@ -92,6 +95,15 @@ export function createPlanetInfo(
     nameEl.style.fontWeight = "bold";
     nameEl.style.fontSize = "12px";
     nameEl.style.fontFamily = "sans-serif";
+
+    if (celestialBody.alt > 0 && onSelect) {
+      nameEl.style.cursor = "pointer";
+      nameEl.style.textDecoration = "underline";
+      nameEl.addEventListener("click", () => {
+        onSelect(celestialBody.az, celestialBody.alt);
+      });
+    }
+
     nameRow.appendChild(nameEl);
 
     // Below-horizon indicator


### PR DESCRIPTION
## Summary

- Added optional `onSelect?: (az: number, alt: number) => void` parameter to `createPlanetInfo`
- Above-horizon body names get `cursor: pointer` and `textDecoration: underline`; clicking calls `onSelect(body.az, body.alt)`
- Below-horizon bodies remain inert (no underline, no click handler)
- `refreshPlanetInfo` in `app.ts` passes `(az, alt) => handleIntent({ type: "set-view", az, alt })`

## Test plan

- [x] Above-horizon body name has `cursor: pointer` and `textDecoration: underline` when `onSelect` is provided
- [x] Clicking above-horizon name calls `onSelect` with correct az/alt values
- [x] Below-horizon body name is not clickable (no underline, callback not invoked)
- [x] `pnpm format && pnpm typecheck && pnpm format:check && pnpm lint && pnpm test:cov && pnpm build` all pass (415 tests)

Closes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)