### PR TITLE
docs: update developer documentation for post-v1 features (closes #169)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,24 +2,49 @@
 
 Interactive web planisphere with satellite overlays. Static SPA built with CesiumJS and satellite.js. Apache 2.0 licensed.
 
-See `docs/specs/2026-04-15-planisphere-v1-design.md` for the full v1 design and `CLAUDE.md` for working conventions.
+See [`docs/architecture.md`](docs/architecture.md) for the current code architecture and Mermaid diagrams, [`docs/user-guide.md`](docs/user-guide.md) for the end-user manual, `docs/specs/2026-04-15-planisphere-v1-design.md` for the frozen v1 design, and `CLAUDE.md` for working conventions.
+
+## Features
+
+- **Stars** — ~5000 HYG-catalog stars, colored by B-V index (blue-white O stars through orange-red M stars).
+- **Solar system bodies** — Sun, Moon (with phase), Mercury, Venus, Mars, Jupiter, Saturn. Ephemerides from Astronomy Engine.
+- **Artificial satellites** — live TLE feed from CelesTrak with a bundled fallback; SGP4 propagation via satellite.js.
+- **Deep-sky objects** — Messier catalog with per-type symbols (open cluster, globular, nebula, galaxy).
+- **Constellations** — IAU stick figures and official boundary polygons. Constellation names in Latin, English, Chinese, Arabic, or Greek.
+- **Milky Way** — a soft additive billboard glow band tracing the galactic plane.
+- **Reference lines** — RA/Dec equatorial grid and the ecliptic, both with independent opacity sliders.
+- **Object trails** — show a dashed 4-hour future path for any solar-system body from the planet info panel.
+- **Telescope FOV reticle** — overlay an on-screen circle sized for naked eye, binoculars, small scope, or large scope.
+- **Interactive controls** — free-look trackball camera, view-direction presets and explicit Az/Alt inputs, layer toggles, magnitude filter, night-vision mode, "📍 Now" button (sets time and requests geolocation), Copy link button.
+- **Search** — type an object name to jump the view to stars, constellations, planets, or satellites above the horizon.
+- **Click / hover to identify** — tooltips on stars, bodies, satellites, and deep-sky objects.
+- **Planet info panel** — current Alt/Az, rise/set times, clickable names, trail toggle.
+- **URL-is-state** — every interesting setting is reflected in the URL, so any view is a shareable link.
+- **PWA / offline** — installable web app with a service worker that caches the shell and falls back to cached TLE when offline.
+
+Under the hood:
+
+- **Web Worker** runs the hot alt/az math for ~5000 stars off the main thread using zero-copy transferable `Float64Array`s.
+- **Fast RA/Dec transform** (hand-rolled GMST) is ~50× faster than astronomy-engine's full pipeline and used everywhere ±0.5° accuracy is acceptable (stars, grid, ecliptic, milky way, deep-sky, search).
 
 ## Architecture
 
-Planisphere is composed of six modules with strict boundaries:
+Planisphere is composed of eight modules with strict boundaries:
 
-| Module        | Role                                                                                                                                           |
-| ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| `src/astro/`  | Pure astronomy math — star catalog, ephemerides, coordinate transforms, constellation/boundary filtering                                       |
-| `src/sat/`    | TLE loading (with bundled fallback), SGP4 propagation via satellite.js                                                                         |
-| `src/scene/`  | CesiumJS rendering — one factory per layer (`StarLayer`, `BodyLayer`, `ConstellationLayer`, `BoundaryLayer`, `SatelliteLayer`, `CompassLayer`) |
-| `src/ui/`     | DOM controls that emit typed `UIIntent` values; no position math                                                                               |
-| `src/state/`  | `AppState` type, URL serialisation/deserialisation                                                                                             |
-| `src/result/` | `Result<T, E>` discriminated union and helpers                                                                                                 |
+| Module         | Role                                                                                                                                                                                                                   |
+| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/astro/`   | Pure astronomy math — star catalog, ephemerides, coordinate transforms, constellation/boundary/Messier/Milky Way filtering, grid/ecliptic geometry, trails, search index, FOV presets, constellation-name translations |
+| `src/sat/`     | TLE loading (with bundled fallback), SGP4 propagation via satellite.js                                                                                                                                                 |
+| `src/scene/`   | CesiumJS rendering — one factory per layer (`Star`, `Body`, `Constellation`, `Boundary`, `Satellite`, `Compass`, `Grid`, `Ecliptic`, `Messier`, `MilkyWay`, `Trail`, `Reticle`) plus camera setup and hover tooltip    |
+| `src/workers/` | Astro computation Web Worker: `astro-worker` (entry), `astro-worker-client`, `worker-math` (pure GMST math extracted for tests), `star-builder` (typed-array packing helpers)                                          |
+| `src/ui/`      | DOM controls that emit typed `UIIntent` values — panel, time, location, view, layer, FOV, planet-info, search; no position math                                                                                        |
+| `src/state/`   | `AppState` type, URL serialisation/deserialisation (`lat`, `lon`, `t`, `layers`, `op_*`, `vaz`, `valt`, `nv`, `mag`, `lang`, `fov`)                                                                                    |
+| `src/result/`  | `Result<T, E>` discriminated union and helpers                                                                                                                                                                         |
+| `src/app.ts`   | Composition root — wires state → computation → rendering → UI, debounces rerenders, dispatches intents, keeps the URL in sync                                                                                          |
 
-`src/app.ts` is the composition root: it wires state → computation → rendering → UI and keeps the URL in sync.
+`src/main.ts` is the browser entrypoint; it also registers the service worker (`public/sw.js`) when the app is served from a production build.
 
-See [`docs/architecture.md`](docs/architecture.md) for Mermaid diagrams covering the module dependency graph, data flow, layer interface model, and TLE fetch/fallback flow.
+See [`docs/architecture.md`](docs/architecture.md) for Mermaid diagrams covering the module dependency graph, data flow, layer interface model, worker sequence, `AppState` schema, URL parameter set, TLE fetch/fallback flow, and a short section per post-v1 subsystem.
 
 ## Prerequisites
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,8 @@
 # Architecture
 
-Planisphere is a static single-page application with no backend. All computation runs in the browser. This document describes the module structure, data flow, layer model, and TLE loading strategy.
+Planisphere is a static single-page application with no backend. All computation runs in the browser. This document describes the module structure, data flow, layer model, worker offload, TLE loading strategy, and the post-v1 feature subsystems.
+
+The v1 baseline design lives in `docs/specs/2026-04-15-planisphere-v1-design.md`. Everything in this file reflects the current state of the repo, including features added since v1 (star colors, Milky Way, Messier, search, planet info, RA/Dec grid + ecliptic, boundaries, view direction controls, trackball camera, Web Worker, fast RA/Dec math, PWA/service worker, copy-link, night vision, magnitude filter, "Now" button, object trails, multi-language constellation names, telescope FOV reticle).
 
 ## Module dependency graph
 
@@ -9,27 +11,34 @@ Each module has a strict boundary. Arrows point from importer to dependency.
 ```mermaid
 graph TD
     app["app.ts<br/>(composition root)"]
+    main["main.ts<br/>(entrypoint + SW register)"]
     state["state/<br/>URL-synced app state"]
     astro["astro/<br/>pure astro math"]
     sat["sat/<br/>TLE loading + SGP4"]
     scene["scene/<br/>CesiumJS rendering"]
     ui["ui/<br/>controls + intents"]
+    workers["workers/<br/>astro Web Worker"]
     result["result/<br/>Result&lt;T,E&gt; helpers"]
 
+    main --> app
     app --> state
     app --> astro
     app --> sat
     app --> scene
     app --> ui
+    app --> workers
 
     state --> result
+    state --> astro
     astro --> result
     sat --> result
 
     scene --> astro
     sat --> astro
+    workers --> astro
 
     ui --> state
+    ui --> astro
 ```
 
 **Boundary rules enforced at review:**
@@ -37,26 +46,47 @@ graph TD
 - `astro/` and `sat/` are pure and framework-free — no CesiumJS imports, no DOM.
 - `scene/` is the only module permitted to import CesiumJS types.
 - `ui/` reads `state/` types and emits `UIIntent` values; it does not compute positions.
+- `workers/` is the only module that constructs `Worker` instances. The worker entry (`src/workers/astro-worker.ts`) imports only from `src/workers/worker-math.ts` and has no DOM, Cesium, or astronomy-engine dependencies.
 - `result/` has no dependencies within the project.
+- `state/` imports narrow types from `astro/` (`Language`, `FovPresetId`) for URL parsing but no math.
+
+## Module inventory
+
+Per-module summary of what lives where. Filenames omit the `.ts` extension; each module also has a `*.test.ts` sibling.
+
+| Module         | Files                                                                                                                                                                                                                                                | Responsibility                                                                                                                                         |
+| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `src/result/`  | `result`                                                                                                                                                                                                                                             | `Result<T, E>` discriminated union, `ok`/`err` helpers.                                                                                                |
+| `src/state/`   | `state`                                                                                                                                                                                                                                              | `AppState`, URL parse/serialize, defaults.                                                                                                             |
+| `src/astro/`   | `catalog`, `coords`, `fast-coords`, `magnitude`, `visibility`, `moon-phase`, `bodies`, `rise-set`, `constellations`, `boundaries`, `grid`, `ecliptic`, `star-color`, `messier`, `milkyway`, `trails`, `constellation-names`, `fov-presets`, `search` | Pure astronomy math. No DOM, no Cesium, no `Worker`.                                                                                                   |
+| `src/sat/`     | `fetch`, `tle`, `propagate`                                                                                                                                                                                                                          | TLE fetch with bundled fallback, TLE parsing to `SatelliteRecord`, SGP4 propagation to Alt/Az.                                                         |
+| `src/scene/`   | `viewer`, `camera`, `stars`, `bodies`, `constellations`, `boundaries`, `satellites`, `compass`, `grid`, `ecliptic`, `messier`, `milkyway`, `trail-layer`, `reticle`, `tooltip`                                                                       | CesiumJS primitives, one `create*Layer` factory per visual layer, camera setup, hover tooltip.                                                         |
+| `src/ui/`      | `panel`, `time-controls`, `location-controls`, `view-controls`, `layer-controls`, `planet-info`, `search`, `fov-controls`, `styles`                                                                                                                  | DOM controls, `UIIntent` union, layout/styles.                                                                                                         |
+| `src/workers/` | `astro-worker`, `astro-worker-client`, `worker-math`, `star-builder`                                                                                                                                                                                 | Web Worker for star alt/az math; pure math extracted for testing; array builders that bridge `StarRecord[]` ↔ transferable `Float64Array`.            |
+| `src/app.ts`   | —                                                                                                                                                                                                                                                    | Composition root. Wires state → computation → layers → UI; debounced rerender; intent dispatch; trail and reticle orchestration; search index rebuild. |
+| `src/main.ts`  | —                                                                                                                                                                                                                                                    | Browser entrypoint. Calls `bootstrap()` and registers the service worker (`/sw.js`) only when `import.meta.env.PROD` is true.                          |
 
 ## Data flow
 
-The application follows a unidirectional flow: state drives computation, computation drives rendering, and user actions produce intents that update state.
+The application follows a unidirectional flow: state drives computation, computation drives rendering, and user actions produce intents that update state. The heavy star math is offloaded to a Web Worker on all rerenders after the first.
 
 ```mermaid
 flowchart LR
     URL["URL search params"]
-    State["AppState\n(observer, time, layers, opacity)"]
-    Astro["astro/\nfilterVisibleStars\ncomputeBodyPositions\nfilterVisibleConstellations\nfilterVisibleBoundaries"]
+    State["AppState\n(observer, time, layers, opacity,\nview, nightVision, magLimit,\nlanguage, fov)"]
+    Astro["astro/ (main thread)\nfilterVisibleBoundaries\ncomputeBodyPositions\ncomputeRaDecGrid\ncomputeEclipticLine\ncomputeMilkyWayPoints\nfilterVisibleMessier\ncomputeBodyTrail\nfilterVisibleConstellations"]
+    Worker["workers/astro-worker\n(alt/az for ~5000 stars)"]
     Sat["sat/\npropagateSatellites"]
     Scene["scene/\nLayer.update()"]
-    UI["ui/\npanel + controls"]
-    Intent["UIIntent\n(set-time | set-observer\n| toggle-layer | set-opacity\n| set-view)"]
+    UI["ui/\npanel + controls + search"]
+    Intent["UIIntent"]
 
     URL -->|parseStateFromSearchParams| State
-    State -->|observer + timeUtc| Astro
+    State -->|observer + timeUtc + magLimit| Astro
+    State -->|RA/Dec catalog + observer + time| Worker
     State -->|observer + timeUtc| Sat
-    Astro -->|stars, bodies, constellations, boundaries| Scene
+    Astro -->|lines, bodies, grid, ecliptic,\nmilkyway, messier, trail, boundaries| Scene
+    Worker -->|altAzs + visibleIndices| Scene
     Sat -->|visible satellites| Scene
     Scene -->|primitives rendered| Browser["Browser / CesiumJS"]
     UI -->|user interaction| Intent
@@ -66,52 +96,77 @@ flowchart LR
 
 On startup `bootstrap()` in `app.ts`:
 
-1. Parses `AppState` from URL search params (defaults used when params are absent).
-2. Parses the bundled star catalog (`data/stars.json`).
-3. Initialises the CesiumJS viewer and camera.
-4. Calls `rerender()` to populate all layers from the initial state.
-5. Fetches TLE data asynchronously (see TLE flow below).
-6. Mounts the UI panel; each control fires a `UIIntent` that `handleIntent` dispatches.
+1. Parses `AppState` from URL search params via `parseStateFromSearchParams` (defaults used when params are absent).
+2. Parses the bundled star catalog (`data/stars.json`), constellation stick figures, boundaries, and Messier catalog.
+3. Initialises the CesiumJS viewer, applies the initial `view` (az/alt) from state, and wires up trackball drag controls (see `src/scene/camera.ts`).
+4. Creates every scene layer up front (stars, bodies, constellations, boundaries, compass, grid, ecliptic, messier, milkyway, trail, reticle). The satellite layer is created later, once TLE data is available.
+5. Runs a synchronous initial `doRerender` so the sky appears instantly.
+6. Tries to spin up an `AstroWorkerClient`; if construction fails (test environment, bundler restriction) it falls back to synchronous rerenders.
+7. Fetches TLE data asynchronously and creates the satellite layer on success (see TLE flow below).
+8. Builds the search index over named stars, constellations, bodies, and satellites.
+9. Mounts the UI panel (time, location, view, FOV, layers, planet info, search box) plus the Copy link and Night vision buttons in the header. Each control fires a `UIIntent` that `handleIntent` dispatches.
+10. `scheduleRerender` debounces subsequent state changes with a 50 ms timeout and routes them through the worker when available.
 
 ## Layer architecture
 
-Each visual layer is an opaque object returned by a `create*Layer` factory in `scene/`. Layers own their Cesium primitives directly and expose a minimal interface. `app.ts` calls these methods; no other module does.
+Each visual layer is an opaque object returned by a `create*Layer` factory in `src/scene/`. Layers own their Cesium primitives directly and expose a minimal interface. `app.ts` calls these methods; no other module does.
 
 ```mermaid
 classDiagram
     class StarLayer {
         +update(stars: AltAzStar[], lat, lon)
-        +setVisible(visible: boolean)
+        +setVisible(visible)
     }
-
     class BodyLayer {
-        +update(bodies: CelestialBody[], lat, lon)
-        +setVisible(visible: boolean)
+        +update(bodies, lat, lon)
+        +setVisible(visible)
     }
-
     class ConstellationLayer {
-        +update(constellations: VisibleConstellation[], lat, lon)
-        +setVisible(visible: boolean)
-        +setOpacity(opacity: number)
+        +update(constellations, lat, lon)
+        +setNameOverrides(map | null)
+        +setVisible(visible)
+        +setOpacity(opacity)
     }
-
     class BoundaryLayer {
-        +update(boundaries: VisibleBoundary[], lat, lon)
-        +setVisible(visible: boolean)
-        +setOpacity(opacity: number)
+        +update(boundaries, lat, lon)
+        +setVisible(visible)
+        +setOpacity(opacity)
     }
-
     class SatelliteLayer {
-        +update(satellites: VisibleSatellite[], lat, lon)
-        +setVisible(visible: boolean)
-        +setOpacity(opacity: number)
+        +update(satellites, lat, lon)
+        +setVisible(visible)
+        +setOpacity(opacity)
     }
-
     class CompassLayer {
         +update(lat, lon)
-        +setVisible(visible: boolean)
+        +setVisible(visible)
     }
-
+    class GridLayer {
+        +update(gridData, lat, lon)
+        +setOpacity(opacity)
+    }
+    class EclipticLayer {
+        +update(points, lat, lon)
+        +setOpacity(opacity)
+    }
+    class MessierLayer {
+        +update(objects, lat, lon)
+        +setVisible(visible)
+        +setOpacity(opacity)
+    }
+    class MilkyWayLayer {
+        +update(points, lat, lon)
+        +setOpacity(opacity)
+    }
+    class TrailLayer {
+        +setPoints(points, lat, lon)
+        +show()
+        +hide()
+    }
+    class ReticleLayer {
+        +setPreset(FovPresetId)
+        +destroy()
+    }
     class CesiumPrimitive {
         <<CesiumJS>>
     }
@@ -122,9 +177,199 @@ classDiagram
     BoundaryLayer --> CesiumPrimitive : PolylineCollection
     SatelliteLayer --> CesiumPrimitive : BillboardCollection\nPolylineCollection
     CompassLayer --> CesiumPrimitive : LabelCollection
+    GridLayer --> CesiumPrimitive : PolylineCollection
+    EclipticLayer --> CesiumPrimitive : PolylineCollection
+    MessierLayer --> CesiumPrimitive : BillboardCollection
+    MilkyWayLayer --> CesiumPrimitive : BillboardCollection
+    TrailLayer --> CesiumPrimitive : PolylineCollection\n(PolylineDash material)
+    ReticleLayer --> DOM : SVG overlay on Cesium canvas
 ```
 
-`setOpacity` is only present on layers that have a variable-alpha component (constellation lines, constellation boundaries, satellite trails). `StarLayer`, `BodyLayer`, and `CompassLayer` have no opacity slider.
+`setVisible` is only present on toggleable layers (stars, planets/bodies, satellites, compass, deep-sky/Messier). Overlays controlled purely by opacity (grid, ecliptic, milky way, constellation lines/boundaries, satellite trails) fade to zero rather than being hidden outright. `TrailLayer` is the only layer with a `show`/`hide` API — it is driven by a transient selection from the planet-info panel, not by persisted state.
+
+The reticle is an SVG element sibling to the Cesium canvas; it is not a Cesium primitive but is treated as a layer for consistency. See [Telescope FOV reticle](#telescope-fov-reticle).
+
+## AppState and URL parameters
+
+`AppState` in `src/state/state.ts` is the single source of truth for everything the URL can represent. Every shape in the tree is `readonly`; `handleIntent` builds a new `AppState` on each change.
+
+```ts
+type AppState = {
+  observer: { lat: number; lon: number };
+  timeUtc: Date;
+  layers: LayerVisibility; // 5 toggles: stars, planets, satellites, compass, deepSky
+  opacity: LayerOpacity; // 6 sliders: constellationLines, constellationBoundaries,
+  //            satelliteTrails, raDecGrid, ecliptic, milkyWay
+  view: { az: number; alt: number };
+  nightVision: boolean;
+  magLimit: number; // 1.0–6.0, default 6.0
+  language: Language; // "la" | "en" | "zh" | "ar" | "el"
+  fov: FovPresetId; // "off" | "naked-eye" | "binoculars" | "small-scope" | "large-scope"
+};
+```
+
+Only fields that differ from their default are written to the URL, so a freshly-loaded app produces a short, human-readable link.
+
+| Param     | Type                | State slice                       | Notes                                                                             |
+| --------- | ------------------- | --------------------------------- | --------------------------------------------------------------------------------- | ----------- | ------------ | ---------- | --------------------------- |
+| `lat`     | `number` (−90…90)   | `observer.lat`                    | Always written.                                                                   |
+| `lon`     | `number` (−180…180) | `observer.lon`                    | Always written.                                                                   |
+| `t`       | ISO 8601 string     | `timeUtc`                         | Always written.                                                                   |
+| `layers`  | comma list          | `layers`                          | Omitted when every layer is on. Keys: `stars,planets,satellites,compass,deepSky`. |
+| `op_cl`   | integer 0–100       | `opacity.constellationLines`      | Omitted at default.                                                               |
+| `op_cb`   | integer 0–100       | `opacity.constellationBoundaries` | Omitted at default.                                                               |
+| `op_st`   | integer 0–100       | `opacity.satelliteTrails`         | Omitted at default.                                                               |
+| `op_grid` | integer 0–100       | `opacity.raDecGrid`               | Omitted at default (20).                                                          |
+| `op_ecl`  | integer 0–100       | `opacity.ecliptic`                | Omitted at default (40).                                                          |
+| `op_mw`   | integer 0–100       | `opacity.milkyWay`                | Omitted at default (30).                                                          |
+| `vaz`     | `number` (0–360)    | `view.az`                         | Written when `view` differs from zenith default.                                  |
+| `valt`    | `number` (0–90)     | `view.alt`                        | Written when `view` differs from zenith default.                                  |
+| `nv`      | `"1"` when on       | `nightVision`                     | Omitted when off.                                                                 |
+| `mag`     | `number` (1.0–6.0)  | `magLimit`                        | Omitted at default (6.0).                                                         |
+| `lang`    | `la                 | en                                | zh                                                                                | ar          | el`          | `language` | Omitted at default (`la`).  |
+| `fov`     | `off                | naked-eye                         | binoculars                                                                        | small-scope | large-scope` | `fov`      | Omitted at default (`off`). |
+
+Parse and serialize are pure and returned as `Result<AppState, StateParseError>`; `handleIntent` in `app.ts` is the only place that re-serializes back into the URL (via `history.replaceState`).
+
+## Intents
+
+The UI never mutates `AppState` directly. It emits a typed `UIIntent` (see `src/ui/index.ts`) that the composition root handles:
+
+```ts
+type UIIntent =
+  | { type: "set-time"; time: Date }
+  | { type: "set-observer"; lat: number; lon: number }
+  | { type: "toggle-layer"; layer: keyof LayerVisibility }
+  | { type: "set-opacity"; layer: keyof LayerOpacity; value: number }
+  | { type: "set-view"; az: number; alt: number }
+  | { type: "toggle-night-vision" }
+  | { type: "set-mag-limit"; value: number }
+  | { type: "show-trail"; objectKind: "body"; id: string }
+  | { type: "hide-trail" }
+  | { type: "set-language"; language: Language }
+  | { type: "set-fov"; preset: FovPresetId }
+  | { type: "now" };
+```
+
+`show-trail` / `hide-trail` are ephemeral — the current trail selection lives as a local variable in `bootstrap()` and is not serialised to the URL. The `now` intent additionally asks for the browser's geolocation; if it resolves, it also fires a `set-observer`-equivalent update.
+
+## Web Worker for star math
+
+Star alt/az computation is the hot loop: ~5000 entries recomputed on every state change. To keep the UI responsive during scrubbing, that work runs in a dedicated Web Worker.
+
+```mermaid
+sequenceDiagram
+    participant UI as UI (main thread)
+    participant App as app.ts
+    participant Client as AstroWorkerClient
+    participant Worker as astro-worker.ts
+
+    UI->>App: UIIntent (set-time, set-observer, ...)
+    App->>App: scheduleRerender (50 ms debounce)
+    Note over App: main thread computes bodies,<br/>grid, ecliptic, milkyway, messier,<br/>boundaries, satellites
+    App->>Client: computeAltAz(raDecs, lat, lon, time)
+    Client->>Worker: postMessage(Float64Array)<br/>[transfer raDecs.buffer]
+    Worker->>Worker: lstFromMs + altAzFromRaDec<br/>for every ra/dec pair
+    Worker->>Client: postMessage(altAzs, visibleIndices)<br/>[transfer buffers]
+    Client->>App: resolve Promise
+    App->>App: buildAltAzStars → StarLayer.update<br/>filterVisibleConstellations → ConstellationLayer.update
+```
+
+Design points:
+
+- **Transferable typed arrays.** Inputs and outputs travel as `Float64Array` / `Uint16Array` and are transferred, not copied. `src/workers/star-builder.ts` has `buildRaDecArray` (pack catalog → `Float64Array`) and `buildAltAzStars` (unpack worker result + apply magnitude filter).
+- **No astronomy-engine inside the worker.** The worker uses a fast, tailored GMST formula (`src/workers/worker-math.ts`). Extracting that math into a non-worker module lets us unit-test it directly with Vitest — the `astro-worker.ts` file is a thin adapter around it.
+- **Per-request correlation.** Every request has an incrementing `id`; the client stores pending resolvers in a `Map<number, ...>` so concurrent requests can interleave.
+- **Graceful fallback.** `tryCreateWorker()` swallows construction errors (test environment, some bundler configs); when `worker === null`, `scheduleRerender` falls back to the synchronous `doRerender` that uses `filterVisibleStars` from `src/astro/visibility.ts`. Within `doRerenderWithWorker`, if the worker promise rejects we fall back to `filterVisibleStars` for just that update.
+- **Stale-update protection.** The worker result is applied only when the `AppState` captured at dispatch time is still the current state. If the user scrubs past it before it resolves, the stale result is dropped.
+
+## Fast RA/Dec transform
+
+Solar-system bodies still use astronomy-engine's full pipeline (precession, nutation, aberration, refraction) in `src/astro/coords.ts` (`raDecToAltAz`). For everything else the code uses `src/astro/fast-coords.ts` (`fastRaDecToAltAz`), a hand-rolled GMST → hour-angle → alt/az calculation:
+
+- Accurate to roughly ±0.5° — invisible at the pixel density used for rendering stars.
+- About 50× faster per call than astronomy-engine's transform, because it skips all the per-call planetary aberration work.
+- Used by: stars (main-thread fallback and search indexing), the equatorial grid, the ecliptic line, Messier catalog filtering, and the Milky Way band.
+- The worker uses the same math (`worker-math.ts`) but inlined to avoid re-computing the local sidereal time per entry.
+
+## Star colors from B-V index
+
+`src/astro/catalog.ts` preserves each star's `ci` (B-V color index) from the HYG database. `src/astro/star-color.ts` (`bvToRgb`) maps that index to a hex color via piecewise linear interpolation between six spectral-class control points (O blue-white → M orange-red). `src/scene/stars.ts` reads `star.ci` and passes it through `bvToRgb` into the billboard's `Color.fromCssColorString(...)`, so hot stars appear blue-white and cool stars orange-red. Stars without a `ci` value render as white.
+
+## Milky Way glow band
+
+`src/astro/milkyway.ts` holds ~30 RA/Dec control points tracing the galactic plane. `computeMilkyWayPoints` runs each through `fastRaDecToAltAz` and returns only the ones above the horizon. The corresponding scene layer (`src/scene/milkyway.ts`) renders each point as an additive radial-gradient billboard whose per-point opacity is driven by the `op_mw` slider. The band effectively replaces an earlier polyline implementation (see commit history for the prior polyline approach) with an additive glow that blends into the starfield.
+
+## Deep-sky objects (Messier catalog)
+
+`data/messier.json` is the bundled Messier catalog (~110 entries). `src/astro/messier.ts` parses it into `MessierRecord[]` and filters above-horizon objects at a given observer/time. `src/scene/messier.ts` draws each object as a custom SVG-on-canvas symbol that encodes its type (open cluster, globular cluster, nebula, galaxy). The layer is toggled by the `deepSky` key in `layers` and the underlying alpha is multiplied by the `op_mw`/`op_ecl`/etc. sliders only where applicable; the Messier layer itself uses its own opacity channel.
+
+## RA/Dec grid and ecliptic
+
+`src/astro/grid.ts` (`computeRaDecGrid`) builds 24 RA great circles (every 15° / 1h) and 17 Dec small circles (−80°…+80° every 10°), sampling each at 10° intervals and keeping only above-horizon segments. `src/astro/ecliptic.ts` does the same for the ecliptic — a great circle defined by a fixed obliquity. Both feed `PolylineCollection`-backed scene layers whose alpha follows `op_grid` and `op_ecl` respectively. Because these are dense polylines they benefit from the fast RA/Dec transform; the grid would be visibly laggy under astronomy-engine.
+
+## Constellation boundaries
+
+`data/boundaries.json` is a bundled copy of the IAU constellation boundary polygons (sourced from d3-celestial). `src/astro/boundaries.ts` parses and filters them above the horizon; `src/scene/boundaries.ts` renders them as faint polylines whose alpha follows `op_cb`. Boundaries and stick-figure lines are independent layers.
+
+## Multi-language constellation names
+
+`data/constellation-names/` holds translated names for constellation labels, one JSON file per non-Latin language (`en.json`, `zh.json`, `ar.json`, `el.json`). Latin (`la`) is the baseline from the upstream Stellarium data and needs no override file. `src/astro/constellation-names.ts` validates a raw map → `ConstellationNameMap` (`Result<..., ConstellationNamesParseError>`). `app.ts::loadNameOverridesForLanguage` reads the language from state; `ConstellationLayer.setNameOverrides(map | null)` patches the labels in place without re-computing constellation geometry. Language is serialised to the URL as `lang`.
+
+## Search
+
+`src/astro/search.ts` builds a single flat `SearchIndex` over named stars, constellations (keyed by a representative star's alt/az), solar-system bodies, and satellite names. For each entry it caches alt/az at the current observer/time so filtering can be done in a single pass. `src/ui/search.ts` emits a `set-view` intent with the chosen entry's az/alt when the user picks a result; above-horizon targets aim the camera directly, below-horizon ones are still listed but disabled. The index is rebuilt whenever observer or time changes (`rebuildSearchIndex` in `app.ts`).
+
+## Click-to-identify and the planet info panel
+
+`src/scene/tooltip.ts` attaches a Cesium `ScreenSpaceEventHandler` that picks the primitive under the cursor on hover, formats a tooltip (name, magnitude, RA/Dec, Alt/Az, satellite altitude/velocity, Moon phase, etc.), and positions it with absolute CSS. `src/ui/planet-info.ts` renders a collapsible planet/Moon/Sun panel in the control tray:
+
+- Current Alt/Az.
+- Rise and set times, computed by `src/astro/rise-set.ts`.
+- Below-horizon indicator.
+- A clickable name — above-horizon bodies dispatch `set-view` so the camera swings to them.
+- A "Show path" / "Hide path" toggle — dispatches `show-trail` / `hide-trail` intents that drive the trail layer.
+
+## Object trails
+
+`src/astro/trails.ts::computeBodyTrail` samples a body's alt/az every 5 minutes for the next 4 hours (`TRAIL_DURATION_HOURS` / `TRAIL_STEP_MINUTES` constants in `app.ts`) and returns a `Result<HorizontalCoord[], TrailError>`. `src/scene/trail-layer.ts` draws the list as a single dashed polyline using Cesium's `PolylineDash` material. The trail is transient state — it is cleared when the user hides it or changes bodies, and is never serialised.
+
+## Telescope FOV reticle
+
+`src/astro/fov-presets.ts` defines five named presets (`off`, `naked-eye` 5°, `binoculars` 7°, `small-scope` 1°, `large-scope` 0.5°). `src/scene/reticle.ts` draws an SVG circle + crosshair on top of the Cesium canvas whose pixel radius is `computeReticleRadiusPx(presetDeg, cameraVfovDeg, canvasHeightPx)` — derived from the projection geometry of the current camera. The selected preset is persisted in URL state as `fov`.
+
+## View direction and trackball camera
+
+`src/scene/camera.ts` exposes two functions:
+
+- `setCameraView(camera, lat, lon, az, alt)` — used at boot and whenever the user picks a view preset, clicks a planet-info name, or drops a search result; clamps `alt` to `[0°, 89.9°]` to avoid gimbal lock at the zenith.
+- `setupTrackballControls(viewer)` — disables Cesium's default camera controls and installs a pointer-drag handler that rotates the camera around the observer using quaternion deltas. Drag gestures are clamped into the same range. The observer position is fixed at 1.7 m above the ground (`const height = 1.7`), matching a human looking up.
+
+The current view is mirrored to `AppState.view` so the URL preserves the exact camera direction.
+
+## Night vision
+
+A global CSS class `night-vision` on `<body>` applies a sepia/saturate/brightness/hue-rotate filter to the whole viewport (see `index.html`). Toggling the 🔴 button in the panel header fires `toggle-night-vision`, which both flips the class and serialises `nv=1` to the URL.
+
+## Magnitude filter
+
+The Layers panel has a single slider (1.0–6.0, default 6.0) that sets `AppState.magLimit`. `filterVisibleStars` in `src/astro/visibility.ts` rejects stars with `mag > magLimit` before passing them to the scene layer; the worker receives the full catalog and the filter is applied in `buildAltAzStars` after the worker returns. Serialised to the URL as `mag`.
+
+## "Now" button and geolocation
+
+The 📍 button in the time controls fires a `now` intent. `app.ts::handleIntent` sets `timeUtc` to the current `Date()` immediately, re-schedules a rerender, and then (if the browser supports it) calls `navigator.geolocation.getCurrentPosition`. On success the observer lat/lon is updated too; on failure/denial only the time change sticks.
+
+## Copy link
+
+The 🔗 button in the panel header reads the current URL (which is already kept in sync with state by `updateUrl`) and writes it to the clipboard via `navigator.clipboard.writeText` with a `document.execCommand("copy")` fallback. No server round-trip and no extra state — it is a thin helper on top of the URL-is-state principle.
+
+## PWA and service worker
+
+`public/manifest.json` registers Planisphere as an installable PWA. `public/sw.js` is a hand-rolled service worker registered from `src/main.ts` **only when `import.meta.env.PROD` is true** (registering in dev caches Vite's HMR chunks and makes the site look broken on refresh). Caching policy:
+
+- **App shell and static assets** — cache-first with network fallback. On install the SW pre-caches `/`, `/index.html`, `/favicon.svg`, and `/manifest.json` into `planisphere-v1`. Any other successful `GET` is also cached on the fly.
+- **CelesTrak TLE requests** — network-first with cache fallback, because TLEs decay quickly. A cached TLE is only served when the network is unreachable.
+- **Cache versioning** — a single `CACHE_VERSION` string; on `activate` every other cache is purged. Bump the version when the shell contents change.
 
 ## TLE fetch and fallback flow
 
@@ -224,16 +469,17 @@ This uses **@vitest/coverage-v8** (V8's built-in coverage). After running, it:
 
 Coverage thresholds are defined in `vitest.config.ts`:
 
-| Module          | Lines | Branches | Rationale                               |
-| --------------- | ----- | -------- | --------------------------------------- |
-| `src/result/**` | ≥ 90% | ≥ 85%    | Pure logic, fully testable              |
-| `src/state/**`  | ≥ 90% | ≥ 85%    | Pure logic, fully testable              |
-| `src/astro/**`  | ≥ 90% | ≥ 85%    | Pure math, fully testable               |
-| `src/sat/**`    | ≥ 90% | ≥ 85%    | Pure logic, fully testable              |
-| `src/scene/**`  | ≥ 80% | ≥ 70%    | Mocked Cesium limits coverage           |
-| `src/ui/**`     | ≥ 80% | ≥ 70%    | DOM tests, harder to cover exhaustively |
-| `src/app.ts`    | ≥ 80% | ≥ 70%    | Integration module                      |
-| Project floor   | ≥ 85% | ≥ 80%    | Safety net for any unlisted files       |
+| Module           | Lines | Branches | Rationale                                                                                             |
+| ---------------- | ----- | -------- | ----------------------------------------------------------------------------------------------------- |
+| `src/result/**`  | ≥ 90% | ≥ 85%    | Pure logic, fully testable                                                                            |
+| `src/state/**`   | ≥ 90% | ≥ 85%    | Pure logic, fully testable                                                                            |
+| `src/astro/**`   | ≥ 90% | ≥ 85%    | Pure math, fully testable                                                                             |
+| `src/sat/**`     | ≥ 90% | ≥ 85%    | Pure logic, fully testable                                                                            |
+| `src/scene/**`   | ≥ 80% | ≥ 70%    | Mocked Cesium limits coverage                                                                         |
+| `src/ui/**`      | ≥ 80% | ≥ 70%    | DOM tests, harder to cover exhaustively                                                               |
+| `src/app.ts`     | ≥ 80% | ≥ 70%    | Integration module                                                                                    |
+| `src/workers/**` | ≥ 60% | ≥ 50%    | `astro-worker.ts` runs in a real Worker context (not jsdom-testable); math lives in `worker-math.ts`. |
+| Project floor    | ≥ 85% | ≥ 80%    | Safety net for any unlisted files                                                                     |
 
 **Never lower a threshold to make a PR pass.** Add tests or narrow the change instead.
 
@@ -315,14 +561,16 @@ node scripts/build-tle.mjs              # ~150 visual satellites from CelesTrak 
 
 Each script fetches from an external URL and writes a committed data file. Internet access required.
 
-| Data file                  | Source                        | Refresh cadence                             |
-| -------------------------- | ----------------------------- | ------------------------------------------- |
-| `data/stars.json`          | HYG Database (Hipparcos)      | Never (catalog is fixed)                    |
-| `data/constellations.json` | Stellarium v23.4              | Never (IAU stick figures are fixed)         |
-| `data/boundaries.json`     | d3-celestial (IAU boundaries) | Never (boundaries are fixed)                |
-| `data/tle/visual.txt`      | CelesTrak                     | Weekly or before demos (TLEs decay in days) |
+| Data file                                     | Source                        | Refresh cadence                             |
+| --------------------------------------------- | ----------------------------- | ------------------------------------------- |
+| `data/stars.json`                             | HYG Database (Hipparcos)      | Never (catalog is fixed)                    |
+| `data/constellations.json`                    | Stellarium v23.4              | Never (IAU stick figures are fixed)         |
+| `data/boundaries.json`                        | d3-celestial (IAU boundaries) | Never (boundaries are fixed)                |
+| `data/messier.json`                           | Messier catalog               | Never (catalog is fixed)                    |
+| `data/constellation-names/{en,zh,ar,el}.json` | Hand-curated translations     | Edit in place when translations change      |
+| `data/tle/visual.txt`                         | CelesTrak                     | Weekly or before demos (TLEs decay in days) |
 
-The app also fetches TLE data at runtime from CelesTrak — the bundled file is a fallback for when that fetch fails.
+The app also fetches TLE data at runtime from CelesTrak — the bundled file is a fallback for when that fetch fails. The service worker uses a network-first policy for CelesTrak requests so a cached TLE is only served when offline.
 
 ## CI — GitHub Actions
 


### PR DESCRIPTION
## Summary

- Rewrote `docs/architecture.md` to reflect the current repo: adds the `workers/` module, updates the module dependency graph / data flow / layer class diagram, and documents `AppState`, the full URL-parameter surface (`lat`, `lon`, `t`, `layers`, `op_cl|cb|st|grid|ecl|mw`, `vaz`, `valt`, `nv`, `mag`, `lang`, `fov`), the `UIIntent` union, and the worker sequence.
- Added short per-subsystem sections for every post-v1 feature: star colors (B-V), Milky Way glow band, Messier deep-sky catalog, RA/Dec grid, ecliptic, constellation boundaries, multi-language constellation names, search, click-to-identify and the planet info panel, object trails, telescope FOV reticle, view direction + trackball camera, night vision, magnitude filter, 📍 Now button, Copy link, and the PWA / service worker.
- Updated coverage threshold table to include `src/workers/**` (60% / 50%).
- Updated the data-file regeneration table with `messier.json` and `data/constellation-names/{en,zh,ar,el}.json`.
- Rewrote `README.md`: user-facing feature list, updated 8-module architecture table, pointers to `docs/architecture.md` and `docs/user-guide.md`.
- Docs-only change; no source files edited.

Closes #169.

## Test plan

- [x] `pnpm typecheck` — green
- [x] `pnpm lint` — green (ESLint + SPDX headers)
- [x] `pnpm format:check` — green (Prettier)
- [x] `pnpm test` — 554 tests pass
- [x] `pnpm build` — production build succeeds
- [ ] Reviewer: skim `docs/architecture.md` end-to-end to confirm each subsystem section accurately matches the code it references

🤖 Generated with [Claude Code](https://claude.com/claude-code)