### PR TITLE
feat: night vision mode toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,6 +26,12 @@
         font-family: monospace;
         padding: 2rem;
       }
+      .night-vision {
+        filter: sepia(1) saturate(3) brightness(0.7) hue-rotate(-30deg);
+      }
+      .night-vision .cesium-widget canvas {
+        filter: sepia(1) saturate(5) brightness(0.6) hue-rotate(-30deg);
+      }
     </style>
   </head>
   <body>

--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -141,6 +141,7 @@ vi.mock("./ui", () => ({
     element: document.createElement("div"),
     setContent: vi.fn(),
     setCollapsed: vi.fn(),
+    setNightVision: vi.fn(),
   }),
   createTimeControls: vi.fn().mockImplementation((_time: unknown, dispatch: unknown) => {
     capturedDispatch = dispatch as (intent: unknown) => void;
@@ -340,6 +341,30 @@ describe("handleIntent routing", () => {
     const { root, panelRoot } = makeRoot();
     await bootstrap(root);
     expect(() => capturedDispatch!({ type: "set-view", az: 180, alt: 30 })).not.toThrow();
+    document.body.removeChild(root);
+    document.body.removeChild(panelRoot);
+  });
+
+  it("toggle-night-vision intent toggles night-vision class on body", async () => {
+    capturedDispatch = null;
+    const { root, panelRoot } = makeRoot();
+    await bootstrap(root);
+    expect(document.body.classList.contains("night-vision")).toBe(false);
+    capturedDispatch!({ type: "toggle-night-vision" });
+    expect(document.body.classList.contains("night-vision")).toBe(true);
+    capturedDispatch!({ type: "toggle-night-vision" });
+    expect(document.body.classList.contains("night-vision")).toBe(false);
+    document.body.removeChild(root);
+    document.body.removeChild(panelRoot);
+  });
+
+  it("nv=1 URL param applies night-vision class and button state on init", async () => {
+    capturedDispatch = null;
+    const { root, panelRoot } = makeRoot();
+    await bootstrap(root, new URLSearchParams({ nv: "1" }));
+    expect(document.body.classList.contains("night-vision")).toBe(true);
+    // clean up
+    document.body.classList.remove("night-vision");
     document.body.removeChild(root);
     document.body.removeChild(panelRoot);
   });

--- a/src/app.ts
+++ b/src/app.ts
@@ -489,13 +489,30 @@ export async function bootstrap(
         updateUrl(state);
         break;
       }
+      case "toggle-night-vision": {
+        state = { ...state, nightVision: !state.nightVision };
+        document.body.classList.toggle("night-vision", state.nightVision);
+        nightVisionPanel?.setNightVision(state.nightVision);
+        updateUrl(state);
+        break;
+      }
     }
   }
 
+  // Apply initial night vision state from URL
+  if (state.nightVision) {
+    document.body.classList.add("night-vision");
+  }
+
   // Build UI panel
+  let nightVisionPanel: ReturnType<typeof createPanel> | null = null;
   const panelRoot = document.getElementById("ui-panel-root");
   if (panelRoot) {
-    const panel = createPanel(panelRoot);
+    const panel = createPanel(panelRoot, handleIntent);
+    nightVisionPanel = panel;
+    if (state.nightVision) {
+      panel.setNightVision(true);
+    }
 
     const uiContainer = document.createElement("div");
 

--- a/src/state/state.test.ts
+++ b/src/state/state.test.ts
@@ -175,3 +175,34 @@ describe("AppState — serialize round-trip with layer fields", () => {
     expect(out.has("op_ecl")).toBe(false);
   });
 });
