### PR TITLE
fix: camera heading direction (remove incorrect reversal)

### DIFF
--- a/src/scene/camera.ts
+++ b/src/scene/camera.ts
@@ -25,7 +25,7 @@ export function setCameraView(
   camera.setView({
     destination: Cartesian3.fromDegrees(lon, lat, height),
     orientation: {
-      heading: CesiumMath.toRadians((360 - azDeg) % 360),
+      heading: CesiumMath.toRadians(azDeg),
       pitch: CesiumMath.toRadians(clampedAlt),
       roll: 0,
     },


### PR DESCRIPTION
The `(360 - azDeg)` reversal in `setCameraView` was wrong — CesiumJS heading
and astronomical azimuth use the same convention (0=N, clockwise). The reversal
caused view buttons and planet info links to point in the wrong direction.