### PR TITLE
feat: object trails (closes #164)

### DIFF
--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -458,4 +458,36 @@ describe("handleIntent routing", () => {
     document.body.removeChild(root);
     document.body.removeChild(panelRoot);
   });
+
+  it("show-trail intent with a valid body id does not throw", async () => {
+    capturedDispatch = null;
+    const { root, panelRoot } = makeRoot();
+    await bootstrap(root);
+    expect(() =>
+      capturedDispatch!({ type: "show-trail", objectKind: "body", id: "Mars" }),
+    ).not.toThrow();
+    document.body.removeChild(root);
+    document.body.removeChild(panelRoot);
+  });
+
+  it("show-trail intent with an unknown id does not throw", async () => {
+    capturedDispatch = null;
+    const { root, panelRoot } = makeRoot();
+    await bootstrap(root);
+    expect(() =>
+      capturedDispatch!({ type: "show-trail", objectKind: "body", id: "NotAPlanet" }),
+    ).not.toThrow();
+    document.body.removeChild(root);
+    document.body.removeChild(panelRoot);
+  });
+
+  it("hide-trail intent after show-trail does not throw", async () => {
+    capturedDispatch = null;
+    const { root, panelRoot } = makeRoot();
+    await bootstrap(root);
+    capturedDispatch!({ type: "show-trail", objectKind: "body", id: "Sun" });
+    expect(() => capturedDispatch!({ type: "hide-trail" })).not.toThrow();
+    document.body.removeChild(root);
+    document.body.removeChild(panelRoot);
+  });
 });

--- a/src/app.ts
+++ b/src/app.ts
@@ -14,6 +14,7 @@ import {
   parseMessier,
   filterVisibleMessier,
   computeMilkyWayPoints,
+  computeBodyTrail,
 } from "./astro";
 import type { StarRecord } from "./astro";
 import { AstroWorkerClient } from "./workers/astro-worker-client";
