### PR TITLE
feat: telescope FOV overlay reticle (closes #168)

### DIFF
--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -16,7 +16,15 @@ vi.mock("./workers/astro-worker-client", () => {
   };
 });
 
-vi.mock("cesium", () => ({
+vi.mock("cesium", () => {
+  const mockCamera = {
+    setView: vi.fn(),
+    direction: { x: 0, y: 0, z: 1 },
+    up: { x: 0, y: 1, z: 0 },
+    right: { x: 1, y: 0, z: 0 },
+    frustum: { fovy: Math.PI / 3, fov: Math.PI / 3 },
+  };
+  return {
   Viewer: vi.fn().mockImplementation(() => ({
     scene: {
       skyBox: undefined,
@@ -27,6 +35,7 @@ vi.mock("cesium", () => ({
       globe: { show: true },
       primitives: { add: vi.fn() },
       canvas: document.createElement("canvas"),
+      camera: mockCamera,
       screenSpaceCameraController: {
         enableRotate: true,
         enableTranslate: true,
@@ -36,12 +45,7 @@ vi.mock("cesium", () => ({
       },
     },
     imageryLayers: { removeAll: vi.fn() },
-    camera: {
-      setView: vi.fn(),
-      direction: { x: 0, y: 0, z: 1 },
-      up: { x: 0, y: 1, z: 0 },
-      right: { x: 1, y: 0, z: 0 },
-    },
+    camera: mockCamera,
     destroy: vi.fn(),
   })),
   BillboardCollection: vi.fn().mockImplementation(() => ({
@@ -66,7 +70,10 @@ vi.mock("cesium", () => ({
     }),
   },
   Ion: { defaultAccessToken: "" },
-  Math: { toRadians: (d: number) => (d * Math.PI) / 180 },
+  Math: {
+    toRadians: (d: number) => (d * Math.PI) / 180,
+    toDegrees: (r: number) => (r * 180) / Math.PI,
+  },
   HorizontalOrigin: { CENTER: 0 },
   VerticalOrigin: { CENTER: 0 },
   Transforms: {
@@ -106,7 +113,8 @@ vi.mock("cesium", () => ({
   })),
   LabelStyle: { FILL: 0 },
   Material: { fromType: vi.fn().mockReturnValue({ uniforms: { color: { alpha: 1 } } }) },
-}));
+  };
+});
 
 vi.mock("../data/stars.json", () => ({
   default: [
@@ -152,6 +160,7 @@ vi.mock("./ui", () => ({
   createViewControls: vi.fn().mockReturnValue(document.createElement("div")),
   createPlanetInfo: vi.fn().mockReturnValue(document.createElement("div")),
   createSearch: vi.fn().mockReturnValue(document.createElement("div")),
+  createFovControls: vi.fn().mockReturnValue(document.createElement("div")),
 }));
 
 // Mock the TLE bundled data
@@ -515,6 +524,16 @@ describe("handleIntent routing", () => {
     await bootstrap(root);
     capturedDispatch!({ type: "show-trail", objectKind: "body", id: "Sun" });
     expect(() => capturedDispatch!({ type: "hide-trail" })).not.toThrow();
+    document.body.removeChild(root);
+    document.body.removeChild(panelRoot);
+  });
+
+  it("set-fov intent updates reticle preset without throwing", async () => {
+    capturedDispatch = null;
+    const { root, panelRoot } = makeRoot();
+    await bootstrap(root);
+    expect(() => capturedDispatch!({ type: "set-fov", preset: "binoculars" })).not.toThrow();
+    expect(() => capturedDispatch!({ type: "set-fov", preset: "off" })).not.toThrow();
     document.body.removeChild(root);
     document.body.removeChild(panelRoot);
   });

--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -25,94 +25,94 @@ vi.mock("cesium", () => {
     frustum: { fovy: Math.PI / 3, fov: Math.PI / 3 },
   };
   return {
-  Viewer: vi.fn().mockImplementation(() => ({
-    scene: {
-      skyBox: undefined,
-      skyAtmosphere: undefined,
-      sun: { show: true },
-      moon: { show: true },
-      backgroundColor: { red: 0, green: 0, blue: 0, alpha: 1 },
-      globe: { show: true },
-      primitives: { add: vi.fn() },
-      canvas: document.createElement("canvas"),
-      camera: mockCamera,
-      screenSpaceCameraController: {
-        enableRotate: true,
-        enableTranslate: true,
-        enableZoom: true,
-        enableTilt: true,
-        enableLook: true,
+    Viewer: vi.fn().mockImplementation(() => ({
+      scene: {
+        skyBox: undefined,
+        skyAtmosphere: undefined,
+        sun: { show: true },
+        moon: { show: true },
+        backgroundColor: { red: 0, green: 0, blue: 0, alpha: 1 },
+        globe: { show: true },
+        primitives: { add: vi.fn() },
+        canvas: document.createElement("canvas"),
+        camera: mockCamera,
+        screenSpaceCameraController: {
+          enableRotate: true,
+          enableTranslate: true,
+          enableZoom: true,
+          enableTilt: true,
+          enableLook: true,
+        },
       },
+      imageryLayers: { removeAll: vi.fn() },
+      camera: mockCamera,
+      destroy: vi.fn(),
+    })),
+    BillboardCollection: vi.fn().mockImplementation(() => ({
+      add: vi.fn(),
+      removeAll: vi.fn(),
+      show: true,
+      length: 0,
+    })),
+    Cartesian3: Object.assign(
+      vi.fn().mockImplementation((x: number, y: number, z: number) => ({ x, y, z })),
+      {
+        fromDegrees: vi.fn().mockReturnValue({ x: 0, y: 0, z: 0 }),
+        cross: vi.fn((a: object, _b: object, result: object) => Object.assign(result, a)),
+        normalize: vi.fn((_v: object, result: object) => result),
+      },
+    ),
+    Color: {
+      BLACK: { clone: () => ({ red: 0, green: 0, blue: 0, alpha: 1 }) },
+      WHITE: { withAlpha: (a: number) => ({ red: 1, green: 1, blue: 1, alpha: a }) },
+      fromCssColorString: vi.fn().mockReturnValue({
+        withAlpha: (a: number) => ({ alpha: a }),
+      }),
     },
-    imageryLayers: { removeAll: vi.fn() },
-    camera: mockCamera,
-    destroy: vi.fn(),
-  })),
-  BillboardCollection: vi.fn().mockImplementation(() => ({
-    add: vi.fn(),
-    removeAll: vi.fn(),
-    show: true,
-    length: 0,
-  })),
-  Cartesian3: Object.assign(
-    vi.fn().mockImplementation((x: number, y: number, z: number) => ({ x, y, z })),
-    {
-      fromDegrees: vi.fn().mockReturnValue({ x: 0, y: 0, z: 0 }),
-      cross: vi.fn((a: object, _b: object, result: object) => Object.assign(result, a)),
-      normalize: vi.fn((_v: object, result: object) => result),
+    Ion: { defaultAccessToken: "" },
+    Math: {
+      toRadians: (d: number) => (d * Math.PI) / 180,
+      toDegrees: (r: number) => (r * 180) / Math.PI,
     },
-  ),
-  Color: {
-    BLACK: { clone: () => ({ red: 0, green: 0, blue: 0, alpha: 1 }) },
-    WHITE: { withAlpha: (a: number) => ({ red: 1, green: 1, blue: 1, alpha: a }) },
-    fromCssColorString: vi.fn().mockReturnValue({
-      withAlpha: (a: number) => ({ alpha: a }),
-    }),
-  },
-  Ion: { defaultAccessToken: "" },
-  Math: {
-    toRadians: (d: number) => (d * Math.PI) / 180,
-    toDegrees: (r: number) => (r * 180) / Math.PI,
-  },
-  HorizontalOrigin: { CENTER: 0 },
-  VerticalOrigin: { CENTER: 0 },
-  Transforms: {
-    eastNorthUpToFixedFrame: vi
-      .fn()
-      .mockReturnValue([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]),
-  },
-  Matrix4: {
-    multiplyByPoint: vi.fn().mockReturnValue({ x: 10, y: 20, z: 30 }),
-  },
-  ScreenSpaceEventHandler: vi.fn().mockImplementation(() => ({
-    setInputAction: vi.fn(),
-    destroy: vi.fn(),
-  })),
-  ScreenSpaceEventType: { MOUSE_MOVE: 0, LEFT_DOWN: 1, LEFT_UP: 2 },
-  Matrix3: {
-    fromQuaternion: vi.fn().mockReturnValue({}),
-    multiplyByVector: vi.fn().mockReturnValue({ x: 0, y: 0, z: 1 }),
-  },
-  Quaternion: {
-    fromAxisAngle: vi.fn().mockReturnValue({}),
-    multiply: vi.fn().mockReturnValue({}),
-  },
-  defined: (v: unknown) => v !== undefined && v !== null,
-  PolylineCollection: vi.fn().mockImplementation(() => ({
-    add: vi.fn().mockReturnValue({ material: { uniforms: { color: { alpha: 1 } } } }),
-    removeAll: vi.fn(),
-    get length() {
-      return 0;
+    HorizontalOrigin: { CENTER: 0 },
+    VerticalOrigin: { CENTER: 0 },
+    Transforms: {
+      eastNorthUpToFixedFrame: vi
+        .fn()
+        .mockReturnValue([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]),
     },
-    show: true,
-  })),
-  LabelCollection: vi.fn().mockImplementation(() => ({
-    add: vi.fn(),
-    removeAll: vi.fn(),
-    show: true,
-  })),
-  LabelStyle: { FILL: 0 },
-  Material: { fromType: vi.fn().mockReturnValue({ uniforms: { color: { alpha: 1 } } }) },
+    Matrix4: {
+      multiplyByPoint: vi.fn().mockReturnValue({ x: 10, y: 20, z: 30 }),
+    },
+    ScreenSpaceEventHandler: vi.fn().mockImplementation(() => ({
+      setInputAction: vi.fn(),
+      destroy: vi.fn(),
+    })),
+    ScreenSpaceEventType: { MOUSE_MOVE: 0, LEFT_DOWN: 1, LEFT_UP: 2 },
+    Matrix3: {
+      fromQuaternion: vi.fn().mockReturnValue({}),
+      multiplyByVector: vi.fn().mockReturnValue({ x: 0, y: 0, z: 1 }),
+    },
+    Quaternion: {
+      fromAxisAngle: vi.fn().mockReturnValue({}),
+      multiply: vi.fn().mockReturnValue({}),
+    },
+    defined: (v: unknown) => v !== undefined && v !== null,
+    PolylineCollection: vi.fn().mockImplementation(() => ({
+      add: vi.fn().mockReturnValue({ material: { uniforms: { color: { alpha: 1 } } } }),
+      removeAll: vi.fn(),
+      get length() {
+        return 0;
+      },
+      show: true,
+    })),
+    LabelCollection: vi.fn().mockImplementation(() => ({
+      add: vi.fn(),
+      removeAll: vi.fn(),
+      show: true,
+    })),
+    LabelStyle: { FILL: 0 },
+    Material: { fromType: vi.fn().mockReturnValue({ uniforms: { color: { alpha: 1 } } }) },
   };
 });
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -36,6 +36,7 @@ import {
   createMessierLayer,
   createMilkyWayLayer,
   createTrailLayer,
+  createReticleLayer,
   setCameraView,
 } from "./scene";
 import type {
@@ -50,6 +51,7 @@ import type {
   MessierLayer,
   MilkyWayLayer,
   TrailLayer,
+  ReticleLayer,
 } from "./scene";
 import { fetchTle, parseTle, propagateSatellites } from "./sat";
 import type { SatelliteRecord, TleParseError } from "./sat";
@@ -62,6 +64,7 @@ import {
   createViewControls,
   createPlanetInfo,
   createSearch,
+  createFovControls,
 } from "./ui";
 import type { UIIntent } from "./ui";
 import { buildSearchIndex, searchObjects } from "./astro/search";
@@ -106,6 +109,7 @@ type Layers = {
   messier: MessierLayer;
   milkyWay: MilkyWayLayer;
   trail: TrailLayer;
+  reticle: ReticleLayer | null;
 };
 
 const TRAIL_DURATION_HOURS = 4;
@@ -366,6 +370,7 @@ export async function bootstrap(
   setupTrackballControls(viewer);
 
   // Create all layers
+  const cesiumContainerEl = document.getElementById("cesium-container");
   const layers: Layers = {
     star: createStarLayer(viewer.scene),
     body: createBodyLayer(viewer.scene),
@@ -378,7 +383,11 @@ export async function bootstrap(
     messier: createMessierLayer(viewer.scene),
     milkyWay: createMilkyWayLayer(viewer.scene),
     trail: createTrailLayer(viewer.scene),
+    reticle: cesiumContainerEl ? createReticleLayer(viewer.scene, cesiumContainerEl) : null,
   };
+
+  // Apply initial reticle preset from URL state
+  layers.reticle?.setPreset(state.fov);
 
   // Current trail selection (ephemeral — not URL-persisted)
   let trailBodyId: string | null = null;
@@ -609,6 +618,12 @@ export async function bootstrap(
         updateUrl(state);
         break;
       }
+      case "set-fov": {
+        state = { ...state, fov: intent.preset };
+        layers.reticle?.setPreset(intent.preset);
+        updateUrl(state);
+        break;
+      }
       case "now": {
         const now = new Date();
         state = { ...state, timeUtc: now };
@@ -668,6 +683,9 @@ export async function bootstrap(
 
     const viewEl = createViewControls(0, 89.9, handleIntent);
     uiContainer.appendChild(viewEl);
+
+    const fovEl = createFovControls(state.fov, handleIntent);
+    uiContainer.appendChild(fovEl);
 
     const layerEl = createLayerControls(
       state.layers,

--- a/src/astro/fov-presets.test.ts
+++ b/src/astro/fov-presets.test.ts
@@ -1,0 +1,84 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { describe, expect, it } from "vitest";
+import { FOV_PRESETS, getFovDegrees, isFovPresetId, parseFovPreset } from "./fov-presets";
+
+describe("FOV_PRESETS table", () => {
+  it("contains off, naked-eye, binoculars, small-scope, large-scope", () => {
+    const ids = FOV_PRESETS.map((p) => p.id);
+    expect(ids).toContain("off");
+    expect(ids).toContain("naked-eye");
+    expect(ids).toContain("binoculars");
+    expect(ids).toContain("small-scope");
+    expect(ids).toContain("large-scope");
+  });
+
+  it("naked-eye is 5 degrees", () => {
+    const p = FOV_PRESETS.find((x) => x.id === "naked-eye");
+    expect(p?.degrees).toBe(5);
+  });
+
+  it("binoculars is 7 degrees", () => {
+    const p = FOV_PRESETS.find((x) => x.id === "binoculars");
+    expect(p?.degrees).toBe(7);
+  });
+
+  it("small-scope is 1 degree", () => {
+    const p = FOV_PRESETS.find((x) => x.id === "small-scope");
+    expect(p?.degrees).toBe(1);
+  });
+
+  it("large-scope is 0.5 degrees", () => {
+    const p = FOV_PRESETS.find((x) => x.id === "large-scope");
+    expect(p?.degrees).toBe(0.5);
+  });
+
+  it("off has 0 degrees (no reticle)", () => {
+    const p = FOV_PRESETS.find((x) => x.id === "off");
+    expect(p?.degrees).toBe(0);
+  });
+
+  it("every preset has a human-readable label", () => {
+    for (const p of FOV_PRESETS) {
+      expect(typeof p.label).toBe("string");
+      expect(p.label.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("isFovPresetId", () => {
+  it("returns true for known preset ids", () => {
+    expect(isFovPresetId("off")).toBe(true);
+    expect(isFovPresetId("naked-eye")).toBe(true);
+    expect(isFovPresetId("binoculars")).toBe(true);
+    expect(isFovPresetId("small-scope")).toBe(true);
+    expect(isFovPresetId("large-scope")).toBe(true);
+  });
+
+  it("returns false for unknown ids", () => {
+    expect(isFovPresetId("unknown")).toBe(false);
+    expect(isFovPresetId("")).toBe(false);
+    expect(isFovPresetId("NAKED-EYE")).toBe(false);
+  });
+});
+
+describe("parseFovPreset", () => {
+  it("returns the id if valid", () => {
+    expect(parseFovPreset("binoculars")).toBe("binoculars");
+  });
+
+  it("returns 'off' for null, undefined, or unknown values", () => {
+    expect(parseFovPreset(null)).toBe("off");
+    expect(parseFovPreset(undefined)).toBe("off");
+    expect(parseFovPreset("garbage")).toBe("off");
+  });
+});
+
+describe("getFovDegrees", () => {
+  it("returns the degree value for each preset", () => {
+    expect(getFovDegrees("off")).toBe(0);
+    expect(getFovDegrees("naked-eye")).toBe(5);
+    expect(getFovDegrees("binoculars")).toBe(7);
+    expect(getFovDegrees("small-scope")).toBe(1);
+    expect(getFovDegrees("large-scope")).toBe(0.5);
+  });
+});

--- a/src/astro/fov-presets.ts
+++ b/src/astro/fov-presets.ts
@@ -1,0 +1,33 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+export type FovPresetId = "off" | "naked-eye" | "binoculars" | "small-scope" | "large-scope";
+
+export type FovPreset = {
+  readonly id: FovPresetId;
+  readonly label: string;
+  readonly degrees: number;
+};
+
+export const FOV_PRESETS: readonly FovPreset[] = [
+  { id: "off", label: "Off", degrees: 0 },
+  { id: "naked-eye", label: "Naked eye (5\u00B0)", degrees: 5 },
+  { id: "binoculars", label: "Binoculars (7\u00B0)", degrees: 7 },
+  { id: "small-scope", label: "Small scope (1\u00B0)", degrees: 1 },
+  { id: "large-scope", label: "Large scope (0.5\u00B0)", degrees: 0.5 },
+];
+
+const ID_SET = new Set<string>(FOV_PRESETS.map((p) => p.id));
+
+export function isFovPresetId(value: string): value is FovPresetId {
+  return ID_SET.has(value);
+}
+
+export function parseFovPreset(raw: string | null | undefined): FovPresetId {
+  if (raw === null || raw === undefined) return "off";
+  return isFovPresetId(raw) ? raw : "off";
+}
+
+export function getFovDegrees(id: FovPresetId): number {
+  const preset = FOV_PRESETS.find((p) => p.id === id);
+  return preset ? preset.degrees : 0;
+}

--- a/src/astro/index.ts
+++ b/src/astro/index.ts
@@ -40,3 +40,11 @@ export {
   LANGUAGES,
   parseConstellationNames,
 } from "./constellation-names";
+export {
+  type FovPresetId,
+  type FovPreset,
+  FOV_PRESETS,
+  isFovPresetId,
+  parseFovPreset,
+  getFovDegrees,
+} from "./fov-presets";

--- a/src/scene/index.ts
+++ b/src/scene/index.ts
@@ -17,3 +17,4 @@ export { type EclipticLayer, createEclipticLayer } from "./ecliptic";
 export { type MessierLayer, createMessierLayer } from "./messier";
 export { type MilkyWayLayer, createMilkyWayLayer } from "./milkyway";
 export { type TrailLayer, createTrailLayer } from "./trail-layer";
+export { type ReticleLayer, createReticleLayer, computeReticleRadiusPx } from "./reticle";

--- a/src/scene/reticle.test.ts
+++ b/src/scene/reticle.test.ts
@@ -1,0 +1,130 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { computeReticleRadiusPx, createReticleLayer } from "./reticle";
+
+vi.mock("cesium", () => ({
+  Math: { toDegrees: (r: number) => (r * 180) / Math.PI },
+}));
+
+describe("computeReticleRadiusPx", () => {
+  it("returns 0 for a zero-degree preset", () => {
+    expect(computeReticleRadiusPx(0, 60, 600)).toBe(0);
+  });
+
+  it("returns half the canvas height for a fov equal to camera vfov", () => {
+    // If reticle fov == camera vfov, the circle diameter should equal canvas height.
+    expect(computeReticleRadiusPx(60, 60, 600)).toBeCloseTo(300, 5);
+  });
+
+  it("scales linearly with preset degrees (small angle approximation)", () => {
+    // For small angles, tan(x) ~= x, so radius ~= (fov / cameraVfov) * (canvasH / 2)
+    const r = computeReticleRadiusPx(1, 60, 600);
+    const expected = (1 / 60) * 300;
+    // Allow a little room for the exact tan-based formula
+    expect(r).toBeGreaterThan(expected * 0.9);
+    expect(r).toBeLessThan(expected * 1.1);
+  });
+
+  it("never returns negative", () => {
+    expect(computeReticleRadiusPx(-1, 60, 600)).toBe(0);
+  });
+
+  it("handles zero camera vfov defensively (returns 0)", () => {
+    expect(computeReticleRadiusPx(5, 0, 600)).toBe(0);
+  });
+
+  it("handles zero canvas height defensively (returns 0)", () => {
+    expect(computeReticleRadiusPx(5, 60, 0)).toBe(0);
+  });
+});
+
+describe("createReticleLayer", () => {
+  let container: HTMLElement;
+  let canvas: HTMLCanvasElement;
+
+  function makeScene(fovyRad = Math.PI / 3): {
+    canvas: HTMLCanvasElement;
+    camera: { frustum: { fovy: number } };
+  } {
+    return {
+      canvas,
+      camera: { frustum: { fovy: fovyRad } },
+    };
+  }
+
+  beforeAll(() => {
+    // Ensure canvas has a usable default size
+    Object.defineProperty(HTMLCanvasElement.prototype, "clientHeight", {
+      configurable: true,
+      get() {
+        return 600;
+      },
+    });
+    Object.defineProperty(HTMLCanvasElement.prototype, "clientWidth", {
+      configurable: true,
+      get() {
+        return 800;
+      },
+    });
+  });
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    canvas = document.createElement("canvas");
+  });
+
+  afterEach(() => {
+    container.remove();
+  });
+
+  it("appends an SVG element to the container", () => {
+    createReticleLayer(makeScene() as never, container);
+    const svg = container.querySelector("svg[data-reticle]");
+    expect(svg).toBeTruthy();
+  });
+
+  it("starts hidden when preset is 'off'", () => {
+    const layer = createReticleLayer(makeScene() as never, container);
+    layer.setPreset("off");
+    const svg = container.querySelector<SVGElement>("svg[data-reticle]")!;
+    expect(svg.style.display).toBe("none");
+  });
+
+  it("shows the reticle when a non-off preset is set", () => {
+    const layer = createReticleLayer(makeScene() as never, container);
+    layer.setPreset("naked-eye");
+    const svg = container.querySelector<SVGElement>("svg[data-reticle]")!;
+    expect(svg.style.display).not.toBe("none");
+  });
+
+  it("draws a circle element inside the svg for non-off presets", () => {
+    const layer = createReticleLayer(makeScene() as never, container);
+    layer.setPreset("binoculars");
+    const circle = container.querySelector("circle");
+    expect(circle).toBeTruthy();
+  });
+
+  it("hiding the reticle again removes display", () => {
+    const layer = createReticleLayer(makeScene() as never, container);
+    layer.setPreset("binoculars");
+    layer.setPreset("off");
+    const svg = container.querySelector<SVGElement>("svg[data-reticle]")!;
+    expect(svg.style.display).toBe("none");
+  });
+
+  it("has destroy() that removes the svg from the container", () => {
+    const layer = createReticleLayer(makeScene() as never, container);
+    layer.destroy();
+    expect(container.querySelector("svg[data-reticle]")).toBeNull();
+  });
+
+  it("draws a larger circle for a wider fov preset", () => {
+    const layer = createReticleLayer(makeScene() as never, container);
+    layer.setPreset("small-scope");
+    const smallR = Number(container.querySelector("circle")!.getAttribute("r"));
+    layer.setPreset("binoculars");
+    const bigR = Number(container.querySelector("circle")!.getAttribute("r"));
+    expect(bigR).toBeGreaterThan(smallR);
+  });
+});

--- a/src/scene/reticle.ts
+++ b/src/scene/reticle.ts
@@ -1,0 +1,130 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { Math as CesiumMath } from "cesium";
+import type { Scene } from "cesium";
+import type { FovPresetId } from "../astro/fov-presets";
+import { getFovDegrees } from "../astro/fov-presets";
+
+export type ReticleLayer = {
+  setPreset: (preset: FovPresetId) => void;
+  destroy: () => void;
+};
+
+const SVG_NS = "http://www.w3.org/2000/svg";
+
+const CIRCLE_STROKE = "rgba(255, 200, 80, 0.85)";
+const CROSSHAIR_STROKE = "rgba(255, 200, 80, 0.6)";
+
+/**
+ * Compute the on-screen reticle radius in pixels for a given preset field-of-view.
+ *
+ * The reticle represents a circle of `presetDeg` angular diameter centered on the view.
+ * For a perspective camera with vertical field-of-view `cameraVfovDeg`, the on-screen
+ * pixel radius r is half the projection of that angular diameter, i.e.:
+ *
+ *   r = (canvasHeightPx / 2) * (tan(presetRad / 2) / tan(cameraVfovRad / 2))
+ */
+export function computeReticleRadiusPx(
+  presetDeg: number,
+  cameraVfovDeg: number,
+  canvasHeightPx: number,
+): number {
+  if (presetDeg <= 0) return 0;
+  if (cameraVfovDeg <= 0) return 0;
+  if (canvasHeightPx <= 0) return 0;
+  const halfPreset = (presetDeg * Math.PI) / 360;
+  const halfCamera = (cameraVfovDeg * Math.PI) / 360;
+  return (canvasHeightPx / 2) * (Math.tan(halfPreset) / Math.tan(halfCamera));
+}
+
+export function createReticleLayer(scene: Scene, container: HTMLElement): ReticleLayer {
+  const svg = document.createElementNS(SVG_NS, "svg");
+  svg.dataset.reticle = "true";
+  svg.style.position = "absolute";
+  svg.style.top = "0";
+  svg.style.left = "0";
+  svg.style.width = "100%";
+  svg.style.height = "100%";
+  svg.style.pointerEvents = "none";
+  svg.style.display = "none";
+  svg.style.zIndex = "5";
+  container.appendChild(svg);
+
+  const circle = document.createElementNS(SVG_NS, "circle");
+  circle.setAttribute("fill", "none");
+  circle.setAttribute("stroke", CIRCLE_STROKE);
+  circle.setAttribute("stroke-width", "1.5");
+  svg.appendChild(circle);
+
+  // Short crosshair ticks in the center
+  const hTick = document.createElementNS(SVG_NS, "line");
+  hTick.setAttribute("stroke", CROSSHAIR_STROKE);
+  hTick.setAttribute("stroke-width", "1");
+  svg.appendChild(hTick);
+  const vTick = document.createElementNS(SVG_NS, "line");
+  vTick.setAttribute("stroke", CROSSHAIR_STROKE);
+  vTick.setAttribute("stroke-width", "1");
+  svg.appendChild(vTick);
+
+  let currentPreset: FovPresetId = "off";
+
+  function canvasDims(): { w: number; h: number } {
+    const canvas = scene.canvas;
+    // Prefer clientWidth/clientHeight (CSS size) because SVG is laid out in CSS px
+    const w = canvas.clientWidth || canvas.width || 0;
+    const h = canvas.clientHeight || canvas.height || 0;
+    return { w, h };
+  }
+
+  function cameraVfovDeg(): number {
+    const frustum = scene.camera.frustum as { fovy?: number; fov?: number };
+    const fovyRad =
+      typeof frustum.fovy === "number" && Number.isFinite(frustum.fovy) && frustum.fovy > 0
+        ? frustum.fovy
+        : typeof frustum.fov === "number" && Number.isFinite(frustum.fov)
+          ? frustum.fov
+          : Math.PI / 3;
+    return CesiumMath.toDegrees(fovyRad);
+  }
+
+  function render(): void {
+    const presetDeg = getFovDegrees(currentPreset);
+    if (presetDeg <= 0) {
+      svg.style.display = "none";
+      return;
+    }
+    const { w, h } = canvasDims();
+    if (w <= 0 || h <= 0) {
+      svg.style.display = "none";
+      return;
+    }
+    const r = computeReticleRadiusPx(presetDeg, cameraVfovDeg(), h);
+    const cx = w / 2;
+    const cy = h / 2;
+    circle.setAttribute("cx", String(cx));
+    circle.setAttribute("cy", String(cy));
+    circle.setAttribute("r", String(Math.max(0, r)));
+
+    const tick = 6;
+    hTick.setAttribute("x1", String(cx - tick));
+    hTick.setAttribute("x2", String(cx + tick));
+    hTick.setAttribute("y1", String(cy));
+    hTick.setAttribute("y2", String(cy));
+    vTick.setAttribute("x1", String(cx));
+    vTick.setAttribute("x2", String(cx));
+    vTick.setAttribute("y1", String(cy - tick));
+    vTick.setAttribute("y2", String(cy + tick));
+
+    svg.style.display = "block";
+  }
+
+  function setPreset(preset: FovPresetId): void {
+    currentPreset = preset;
+    render();
+  }
+
+  function destroy(): void {
+    svg.remove();
+  }
+
+  return { setPreset, destroy };
+}

--- a/src/state/state.test.ts
+++ b/src/state/state.test.ts
@@ -320,3 +320,58 @@ describe("language — serialize round-trip", () => {
     expect(s2.language).toBe("zh");
   });
 });
+
+describe("fov preset — defaults", () => {
+  it("defaults to 'off' when fov param is absent", () => {
+    const s = expectOk(parseStateFromSearchParams(new URLSearchParams()));
+    expect(s.fov).toBe("off");
+  });
+});
+
+describe("fov preset — parse from URL", () => {
+  it("parses a known preset id", () => {
+    const s = expectOk(parseStateFromSearchParams(new URLSearchParams({ fov: "binoculars" })));
+    expect(s.fov).toBe("binoculars");
+  });
+
+  it("parses naked-eye", () => {
+    const s = expectOk(parseStateFromSearchParams(new URLSearchParams({ fov: "naked-eye" })));
+    expect(s.fov).toBe("naked-eye");
+  });
+
+  it("parses small-scope", () => {
+    const s = expectOk(parseStateFromSearchParams(new URLSearchParams({ fov: "small-scope" })));
+    expect(s.fov).toBe("small-scope");
+  });
+
+  it("parses large-scope", () => {
+    const s = expectOk(parseStateFromSearchParams(new URLSearchParams({ fov: "large-scope" })));
+    expect(s.fov).toBe("large-scope");
+  });
+
+  it("falls back to 'off' for unknown preset id", () => {
+    const s = expectOk(parseStateFromSearchParams(new URLSearchParams({ fov: "garbage" })));
+    expect(s.fov).toBe("off");
+  });
+});
+
+describe("fov preset — serialize round-trip", () => {
+  it("omits fov param when at default (off)", () => {
+    const s = expectOk(parseStateFromSearchParams(new URLSearchParams()));
+    const out = serializeStateToSearchParams(s);
+    expect(out.has("fov")).toBe(false);
+  });
+
+  it("writes fov param when a preset is selected", () => {
+    const s = expectOk(parseStateFromSearchParams(new URLSearchParams({ fov: "small-scope" })));
+    const out = serializeStateToSearchParams(s);
+    expect(out.get("fov")).toBe("small-scope");
+  });
+
+  it("round-trips a non-default fov preset", () => {
+    const s = expectOk(parseStateFromSearchParams(new URLSearchParams({ fov: "binoculars" })));
+    const out = serializeStateToSearchParams(s);
+    const s2 = expectOk(parseStateFromSearchParams(out));
+    expect(s2.fov).toBe("binoculars");
+  });
+});

--- a/src/state/state.ts
+++ b/src/state/state.ts
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 import { err, ok, type Result } from "../result";
 import { LANGUAGES, type Language } from "../astro/constellation-names";
+import { type FovPresetId, parseFovPreset } from "../astro/fov-presets";
 
 export type Observer = { readonly lat: number; readonly lon: number };
 
@@ -35,6 +36,7 @@ export type AppState = {
   readonly nightVision: boolean;
   readonly magLimit: number; // 1.0–6.0, default 6.0
   readonly language: Language;
+  readonly fov: FovPresetId; // telescope FOV reticle preset, default "off"
 };
 
 export type StateParseError =
@@ -74,6 +76,7 @@ export const DEFAULT_VIEW: ViewDirection = { az: 0, alt: 89.9 };
 export const DEFAULT_MAG_LIMIT = 6.0;
 
 export const DEFAULT_LANGUAGE: Language = "la";
+export const DEFAULT_FOV: FovPresetId = "off";
 
 export const DEFAULT_STATE: AppState = {
   observer: { lat: 0, lon: 0 },
@@ -84,6 +87,7 @@ export const DEFAULT_STATE: AppState = {
   nightVision: false,
   magLimit: DEFAULT_MAG_LIMIT,
   language: DEFAULT_LANGUAGE,
+  fov: DEFAULT_FOV,
 };
 
 function parseLat(raw: string): Result<number, StateParseError> {
@@ -190,6 +194,7 @@ export function parseStateFromSearchParams(
   const rawMag = params.get("mag");
   const magLimit = parseMagLimit(rawMag);
   const language = parseLanguage(params.get("lang"));
+  const fov = parseFovPreset(params.get("fov"));
 
   return ok({
     observer: { lat, lon },
@@ -200,6 +205,7 @@ export function parseStateFromSearchParams(
     nightVision,
     magLimit,
     language,
+    fov,
   });
 }
 
@@ -253,6 +259,10 @@ export function serializeStateToSearchParams(state: AppState): URLSearchParams {
 
   if (state.language !== DEFAULT_LANGUAGE) {
     params.set("lang", state.language);
+  }
+
+  if (state.fov !== DEFAULT_FOV) {
+    params.set("fov", state.fov);
   }
 
   return params;

--- a/src/ui/fov-controls.test.ts
+++ b/src/ui/fov-controls.test.ts
@@ -1,0 +1,54 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { describe, expect, it, vi } from "vitest";
+import { createFovControls } from "./fov-controls";
+import type { UIIntent } from "./index";
+
+describe("createFovControls", () => {
+  it("returns an HTMLElement", () => {
+    const el = createFovControls("off", vi.fn());
+    expect(el).toBeInstanceOf(HTMLElement);
+  });
+
+  it("renders a select with an option for each preset", () => {
+    const el = createFovControls("off", vi.fn());
+    const select = el.querySelector<HTMLSelectElement>("select[data-fov='preset']");
+    expect(select).not.toBeNull();
+    // off + 4 setups = 5
+    expect(select!.querySelectorAll("option").length).toBe(5);
+  });
+
+  it("select reflects initial preset", () => {
+    const el = createFovControls("binoculars", vi.fn());
+    const select = el.querySelector<HTMLSelectElement>("select[data-fov='preset']")!;
+    expect(select.value).toBe("binoculars");
+  });
+
+  it("changing the select dispatches a set-fov intent", () => {
+    const dispatch = vi.fn();
+    const el = createFovControls("off", dispatch);
+    const select = el.querySelector<HTMLSelectElement>("select[data-fov='preset']")!;
+    select.value = "small-scope";
+    select.dispatchEvent(new Event("change"));
+    expect(dispatch).toHaveBeenCalledOnce();
+    const intent = dispatch.mock.calls[0]![0] as UIIntent;
+    expect(intent.type).toBe("set-fov");
+    if (intent.type === "set-fov") {
+      expect(intent.preset).toBe("small-scope");
+    }
+  });
+
+  it("ignores non-preset select values (defensive)", () => {
+    const dispatch = vi.fn();
+    const el = createFovControls("off", dispatch);
+    const select = el.querySelector<HTMLSelectElement>("select[data-fov='preset']")!;
+    // Manually set an invalid value
+    select.value = "not-a-preset";
+    select.dispatchEvent(new Event("change"));
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it("has a visible heading labelled 'Telescope FOV' (or similar)", () => {
+    const el = createFovControls("off", vi.fn());
+    expect(el.textContent?.toLowerCase()).toContain("fov");
+  });
+});

--- a/src/ui/fov-controls.ts
+++ b/src/ui/fov-controls.ts
@@ -1,0 +1,50 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { FOV_PRESETS, type FovPresetId, isFovPresetId } from "../astro/fov-presets";
+import type { UIIntent } from "./index";
+
+export function createFovControls(
+  initialPreset: FovPresetId,
+  onIntent: (intent: UIIntent) => void,
+): HTMLElement {
+  const section = document.createElement("div");
+  section.style.cssText = "padding:8px 0;border-top:1px solid rgba(255,255,255,0.1)";
+
+  const heading = document.createElement("div");
+  heading.textContent = "Telescope FOV";
+  heading.style.cssText = "color:#fff;font:bold 12px sans-serif;margin-bottom:6px";
+  section.appendChild(heading);
+
+  const row = document.createElement("div");
+  row.style.cssText = "display:flex;align-items:center;gap:8px";
+
+  const label = document.createElement("label");
+  label.textContent = "Reticle";
+  label.style.cssText = "color:rgba(255,255,255,0.6);font:12px sans-serif";
+  row.appendChild(label);
+
+  const select = document.createElement("select");
+  select.dataset.fov = "preset";
+  select.style.cssText =
+    "flex:1;background:rgba(255,255,255,0.1);color:#fff;border:1px solid rgba(255,255,255,0.2);" +
+    "border-radius:4px;padding:4px;font:12px sans-serif";
+
+  for (const preset of FOV_PRESETS) {
+    const option = document.createElement("option");
+    option.value = preset.id;
+    option.textContent = preset.label;
+    select.appendChild(option);
+  }
+
+  select.value = initialPreset;
+
+  select.addEventListener("change", () => {
+    const value = select.value;
+    if (!isFovPresetId(value)) return;
+    onIntent({ type: "set-fov", preset: value });
+  });
+
+  row.appendChild(select);
+  section.appendChild(row);
+
+  return section;
+}

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -7,9 +7,11 @@ export { createLayerControls } from "./layer-controls";
 export { createViewControls } from "./view-controls";
 export { createPlanetInfo } from "./planet-info";
 export { createSearch } from "./search";
+export { createFovControls } from "./fov-controls";
 
 import type { LayerVisibility, LayerOpacity } from "../state/state";
 import type { Language } from "../astro/constellation-names";
+import type { FovPresetId } from "../astro/fov-presets";
 
 export type UIIntent =
   | { type: "set-time"; time: Date }
@@ -22,4 +24,5 @@ export type UIIntent =
   | { type: "show-trail"; objectKind: "body"; id: string }
   | { type: "hide-trail" }
   | { type: "set-language"; language: Language }
+  | { type: "set-fov"; preset: FovPresetId }
   | { type: "now" };


### PR DESCRIPTION
## Summary

- Adds a circular reticle overlay to the Cesium canvas showing the field-of-view for common setups: naked eye (5°), binoculars (7°), small scope (1°), large scope (0.5°).
- Rendered as an SVG circle centered on the view, sized from the camera vertical FOV so the reticle's angular diameter stays correct as the view changes.
- URL-persisted via a new `fov` param (default `off`); dropdown control in the UI panel dispatches a `set-fov` intent.

## Files

- `src/astro/fov-presets.ts` — pure preset table and parser (no Cesium).
- `src/state/state.ts` — adds `fov` to `AppState` + URL round-trip.
- `src/scene/reticle.ts` — SVG overlay layer (`createReticleLayer`) with `setPreset()`.
- `src/ui/fov-controls.ts` — dropdown control dispatching `set-fov`.
- `src/app.ts` — wires the layer, UI control, and intent handler.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test` (499 passed)
- [x] `pnpm test:cov` — coverage thresholds met (pure ≥90/85, integration ≥80/70)
- [x] `pnpm build`
- [ ] Manually verify reticle appears and resizes correctly across presets in the browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)