### PR TITLE
fix: only register service worker in production

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,6 @@ import { bootstrap } from "./app";
 
 void bootstrap(document.getElementById("app"));
 
-if ("serviceWorker" in navigator) {
+if ("serviceWorker" in navigator && import.meta.env.PROD) {
   navigator.serviceWorker.register("/sw.js").catch(() => {});
 }


### PR DESCRIPTION
## Summary
Disable service worker registration in development mode to fix caching issues during development.

## Changes
- Modified `src/main.ts` to add `import.meta.env.PROD` check
- Service worker now only registers in production builds
- Development builds (`pnpm dev`) will not register the service worker

Closes #160

## Test Plan
- [x] All format checks pass
- [x] Type checking passes
- [x] Linting passes
- [x] Test coverage passes (92.44% overall)
- [x] Production build succeeds