@@ -33,6 +34,7 @@ import {
   createEclipticLayer,
   createMessierLayer,
   createMilkyWayLayer,
+  createTrailLayer,
   setCameraView,
 } from "./scene";
 import type {
@@ -46,6 +48,7 @@ import type {
   EclipticLayer,
   MessierLayer,
   MilkyWayLayer,
+  TrailLayer,
 } from "./scene";
 import { fetchTle, parseTle, propagateSatellites } from "./sat";
 import type { SatelliteRecord, TleParseError } from "./sat";
@@ -78,7 +81,11 @@ type Layers = {
   ecliptic: EclipticLayer;
   messier: MessierLayer;
   milkyWay: MilkyWayLayer;
+  trail: TrailLayer;
 };
+
+const TRAIL_DURATION_HOURS = 4;
+const TRAIL_STEP_MINUTES = 5;
 
 function applyLayerVisibility(layers: Layers, visibility: LayerVisibility): void {
   layers.star.setVisible(visibility.stars);
@@ -346,7 +353,32 @@ export async function bootstrap(
     ecliptic: createEclipticLayer(viewer.scene),
     messier: createMessierLayer(viewer.scene),
     milkyWay: createMilkyWayLayer(viewer.scene),
+    trail: createTrailLayer(viewer.scene),
   };
+
+  // Current trail selection (ephemeral — not URL-persisted)
+  let trailBodyId: string | null = null;
+
+  function rerenderTrail(s: AppState): void {
+    if (trailBodyId === null) {
+      layers.trail.hide();
+      return;
+    }
+    const result = computeBodyTrail(
+      trailBodyId,
+      s.observer.lat,
+      s.observer.lon,
+      s.timeUtc,
+      TRAIL_DURATION_HOURS,
+      TRAIL_STEP_MINUTES,
+    );
+    if (!result.ok) {
+      layers.trail.hide();
+      return;
+    }
+    layers.trail.setPoints(result.value, s.observer.lat, s.observer.lon);
+    layers.trail.show();
+  }
 
   // Parse static data once
   const constellationResult = parseConstellations(rawConstellations);
@@ -438,9 +470,23 @@ export async function bootstrap(
   function refreshPlanetInfo(s: AppState): void {
     const bodies = computeBodyPositions(s.observer.lat, s.observer.lon, s.timeUtc, false);
     planetInfoWrapper.replaceChildren(
-      createPlanetInfo(bodies, s.observer.lat, s.observer.lon, s.timeUtc, (az, alt) => {
-        handleIntent({ type: "set-view", az, alt });
-      }),
+      createPlanetInfo(
+        bodies,
+        s.observer.lat,
+        s.observer.lon,
+        s.timeUtc,
+        (az, alt) => {
+          handleIntent({ type: "set-view", az, alt });
+        },
+        (id) => {
+          if (trailBodyId === id) {
+            handleIntent({ type: "hide-trail" });
+          } else {
+            handleIntent({ type: "show-trail", objectKind: "body", id });
+          }
+        },
+        trailBodyId,
+      ),
     );
   }
 
@@ -464,6 +510,7 @@ export async function bootstrap(
         scheduleRerender(state);
         refreshPlanetInfo(state);
         rebuildSearchIndex(state);
+        rerenderTrail(state);
         updateUrl(state);
         break;
       }
@@ -473,6 +520,7 @@ export async function bootstrap(
         scheduleRerender(state);
         refreshPlanetInfo(state);
         rebuildSearchIndex(state);
+        rerenderTrail(state);
         updateUrl(state);
         break;
       }
@@ -514,12 +562,25 @@ export async function bootstrap(
         updateUrl(state);
         break;
       }
+      case "show-trail": {
+        trailBodyId = intent.id;
+        rerenderTrail(state);
+        refreshPlanetInfo(state);
+        break;
+      }
+      case "hide-trail": {
+        trailBodyId = null;
+        layers.trail.hide();
+        refreshPlanetInfo(state);
+        break;
+      }
       case "now": {
         const now = new Date();
         state = { ...state, timeUtc: now };
         scheduleRerender(state);
         refreshPlanetInfo(state);
         rebuildSearchIndex(state);
+        rerenderTrail(state);
         updateUrl(state);
         if (navigator.geolocation) {
           navigator.geolocation.getCurrentPosition(
@@ -530,6 +591,7 @@ export async function bootstrap(
               scheduleRerender(state);
               refreshPlanetInfo(state);
               rebuildSearchIndex(state);
+              rerenderTrail(state);
               updateUrl(state);
             },
             () => {

--- a/src/astro/index.ts
+++ b/src/astro/index.ts
@@ -32,3 +32,4 @@ export {
   filterVisibleMessier,
 } from "./messier";
 export { computeMilkyWayPoints } from "./milkyway";
+export { type TrailError, computeBodyTrail } from "./trails";

--- a/src/astro/trails.test.ts
+++ b/src/astro/trails.test.ts
@@ -1,0 +1,68 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { describe, expect, it } from "vitest";
+import { computeBodyTrail } from "./trails";
+
+describe("computeBodyTrail", () => {
+  it("returns a non-empty array of alt/az points for a known body", () => {
+    const result = computeBodyTrail("Sun", 33, -117, new Date("2026-06-15T12:00:00Z"), 4, 5);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.length).toBeGreaterThan(0);
+    for (const pt of result.value) {
+      expect(pt).toHaveProperty("alt");
+      expect(pt).toHaveProperty("az");
+      expect(Number.isFinite(pt.alt)).toBe(true);
+      expect(Number.isFinite(pt.az)).toBe(true);
+    }
+  });
+
+  it("returns err for an unknown body id", () => {
+    const result = computeBodyTrail("Pluto", 33, -117, new Date("2026-06-15T12:00:00Z"), 4, 5);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.kind).toBe("unknown-body");
+  });
+
+  it("returns N+1 points over N durationHours at 60-minute step", () => {
+    // 4 hours, 60-min step => 0, 1, 2, 3, 4 = 5 points
+    const result = computeBodyTrail("Sun", 33, -117, new Date("2026-06-15T12:00:00Z"), 4, 60);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value).toHaveLength(5);
+  });
+
+  it("Sun trail moves westward across the sky during daytime", () => {
+    // At local noon on summer solstice lat 33 lon -117, Sun is high and moving W.
+    // Local noon for lon=-117 is ~19:00 UTC.
+    const result = computeBodyTrail("Sun", 33, -117, new Date("2026-06-15T19:00:00Z"), 2, 30);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const pts = result.value;
+    // Azimuth should advance monotonically (S -> W is increasing az from 180 -> 270)
+    // Pick first and last, check last azimuth is greater than first.
+    expect(pts[pts.length - 1]!.az).toBeGreaterThan(pts[0]!.az);
+  });
+
+  it("is deterministic for same inputs", () => {
+    const a = computeBodyTrail("Jupiter", 40, -74, new Date("2026-03-15T22:00:00Z"), 3, 15);
+    const b = computeBodyTrail("Jupiter", 40, -74, new Date("2026-03-15T22:00:00Z"), 3, 15);
+    expect(a.ok).toBe(true);
+    expect(b.ok).toBe(true);
+    if (!a.ok || !b.ok) return;
+    expect(a.value).toEqual(b.value);
+  });
+
+  it("rejects zero or negative durationHours", () => {
+    const r = computeBodyTrail("Sun", 33, -117, new Date("2026-06-15T12:00:00Z"), 0, 5);
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.error.kind).toBe("invalid-duration");
+  });
+
+  it("rejects zero or negative stepMinutes", () => {
+    const r = computeBodyTrail("Sun", 33, -117, new Date("2026-06-15T12:00:00Z"), 4, 0);
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.error.kind).toBe("invalid-step");
+  });
+});

--- a/src/astro/trails.ts
+++ b/src/astro/trails.ts
@@ -1,0 +1,55 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { Body, Equator, MakeTime, Observer } from "astronomy-engine";
+import { err, ok, type Result } from "../result";
+import { raDecToAltAz, type HorizontalCoord } from "./coords";
+
+export type TrailError =
+  | { kind: "unknown-body"; id: string }
+  | { kind: "invalid-duration"; value: number }
+  | { kind: "invalid-step"; value: number };
+
+const BODY_MAP: Record<string, Body> = {
+  Sun: Body.Sun,
+  Moon: Body.Moon,
+  Mercury: Body.Mercury,
+  Venus: Body.Venus,
+  Mars: Body.Mars,
+  Jupiter: Body.Jupiter,
+  Saturn: Body.Saturn,
+};
+
+/**
+ * Compute a body's future path across the sky as a series of alt/az points.
+ *
+ * Samples every `stepMinutes` from `startTime` through `startTime + durationHours`.
+ * Returns (N + 1) points where N = floor(durationHours * 60 / stepMinutes).
+ */
+export function computeBodyTrail(
+  id: string,
+  lat: number,
+  lon: number,
+  startTime: Date,
+  durationHours: number,
+  stepMinutes: number,
+): Result<HorizontalCoord[], TrailError> {
+  const body = BODY_MAP[id];
+  if (body === undefined) return err({ kind: "unknown-body", id });
+  if (!(durationHours > 0)) return err({ kind: "invalid-duration", value: durationHours });
+  if (!(stepMinutes > 0)) return err({ kind: "invalid-step", value: stepMinutes });
+
+  const observer = new Observer(lat, lon, 0);
+  const totalMinutes = durationHours * 60;
+  const steps = Math.floor(totalMinutes / stepMinutes);
+  const points: HorizontalCoord[] = [];
+
+  for (let i = 0; i <= steps; i++) {
+    const t = new Date(startTime.getTime() + i * stepMinutes * 60_000);
+    const astroTime = MakeTime(t);
+    const eq = Equator(body, astroTime, observer, true, true);
+    const raDeg = eq.ra * 15;
+    const { alt, az } = raDecToAltAz(raDeg, eq.dec, lat, lon, t);
+    points.push({ alt, az });
+  }
+
+  return ok(points);
+}

--- a/src/scene/index.ts
+++ b/src/scene/index.ts
@@ -12,3 +12,4 @@ export { type GridLayer, createGridLayer } from "./grid";
 export { type EclipticLayer, createEclipticLayer } from "./ecliptic";
 export { type MessierLayer, createMessierLayer } from "./messier";
 export { type MilkyWayLayer, createMilkyWayLayer } from "./milkyway";
+export { type TrailLayer, createTrailLayer } from "./trail-layer";

--- a/src/scene/trail-layer.test.ts
+++ b/src/scene/trail-layer.test.ts
@@ -1,0 +1,147 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createTrailLayer } from "./trail-layer";
+import type { HorizontalCoord } from "../astro/coords";
+
+const mockPolylineAdd = vi.fn();
+const mockPolylineRemoveAll = vi.fn();
+const mockPolylines: Array<{ material: { uniforms: { color: { alpha: number } } } }> = [];
+
+vi.mock("cesium", () => {
+  const MockCartesian3 = vi.fn().mockImplementation((x: number, y: number, z: number) => ({
+    x,
+    y,
+    z,
+  }));
+  (MockCartesian3 as unknown as { fromDegrees: ReturnType<typeof vi.fn> }).fromDegrees = vi
+    .fn()
+    .mockReturnValue({ x: 1, y: 2, z: 3 });
+
+  const makeMaterial = (): { uniforms: { color: { alpha: number } } } => ({
+    uniforms: { color: { alpha: 1 } },
+  });
+
+  return {
+    PolylineCollection: vi.fn().mockImplementation(() => ({
+      add: (opts: Record<string, unknown>) => {
+        mockPolylineAdd(opts);
+        const polyline = { material: makeMaterial(), ...opts };
+        mockPolylines.push(polyline as never);
+        return polyline;
+      },
+      removeAll: () => {
+        mockPolylineRemoveAll();
+        mockPolylines.length = 0;
+      },
+      show: true,
+    })),
+    Cartesian3: MockCartesian3,
+    Color: {
+      WHITE: { withAlpha: (a: number) => ({ r: 1, g: 1, b: 1, alpha: a }) },
+      fromCssColorString: vi.fn().mockReturnValue({
+        withAlpha: (a: number) => ({ alpha: a }),
+      }),
+    },
+    Math: { toRadians: (d: number) => (d * Math.PI) / 180 },
+    Transforms: {
+      eastNorthUpToFixedFrame: vi
+        .fn()
+        .mockReturnValue([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]),
+    },
+    Matrix4: {
+      multiplyByPoint: vi.fn().mockReturnValue({ x: 10, y: 20, z: 30 }),
+    },
+    Material: {
+      fromType: vi.fn().mockImplementation(() => ({ uniforms: { color: { alpha: 1 } } })),
+    },
+  };
+});
+
+function makeMockScene() {
+  return { primitives: { add: vi.fn() } };
+}
+
+const SAMPLE: HorizontalCoord[] = [
+  { alt: 45, az: 180 },
+  { alt: 40, az: 190 },
+  { alt: 35, az: 200 },
+  { alt: 30, az: 210 },
+];
+
+beforeEach(() => {
+  mockPolylineAdd.mockClear();
+  mockPolylineRemoveAll.mockClear();
+  mockPolylines.length = 0;
+});
+
+describe("createTrailLayer", () => {
+  it("returns an object with show, hide, and setPoints methods", () => {
+    const layer = createTrailLayer(makeMockScene() as never);
+    expect(layer).toHaveProperty("show");
+    expect(layer).toHaveProperty("hide");
+    expect(layer).toHaveProperty("setPoints");
+  });
+
+  it("registers PolylineCollection with scene.primitives", () => {
+    const scene = makeMockScene();
+    createTrailLayer(scene as never);
+    expect(scene.primitives.add).toHaveBeenCalledTimes(1);
+  });
+
+  it("setPoints adds a single polyline for sample points", () => {
+    const layer = createTrailLayer(makeMockScene() as never);
+    layer.setPoints(SAMPLE, 33, -117);
+    expect(mockPolylineRemoveAll).toHaveBeenCalledOnce();
+    expect(mockPolylineAdd).toHaveBeenCalledTimes(1);
+  });
+
+  it("setPoints with empty array adds no polyline", () => {
+    const layer = createTrailLayer(makeMockScene() as never);
+    layer.setPoints([], 0, 0);
+    expect(mockPolylineAdd).not.toHaveBeenCalled();
+  });
+
+  it("setPoints with a single point adds no polyline", () => {
+    const layer = createTrailLayer(makeMockScene() as never);
+    layer.setPoints([{ alt: 45, az: 180 }], 33, -117);
+    expect(mockPolylineAdd).not.toHaveBeenCalled();
+  });
+
+  it("setPoints clears previous polyline before adding new one", () => {
+    const layer = createTrailLayer(makeMockScene() as never);
+    layer.setPoints(SAMPLE, 33, -117);
+    mockPolylineAdd.mockClear();
+    mockPolylineRemoveAll.mockClear();
+    layer.setPoints(SAMPLE.slice(0, 3), 33, -117);
+    expect(mockPolylineRemoveAll).toHaveBeenCalledOnce();
+    expect(mockPolylineAdd).toHaveBeenCalledTimes(1);
+  });
+
+  it("hide() does not throw", () => {
+    const layer = createTrailLayer(makeMockScene() as never);
+    layer.setPoints(SAMPLE, 33, -117);
+    expect(() => layer.hide()).not.toThrow();
+  });
+
+  it("show() does not throw", () => {
+    const layer = createTrailLayer(makeMockScene() as never);
+    layer.setPoints(SAMPLE, 33, -117);
+    layer.hide();
+    expect(() => layer.show()).not.toThrow();
+  });
+
+  it("hide() before setPoints does not throw", () => {
+    const layer = createTrailLayer(makeMockScene() as never);
+    expect(() => layer.hide()).not.toThrow();
+  });
+
+  it("uses a dashed material so trail is visually distinct", () => {
+    const layer = createTrailLayer(makeMockScene() as never);
+    layer.setPoints(SAMPLE, 33, -117);
+    // The polyline should have been configured with a Material (dashed or polyline-specific).
+    // At minimum, the add call should include a material option.
+    const call = mockPolylineAdd.mock.calls[0]?.[0] as Record<string, unknown> | undefined;
+    expect(call).toBeDefined();
+    expect(call!.material).toBeDefined();
+  });
+});

--- a/src/scene/trail-layer.ts
+++ b/src/scene/trail-layer.ts
@@ -1,0 +1,52 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { PolylineCollection, Color, Material } from "cesium";
+import type { Scene } from "cesium";
+import type { HorizontalCoord } from "../astro/coords";
+import { altAzToCartesian } from "./stars";
+
+export type TrailLayer = {
+  setPoints: (points: readonly HorizontalCoord[], lat: number, lon: number) => void;
+  show: () => void;
+  hide: () => void;
+};
+
+const TRAIL_COLOR = Color.fromCssColorString("#6cf");
+const DASH_GAP_COLOR = Color.fromCssColorString("#000000");
+
+/**
+ * Layer that renders a dashed polyline for an object's future path across the sky.
+ *
+ * Rendered as a single polyline using the built-in "PolylineDash" Cesium material so
+ * the path looks dotted/dashed — visually distinct from the solid ecliptic/grid lines.
+ */
+export function createTrailLayer(scene: Scene): TrailLayer {
+  const polylines = new PolylineCollection();
+  scene.primitives.add(polylines);
+
+  function setPoints(points: readonly HorizontalCoord[], lat: number, lon: number): void {
+    polylines.removeAll();
+    if (points.length < 2) return;
+
+    const positions = points.map((pt) => altAzToCartesian(pt.alt, pt.az, lat, lon));
+    polylines.add({
+      positions,
+      width: 2,
+      material: Material.fromType("PolylineDash", {
+        color: TRAIL_COLOR,
+        gapColor: DASH_GAP_COLOR.withAlpha(0),
+        dashLength: 16,
+      }),
+    });
+    (polylines as unknown as { show: boolean }).show = true;
+  }
+
+  function show(): void {
+    (polylines as unknown as { show: boolean }).show = true;
+  }
+
+  function hide(): void {
+    (polylines as unknown as { show: boolean }).show = false;
+  }
+
+  return { setPoints, show, hide };
+}

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -18,4 +18,6 @@ export type UIIntent =
   | { type: "set-view"; az: number; alt: number }
   | { type: "toggle-night-vision" }
   | { type: "set-mag-limit"; value: number }
+  | { type: "show-trail"; objectKind: "body"; id: string }
+  | { type: "hide-trail" }
   | { type: "now" };

--- a/src/ui/planet-info.test.ts
+++ b/src/ui/planet-info.test.ts
@@ -203,4 +203,51 @@ describe("createPlanetInfo", () => {
       expect(onSelect).not.toHaveBeenCalled();
     });
   });