+
+describe("NightVision — URL round-trip", () => {
+  it("defaults to false when nv param is absent", () => {
+    const s = expectOk(parseStateFromSearchParams(new URLSearchParams()));
+    expect(s.nightVision).toBe(false);
+  });
+
+  it("parses nv=1 as nightVision true", () => {
+    const s = expectOk(parseStateFromSearchParams(new URLSearchParams({ nv: "1" })));
+    expect(s.nightVision).toBe(true);
+  });
+
+  it("does not set nv when nightVision is false", () => {
+    const s = expectOk(parseStateFromSearchParams(new URLSearchParams()));
+    const out = serializeStateToSearchParams(s);
+    expect(out.has("nv")).toBe(false);
+  });
+
+  it("serializes nv=1 when nightVision is true", () => {
+    const s = expectOk(parseStateFromSearchParams(new URLSearchParams({ nv: "1" })));
+    const out = serializeStateToSearchParams(s);
+    expect(out.get("nv")).toBe("1");
+  });
+
+  it("round-trips nightVision=true through serialize/parse", () => {
+    const s = expectOk(parseStateFromSearchParams(new URLSearchParams({ nv: "1" })));
+    const out = serializeStateToSearchParams(s);
+    const s2 = expectOk(parseStateFromSearchParams(out));
+    expect(s2.nightVision).toBe(true);
+  });
+});

--- a/src/state/state.ts
+++ b/src/state/state.ts
@@ -31,6 +31,7 @@ export type AppState = {
   readonly layers: LayerVisibility;
   readonly opacity: LayerOpacity;
   readonly view: ViewDirection;
+  readonly nightVision: boolean;
 };
 
 export type StateParseError =