+
+  describe("show-trail button (onShowTrail)", () => {
+    it("renders a 'Show path' button for above-horizon bodies when onShowTrail is provided", () => {
+      const onShowTrail = vi.fn();
+      const el = createPlanetInfo(BODIES_ABOVE, LAT, LON, TIME, undefined, onShowTrail, null);
+      const buttons = el.querySelectorAll("[data-testid='planet-show-trail']");
+      expect(buttons.length).toBe(BODIES_ABOVE.length);
+    });
+
+    it("does not render a 'Show path' button for below-horizon bodies", () => {
+      const onShowTrail = vi.fn();
+      const el = createPlanetInfo(BODIES_MIXED, LAT, LON, TIME, undefined, onShowTrail, null);
+      const rows = el.querySelectorAll("[data-testid='planet-info-row']");
+      const venusRow = [...rows].find(
+        (r) => r.querySelector("[data-testid='planet-name']")?.textContent === "Venus",
+      )!;
+      expect(venusRow.querySelector("[data-testid='planet-show-trail']")).toBeNull();
+    });
+
+    it("clicking 'Show path' calls onShowTrail with the body id", () => {
+      const onShowTrail = vi.fn();
+      const el = createPlanetInfo(BODIES_ABOVE, LAT, LON, TIME, undefined, onShowTrail, null);
+      const rows = el.querySelectorAll("[data-testid='planet-info-row']");
+      const marsRow = [...rows].find(
+        (r) => r.querySelector("[data-testid='planet-name']")?.textContent === "Mars",
+      )!;
+      const btn = marsRow.querySelector<HTMLButtonElement>("[data-testid='planet-show-trail']")!;
+      btn.click();
+      expect(onShowTrail).toHaveBeenCalledWith("Mars");
+    });
+
+    it("when trailBodyId matches, button text becomes 'Hide path'", () => {
+      const onShowTrail = vi.fn();
+      const el = createPlanetInfo(BODIES_ABOVE, LAT, LON, TIME, undefined, onShowTrail, "Mars");
+      const rows = el.querySelectorAll("[data-testid='planet-info-row']");
+      const marsRow = [...rows].find(
+        (r) => r.querySelector("[data-testid='planet-name']")?.textContent === "Mars",
+      )!;
+      const btn = marsRow.querySelector<HTMLButtonElement>("[data-testid='planet-show-trail']")!;
+      expect(btn.textContent?.toLowerCase()).toContain("hide");
+    });
+
+    it("does not render the button when onShowTrail is undefined", () => {
+      const el = createPlanetInfo(BODIES_ABOVE, LAT, LON, TIME);
+      expect(el.querySelectorAll("[data-testid='planet-show-trail']").length).toBe(0);
+    });
+  });
 });

--- a/src/ui/planet-info.ts
+++ b/src/ui/planet-info.ts
@@ -23,6 +23,8 @@ function formatAltAz(alt: number, az: number): string {
  * Bodies below the horizon are shown with a "below horizon" indicator.
  * When onSelect is provided, above-horizon body names are clickable and call
  * onSelect(az, alt) to point the view at that body.
+ * When onShowTrail is provided, above-horizon bodies get a "Show path" button.
+ * The button flips to "Hide path" when trailBodyId equals that body's id.
  */
 export function createPlanetInfo(
   bodies: CelestialBody[],
@@ -30,6 +32,8 @@ export function createPlanetInfo(
   lon: number,
   time: Date,
   onSelect?: (az: number, alt: number) => void,
+  onShowTrail?: (id: string) => void,
+  trailBodyId?: string | null,
 ): HTMLElement {
   const section = document.createElement("div");
   section.style.marginBottom = GAP;
@@ -152,6 +156,27 @@ export function createPlanetInfo(
     riseSetRow.appendChild(setEl);
 
     row.appendChild(riseSetRow);
+
+    if (celestialBody.alt > 0 && onShowTrail) {
+      const trailBtn = document.createElement("button");
+      trailBtn.dataset.testid = "planet-show-trail";
+      const active = trailBodyId === celestialBody.id;
+      trailBtn.textContent = active ? "Hide path" : "Show path";
+      trailBtn.style.marginTop = "4px";
+      trailBtn.style.padding = "2px 6px";
+      trailBtn.style.fontSize = "11px";
+      trailBtn.style.fontFamily = "sans-serif";
+      trailBtn.style.background = active ? "rgba(100,160,255,0.25)" : "rgba(255,255,255,0.08)";
+      trailBtn.style.color = TEXT_COLOR;
+      trailBtn.style.border = "1px solid rgba(255,255,255,0.2)";
+      trailBtn.style.borderRadius = "3px";
+      trailBtn.style.cursor = "pointer";
+      trailBtn.addEventListener("click", () => {
+        onShowTrail(celestialBody.id);
+      });
+      row.appendChild(trailBtn);
+    }
+
     body.appendChild(row);
   }
 


### PR DESCRIPTION
## Summary
- Adds a pure `computeBodyTrail` (Result<HorizontalCoord[], TrailError>) in `src/astro/trails.ts` that time-steps a body's alt/az over N hours using Astronomy Engine.
- New `src/scene/trail-layer.ts` renders the alt/az points as a dotted polyline (Cesium `PolylineDash` material) — visually distinct from ecliptic/grid lines.
- Planet Info panel now shows a per-row "Show path" / "Hide path" button for above-horizon bodies; clicking dispatches `show-trail` / `hide-trail` intents wired up in `app.ts`.
- Trail is re-rendered automatically when time or observer changes. State is intentionally ephemeral (not URL-persisted) per the note in the issue brief.

## Design notes
- Defaults: 4 hours ahead, 5-minute steps.
- Module boundaries respected: `astro/trails.ts` is pure and framework-free; Cesium import only in `scene/trail-layer.ts`; `ui/planet-info.ts` dispatches intents only.
- Intent shape is `{ type: "show-trail"; objectKind: "body"; id: string }` so the `"satellite"` variant can slot in without a breaking change.
- Satellite trails deferred as follow-up — the tooltip entry point for satellites would need pinned-tooltip click handling, which was out of scope to keep this PR tight.

## Coverage
- `astro/trails.ts`: 100% lines / 100% branches
- `scene/trail-layer.ts`: 100% lines / 100% branches
- `ui/planet-info.ts`: 100% lines / 95% branches
- `app.ts`: 92.6% (above 80% gate)
- Project floor still green; no thresholds lowered.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test` (483 tests pass, +25 new)
- [x] `pnpm test:cov` (no threshold regressions)
- [x] `pnpm build`
- [ ] Manual: open app, click Show path next to Mars, verify a dashed arc appears; scrub time forward, arc updates; click Hide path, arc goes away.

🤖 Generated with [Claude Code](https://claude.com/claude-code)