@@ -73,6 +74,7 @@ export const DEFAULT_STATE: AppState = {
   layers: DEFAULT_LAYERS,
   opacity: DEFAULT_OPACITY,
   view: DEFAULT_VIEW,
+  nightVision: false,
 };
 
 function parseLat(raw: string): Result<number, StateParseError> {
@@ -163,12 +165,15 @@ export function parseStateFromSearchParams(
   const viewAlt =
     rawValt !== null && Number.isFinite(Number(rawValt)) ? Number(rawValt) : DEFAULT_VIEW.alt;
 
+  const nightVision = params.get("nv") === "1";
+
   return ok({
     observer: { lat, lon },
     timeUtc,
     layers,
     opacity,
     view: { az: viewAz, alt: viewAlt },
+    nightVision,
   });
 }
 
@@ -206,6 +211,10 @@ export function serializeStateToSearchParams(state: AppState): URLSearchParams {
   if (state.view.az !== DEFAULT_VIEW.az || state.view.alt !== DEFAULT_VIEW.alt) {
     params.set("vaz", String(Math.round(state.view.az * 10) / 10));
     params.set("valt", String(Math.round(state.view.alt * 10) / 10));
+  }
+
+  if (state.nightVision) {
+    params.set("nv", "1");
   }
 
   return params;

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -15,4 +15,5 @@ export type UIIntent =
   | { type: "set-observer"; lat: number; lon: number }
   | { type: "toggle-layer"; layer: keyof LayerVisibility }
   | { type: "set-opacity"; layer: keyof LayerOpacity; value: number }
-  | { type: "set-view"; az: number; alt: number };
+  | { type: "set-view"; az: number; alt: number }
+  | { type: "toggle-night-vision" };

--- a/src/ui/panel.test.ts
+++ b/src/ui/panel.test.ts
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createPanel } from "./panel";
+import type { UIIntent } from "./index";
 
 describe("createPanel", () => {
   let container: HTMLElement;
@@ -54,6 +55,37 @@ describe("createPanel", () => {
     child.textContent = "hello";
     setContent(child);
     expect(container.querySelector("span")).not.toBeNull();
+  });
+
+  describe("night vision button", () => {
+    it("renders a night-vision button in the header", () => {
+      const { element } = createPanel(container, vi.fn());
+      const btn = element.querySelector("[data-testid='panel-night-vision']");
+      expect(btn).not.toBeNull();
+    });
+
+    it("clicking the night-vision button dispatches toggle-night-vision intent", () => {
+      const dispatch = vi.fn();
+      const { element } = createPanel(container, dispatch);
+      const btn = element.querySelector<HTMLButtonElement>("[data-testid='panel-night-vision']")!;
+      btn.click();
+      expect(dispatch).toHaveBeenCalledWith({ type: "toggle-night-vision" } satisfies UIIntent);
+    });
+
+    it("button glows red when nightVision is true", () => {
+      const { element, setNightVision } = createPanel(container, vi.fn());
+      const btn = element.querySelector<HTMLButtonElement>("[data-testid='panel-night-vision']")!;
+      setNightVision(true);
+      expect(btn.style.boxShadow).toContain("red");
+    });
+
+    it("button reverts style when nightVision is false", () => {
+      const { element, setNightVision } = createPanel(container, vi.fn());
+      const btn = element.querySelector<HTMLButtonElement>("[data-testid='panel-night-vision']")!;
+      setNightVision(true);
+      setNightVision(false);
+      expect(btn.style.boxShadow).toBe("");
+    });
   });
 
   describe("copy-link button", () => {

--- a/src/ui/panel.ts
+++ b/src/ui/panel.ts
@@ -8,14 +8,19 @@ import {
   TEXT_COLOR,
   applyButton,
 } from "./styles";
+import type { UIIntent } from "./index";
 
 export type Panel = {
   element: HTMLElement;
   setContent: (child: HTMLElement) => void;
   setCollapsed: (collapsed: boolean) => void;
+  setNightVision: (on: boolean) => void;
 };
 
-export function createPanel(container: HTMLElement): Panel {
+export function createPanel(
+  container: HTMLElement,
+  dispatch: (intent: UIIntent) => void = () => {},
+): Panel {
   const panel = document.createElement("div");
   panel.style.position = "fixed";
   panel.style.top = "16px";
@@ -50,6 +55,12 @@ export function createPanel(container: HTMLElement): Panel {
   btnGroup.style.gap = "4px";
   btnGroup.style.alignItems = "center";
 
+  const nightVisionBtn = document.createElement("button");
+  nightVisionBtn.dataset.testid = "panel-night-vision";
+  nightVisionBtn.textContent = "🔴";
+  nightVisionBtn.title = "Toggle night vision";
+  applyButton(nightVisionBtn);
+
   const copyLinkBtn = document.createElement("button");
   copyLinkBtn.dataset.testid = "panel-copy-link";
   copyLinkBtn.textContent = "🔗";
@@ -62,6 +73,7 @@ export function createPanel(container: HTMLElement): Panel {
   toggleBtn.title = "Toggle panel";
   applyButton(toggleBtn);
 
+  btnGroup.appendChild(nightVisionBtn);
   btnGroup.appendChild(copyLinkBtn);
   btnGroup.appendChild(toggleBtn);
 
@@ -78,6 +90,10 @@ export function createPanel(container: HTMLElement): Panel {
   container.appendChild(panel);
 
   let collapsed = false;
+
+  nightVisionBtn.addEventListener("click", () => {
+    dispatch({ type: "toggle-night-vision" });
+  });
 
   copyLinkBtn.addEventListener("click", () => {
     const url = window.location.href;
@@ -119,5 +135,15 @@ export function createPanel(container: HTMLElement): Panel {
     body.replaceChildren(child);
   }
 
-  return { element: panel, setContent, setCollapsed };
+  function setNightVision(on: boolean): void {
+    if (on) {
+      nightVisionBtn.style.boxShadow = "0 0 6px 2px red";
+      nightVisionBtn.style.borderColor = "red";
+    } else {
+      nightVisionBtn.style.boxShadow = "";
+      nightVisionBtn.style.borderColor = "";
+    }
+  }
+
+  return { element: panel, setContent, setCollapsed, setNightVision };
 }


### PR DESCRIPTION
## Summary

- Adds a 🔴 button to the panel header that toggles night vision mode on/off
- When active, applies a CSS filter (`sepia(1) saturate(3) brightness(0.7) hue-rotate(-30deg)`) to `document.body` converting all colors to red tones for dark-adapted viewing
- Adds `toggle-night-vision` UIIntent dispatched from the button click
- Adds `nightVision: boolean` to `AppState` with `nv=1` URL parameter for persistence and round-tripping
- Button glows red (box-shadow) when night vision is active

## Test plan

- [x] `panel.test.ts`: night vision button exists in header
- [x] `panel.test.ts`: clicking button dispatches `toggle-night-vision` intent
- [x] `panel.test.ts`: `setNightVision(true)` makes button glow red; `setNightVision(false)` reverts
- [x] `state.test.ts`: `nv=1` parses to `nightVision: true`; absent `nv` defaults to `false`
- [x] `state.test.ts`: `nv=1` serializes and round-trips correctly
- [x] `app.test.ts`: `toggle-night-vision` intent toggles `night-vision` class on body
- [x] `app.test.ts`: `nv=1` URL param applies class on init
- [x] All coverage thresholds met, typecheck clean, lint clean, build passes

Closes #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)