### PR TITLE
feat(ux): events drawer replaces always-on events section (closes #197)

### DIFF
--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -208,14 +208,33 @@ vi.mock("../data/boundaries.json", () => ({
 // Captured dispatch function from UI mock — used in intent tests
 let capturedDispatch: ((intent: unknown) => void) | null = null;
 
+// Captured panel options from UI mock — lets tests assert on drawer wiring.
+let capturedPanelOptions: { onOpenEvents?: () => void; onOpenHelp?: () => void } | null = null;
+
+// Captured events-drawer setEvents spy — lets tests assert it was called when
+// `set-time` / `set-observer` / `now` intents fire.
+const eventsDrawerSetEvents = vi.fn();
+const eventsDrawerOpen = vi.fn();
+
 // Mock UI modules — they exercise DOM which is fully covered in their own tests
 vi.mock("./ui", () => ({
-  createPanel: vi.fn().mockReturnValue({
-    element: document.createElement("div"),
-    setContent: vi.fn(),
-    setCollapsed: vi.fn(),
-    setNightVision: vi.fn(),
-  }),
+  createPanel: vi
+    .fn()
+    .mockImplementation(
+      (
+        _root: HTMLElement,
+        _dispatch: unknown,
+        options?: { onOpenEvents?: () => void; onOpenHelp?: () => void },
+      ) => {
+        capturedPanelOptions = options ?? null;
+        return {
+          element: document.createElement("div"),
+          setContent: vi.fn(),
+          setCollapsed: vi.fn(),
+          setNightVision: vi.fn(),
+        };
+      },
+    ),
   createLocationControls: vi.fn().mockReturnValue(document.createElement("div")),
   createLayerControls: vi.fn().mockReturnValue(document.createElement("div")),
   createViewControls: vi.fn().mockReturnValue(document.createElement("div")),
@@ -223,6 +242,23 @@ vi.mock("./ui", () => ({
   createSearch: vi.fn().mockReturnValue(document.createElement("div")),
   createFovControls: vi.fn().mockReturnValue(document.createElement("div")),
   createEventsPanel: vi.fn().mockReturnValue(document.createElement("div")),
+  createEventsDrawer: vi.fn().mockImplementation(() => {
+    const element = document.createElement("div");
+    element.dataset.testid = "events-drawer";
+    let open = false;
+    return {
+      element,
+      open: vi.fn().mockImplementation(() => {
+        open = true;
+        eventsDrawerOpen();
+      }),
+      close: vi.fn().mockImplementation(() => {
+        open = false;
+      }),
+      isOpen: vi.fn().mockImplementation(() => open),
+      setEvents: eventsDrawerSetEvents,
+    };
+  }),
   createHelpModal: vi.fn().mockReturnValue({
     element: document.createElement("div"),
     open: vi.fn(),
@@ -860,6 +896,109 @@ describe("handleIntent routing", () => {
     expect(writeText).toHaveBeenCalledOnce();
     document.body.removeChild(root);
     document.body.removeChild(panelRoot);
+  });
+
+  it("mounts the events drawer on the document body", async () => {
+    capturedDispatch = null;
+    capturedPanelOptions = null;
+    eventsDrawerSetEvents.mockClear();
+    eventsDrawerOpen.mockClear();
+    const { root, panelRoot } = makeRoot();
+    await bootstrap(root);
+
+    expect(document.querySelector("[data-testid='events-drawer']")).not.toBeNull();
+    document.body.removeChild(root);
+    document.body.removeChild(panelRoot);
+    document
+      .querySelectorAll("[data-testid='events-drawer']")
+      .forEach((el) => el.parentNode?.removeChild(el));
+  });
+
+  it("events drawer is refreshed on set-time intent", async () => {
+    vi.useFakeTimers();
+    capturedDispatch = null;
+    capturedPanelOptions = null;
+    eventsDrawerSetEvents.mockClear();
+    eventsDrawerOpen.mockClear();
+    const { root, panelRoot } = makeRoot();
+    await bootstrap(root);
+
+    const beforeCount = eventsDrawerSetEvents.mock.calls.length;
+    capturedDispatch!({ type: "set-time", time: new Date("2026-05-01T00:00:00Z") });
+    expect(eventsDrawerSetEvents.mock.calls.length).toBeGreaterThan(beforeCount);
+
+    vi.advanceTimersByTime(100);
+    document.body.removeChild(root);
+    document.body.removeChild(panelRoot);
+    document
+      .querySelectorAll("[data-testid='events-drawer']")
+      .forEach((el) => el.parentNode?.removeChild(el));
+    vi.useRealTimers();
+  });
+
+  it("events drawer is refreshed on set-observer intent", async () => {
+    vi.useFakeTimers();
+    capturedDispatch = null;
+    capturedPanelOptions = null;
+    eventsDrawerSetEvents.mockClear();
+    eventsDrawerOpen.mockClear();
+    const { root, panelRoot } = makeRoot();
+    await bootstrap(root);
+
+    const beforeCount = eventsDrawerSetEvents.mock.calls.length;
+    capturedDispatch!({ type: "set-observer", lat: 48.8, lon: 2.35 });
+    expect(eventsDrawerSetEvents.mock.calls.length).toBeGreaterThan(beforeCount);
+
+    vi.advanceTimersByTime(100);
+    document.body.removeChild(root);
+    document.body.removeChild(panelRoot);
+    document
+      .querySelectorAll("[data-testid='events-drawer']")
+      .forEach((el) => el.parentNode?.removeChild(el));
+    vi.useRealTimers();
+  });
+
+  it("events drawer is refreshed on now intent", async () => {
+    vi.useFakeTimers();
+    capturedDispatch = null;
+    capturedPanelOptions = null;
+    eventsDrawerSetEvents.mockClear();
+    eventsDrawerOpen.mockClear();
+    Object.defineProperty(navigator, "geolocation", { value: undefined, configurable: true });
+    const { root, panelRoot } = makeRoot();
+    await bootstrap(root);
+
+    const beforeCount = eventsDrawerSetEvents.mock.calls.length;
+    capturedDispatch!({ type: "now" });
+    expect(eventsDrawerSetEvents.mock.calls.length).toBeGreaterThan(beforeCount);
+
+    vi.advanceTimersByTime(100);
+    document.body.removeChild(root);
+    document.body.removeChild(panelRoot);
+    document
+      .querySelectorAll("[data-testid='events-drawer']")
+      .forEach((el) => el.parentNode?.removeChild(el));
+    vi.useRealTimers();
+  });
+
+  it("panel's onOpenEvents callback opens the events drawer", async () => {
+    capturedDispatch = null;
+    capturedPanelOptions = null;
+    eventsDrawerSetEvents.mockClear();
+    eventsDrawerOpen.mockClear();
+    const { root, panelRoot } = makeRoot();
+    await bootstrap(root);
+
+    expect(capturedPanelOptions).not.toBeNull();
+    expect(typeof capturedPanelOptions!.onOpenEvents).toBe("function");
+    capturedPanelOptions!.onOpenEvents!();
+    expect(eventsDrawerOpen).toHaveBeenCalled();
+
+    document.body.removeChild(root);
+    document.body.removeChild(panelRoot);
+    document
+      .querySelectorAll("[data-testid='events-drawer']")
+      .forEach((el) => el.parentNode?.removeChild(el));
   });
 
   it("Ctrl+K / Cmd+K opens the command palette via the global keydown handler", async () => {

--- a/src/app.ts
+++ b/src/app.ts
@@ -75,12 +75,12 @@ import {
   createPlanetInfo,
   createSearch,
   createFovControls,
-  createEventsPanel,
+  createEventsDrawer,
   createHelpModal,
   createBottomHud,
   createCommandPalette,
 } from "./ui";
-import type { BottomHud } from "./ui";
+import type { BottomHud, EventsDrawer } from "./ui";
 import type {
   CommandPalette,
   PaletteSources,
@@ -758,10 +758,11 @@ export async function bootstrap(
   // Planet info wrapper — holds the current planet-info section, refreshed on time/observer changes
   const planetInfoWrapper = document.createElement("div");
 
-  // Events panel wrapper — celestial event alerts (conjunctions / lunar eclipses / meteor showers).
-  // Cached: only recomputed on observer / time changes (events shift forward as `now` advances).
-  const eventsWrapper = document.createElement("div");
+  // Events drawer — celestial event alerts (conjunctions / lunar eclipses / meteor showers / ISS).
+  // Drawer is created at bootstrap (lives on <body>) and refreshed on any observer/time change
+  // regardless of whether it's currently open, so it's always fresh when the user taps 📅.
   let cachedEvents: readonly CelestialEvent[] = [];
+  let eventsDrawer: EventsDrawer | null = null;
 
   function refreshEvents(s: AppState): void {
     const result = computeUpcomingEvents(
@@ -770,7 +771,7 @@ export async function bootstrap(
       satelliteRecords,
     );
     cachedEvents = result.ok ? result.value : [];
-    eventsWrapper.replaceChildren(createEventsPanel(cachedEvents, handleIntent));
+    eventsDrawer?.setEvents(cachedEvents);
   }
 
   function refreshPlanetInfo(s: AppState): void {
@@ -992,6 +993,13 @@ export async function bootstrap(
   const helpModal = createHelpModal();
   document.body.appendChild(helpModal.element);
 
+  // Events drawer — slide-in surface holding the upcoming-events list (replaces
+  // the always-on side-panel section). Created here (after handleIntent is in
+  // scope) and refreshed with the first event list below once satellites load.
+  eventsDrawer = createEventsDrawer({ dispatch: handleIntent });
+  document.body.appendChild(eventsDrawer.element);
+  eventsDrawer.setEvents(cachedEvents);
+
   // Bottom HUD — ambient bar with time, location chip, and compass. Replaces the
   // side-panel Time section (milestone 1A of Plan 07). Appended to <body> so it
   // sits above the cesium canvas independently of the side panel.
@@ -1027,12 +1035,22 @@ export async function bootstrap(
   );
   document.body.appendChild(palette.element);
 
+  // Refresh events now that the drawer is mounted and satelliteRecords are known.
+  // This gives the drawer its first population regardless of whether the side panel
+  // exists (headless / test environments include).
+  refreshEvents(state);
+
   // Build UI panel
   let nightVisionPanel: ReturnType<typeof createPanel> | null = null;
   const panelRoot = document.getElementById("ui-panel-root");
   if (panelRoot) {
     const panel = createPanel(panelRoot, handleIntent, {
       onOpenHelp: () => helpModal.open(),
+      onOpenEvents: () => {
+        // Mutual exclusion: close other open surfaces before opening the drawer.
+        if (helpModal.isOpen()) helpModal.close();
+        eventsDrawer?.open();
+      },
     });
     nightVisionPanel = panel;
     if (state.nightVision) {
@@ -1044,12 +1062,6 @@ export async function bootstrap(
     // Search box — at the top of the panel
     const searchEl = createSearch((query) => searchObjects(searchIndex, query), handleIntent);
     uiContainer.appendChild(searchEl);
-
-    // Events panel sits right after search because Go-to jumps the time cursor;
-    // putting it above the location/layer blocks keeps it above the fold for
-    // typical panel heights.
-    refreshEvents(state);
-    uiContainer.appendChild(eventsWrapper);
 
     const locationEl = createLocationControls(state.observer.lat, state.observer.lon, handleIntent);
     uiContainer.appendChild(locationEl);

--- a/src/ui/events-drawer.test.ts
+++ b/src/ui/events-drawer.test.ts
@@ -1,0 +1,122 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createEventsDrawer } from "./events-drawer";
+import type { CelestialEvent } from "../astro/events";
+
+function makeConjunction(when: Date): CelestialEvent {
+  return {
+    kind: "conjunction",
+    when,
+    title: "Venus – Mars conjunction",
+    description: "Venus and Mars appear within 1.2° of each other.",
+    body1: "Venus",
+    body2: "Mars",
+    separationDeg: 1.2,
+  };
+}
+
+describe("createEventsDrawer", () => {
+  afterEach(() => {
+    // Any drawers attached to body get removed here to keep tests isolated.
+    document.querySelectorAll("[data-testid='events-drawer']").forEach((el) => el.remove());
+  });
+
+  it("returns an object with element, open, close, isOpen, setEvents", () => {
+    const drawer = createEventsDrawer({ dispatch: vi.fn() });
+    expect(drawer).toHaveProperty("element");
+    expect(drawer).toHaveProperty("open");
+    expect(drawer).toHaveProperty("close");
+    expect(drawer).toHaveProperty("isOpen");
+    expect(drawer).toHaveProperty("setEvents");
+  });
+
+  it("is closed by default (element hidden)", () => {
+    const drawer = createEventsDrawer({ dispatch: vi.fn() });
+    expect(drawer.isOpen()).toBe(false);
+    expect(drawer.element.style.display).toBe("none");
+  });
+
+  it("open() shows the drawer and isOpen() returns true", () => {
+    const drawer = createEventsDrawer({ dispatch: vi.fn() });
+    drawer.open();
+    expect(drawer.isOpen()).toBe(true);
+    expect(drawer.element.style.display).not.toBe("none");
+  });
+
+  it("close() hides the drawer and isOpen() returns false", () => {
+    const drawer = createEventsDrawer({ dispatch: vi.fn() });
+    drawer.open();
+    drawer.close();
+    expect(drawer.isOpen()).toBe(false);
+    expect(drawer.element.style.display).toBe("none");
+  });
+
+  it("renders the Events heading via the wrapped events panel", () => {
+    const drawer = createEventsDrawer({ dispatch: vi.fn() });
+    drawer.setEvents([makeConjunction(new Date("2026-06-10T10:00:00Z"))]);
+    const heading = drawer.element.querySelector("[data-testid='events-heading']");
+    expect(heading).not.toBeNull();
+  });
+
+  it("setEvents() re-renders content with a new list", () => {
+    const drawer = createEventsDrawer({ dispatch: vi.fn() });
+    drawer.setEvents([]);
+    expect(drawer.element.querySelectorAll("[data-testid='event-row']").length).toBe(0);
+
+    drawer.setEvents([
+      makeConjunction(new Date("2026-06-10T10:00:00Z")),
+      makeConjunction(new Date("2026-07-20T18:00:00Z")),
+    ]);
+    expect(drawer.element.querySelectorAll("[data-testid='event-row']").length).toBe(2);
+  });
+
+  it("close button (×) closes the drawer", () => {
+    const drawer = createEventsDrawer({ dispatch: vi.fn() });
+    drawer.open();
+    const closeBtn = drawer.element.querySelector<HTMLButtonElement>(
+      "[data-testid='events-drawer-close']",
+    );
+    expect(closeBtn).not.toBeNull();
+    closeBtn!.click();
+    expect(drawer.isOpen()).toBe(false);
+  });
+
+  it("pressing Escape while open closes the drawer", () => {
+    const drawer = createEventsDrawer({ dispatch: vi.fn() });
+    document.body.appendChild(drawer.element);
+    drawer.open();
+    const evt = new KeyboardEvent("keydown", { key: "Escape" });
+    document.dispatchEvent(evt);
+    expect(drawer.isOpen()).toBe(false);
+  });
+
+  it("pressing Escape while closed is a no-op", () => {
+    const drawer = createEventsDrawer({ dispatch: vi.fn() });
+    document.body.appendChild(drawer.element);
+    // Dispatch Escape while closed — should stay closed, no throw.
+    const evt = new KeyboardEvent("keydown", { key: "Escape" });
+    expect(() => document.dispatchEvent(evt)).not.toThrow();
+    expect(drawer.isOpen()).toBe(false);
+  });
+
+  it("clicking the backdrop closes the drawer", () => {
+    const drawer = createEventsDrawer({ dispatch: vi.fn() });
+    drawer.open();
+    const backdrop = drawer.element.querySelector<HTMLElement>(
+      "[data-testid='events-drawer-backdrop']",
+    );
+    expect(backdrop).not.toBeNull();
+    backdrop!.click();
+    expect(drawer.isOpen()).toBe(false);
+  });
+
+  it("dispatch is passed through to the events panel Go-to button", () => {
+    const dispatch = vi.fn();
+    const drawer = createEventsDrawer({ dispatch });
+    const when = new Date("2026-06-10T10:00:00Z");
+    drawer.setEvents([makeConjunction(when)]);
+    const gotoBtn = drawer.element.querySelector<HTMLButtonElement>("[data-testid='event-goto']")!;
+    gotoBtn.click();
+    expect(dispatch).toHaveBeenCalledWith({ type: "set-time", time: when });
+  });
+});

--- a/src/ui/events-drawer.ts
+++ b/src/ui/events-drawer.ts
@@ -1,0 +1,164 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { createEventsPanel } from "./events-panel";
+import { PANEL_BG, PANEL_BORDER, TEXT_COLOR } from "./styles";
+import type { CelestialEvent } from "../astro/events";
+import type { UIIntent } from "./index";
+
+export type EventsDrawer = {
+  element: HTMLElement;
+  open(): void;
+  close(): void;
+  isOpen(): boolean;
+  setEvents(events: readonly CelestialEvent[]): void;
+};
+
+export type EventsDrawerOptions = {
+  dispatch: (intent: UIIntent) => void;
+};
+
+// TODO: consolidate with settings drawer primitive (issue #196).
+// When #196 lands `src/ui/drawer.ts` exporting a generic `createDrawer`,
+// replace this inline implementation with an import from there.
+type Drawer = {
+  element: HTMLElement;
+  body: HTMLElement;
+  open(): void;
+  close(): void;
+  isOpen(): boolean;
+};
+
+function createDrawer(title: string, testidPrefix: string): Drawer {
+  const root = document.createElement("div");
+  root.dataset.testid = `${testidPrefix}`;
+  root.style.display = "none";
+  root.style.position = "fixed";
+  root.style.inset = "0";
+  root.style.zIndex = "1500";
+
+  const backdrop = document.createElement("div");
+  backdrop.dataset.testid = `${testidPrefix}-backdrop`;
+  backdrop.style.position = "absolute";
+  backdrop.style.inset = "0";
+  backdrop.style.background = "rgba(0,0,0,0.4)";
+
+  const panel = document.createElement("aside");
+  panel.dataset.testid = `${testidPrefix}-panel`;
+  panel.style.position = "absolute";
+  panel.style.top = "0";
+  panel.style.right = "0";
+  panel.style.height = "100vh";
+  // Responsive: full viewport on narrow screens, 360px on wider ones. `min` keeps
+  // the drawer from exceeding the viewport on phones while sizing to 360 on desktop.
+  panel.style.width = "min(100vw, 360px)";
+  panel.style.background = PANEL_BG;
+  panel.style.borderLeft = PANEL_BORDER;
+  panel.style.boxSizing = "border-box";
+  panel.style.display = "flex";
+  panel.style.flexDirection = "column";
+
+  const header = document.createElement("div");
+  header.style.display = "flex";
+  header.style.justifyContent = "space-between";
+  header.style.alignItems = "center";
+  header.style.padding = "8px 12px";
+  header.style.borderBottom = "1px solid rgba(255,255,255,0.15)";
+  header.style.flexShrink = "0";
+
+  const titleEl = document.createElement("span");
+  titleEl.textContent = title;
+  titleEl.style.color = TEXT_COLOR;
+  titleEl.style.fontSize = "14px";
+  titleEl.style.fontWeight = "bold";
+  titleEl.style.fontFamily = "sans-serif";
+
+  const closeBtn = document.createElement("button");
+  closeBtn.dataset.testid = `${testidPrefix}-close`;
+  closeBtn.textContent = "×";
+  closeBtn.title = "Close (Esc)";
+  closeBtn.style.background = "rgba(255,255,255,0.1)";
+  closeBtn.style.border = "1px solid rgba(255,255,255,0.3)";
+  closeBtn.style.borderRadius = "4px";
+  closeBtn.style.color = TEXT_COLOR;
+  closeBtn.style.cursor = "pointer";
+  closeBtn.style.fontSize = "18px";
+  closeBtn.style.lineHeight = "1";
+  closeBtn.style.padding = "2px 10px";
+
+  header.appendChild(titleEl);
+  header.appendChild(closeBtn);
+
+  const body = document.createElement("div");
+  body.dataset.testid = `${testidPrefix}-body`;
+  body.style.overflowY = "auto";
+  body.style.padding = "12px";
+  body.style.flex = "1 1 auto";
+
+  panel.appendChild(header);
+  panel.appendChild(body);
+  root.appendChild(backdrop);
+  root.appendChild(panel);
+
+  let open = false;
+
+  function doOpen(): void {
+    open = true;
+    root.style.display = "block";
+  }
+
+  function doClose(): void {
+    open = false;
+    root.style.display = "none";
+  }
+
+  backdrop.addEventListener("click", doClose);
+  closeBtn.addEventListener("click", doClose);
+
+  document.addEventListener("keydown", (e) => {
+    if (e.key === "Escape" && open) {
+      doClose();
+    }
+  });
+
+  return {
+    element: root,
+    body,
+    open: doOpen,
+    close: doClose,
+    isOpen: () => open,
+  };
+}
+
+/**
+ * Slide-in drawer holding the celestial-events list.
+ *
+ * The drawer is a thin container around `createEventsPanel`: same rows, same
+ * Go-to button, same empty state. Opened via the 📅 icon on the side panel.
+ * Content is refreshed via `setEvents(events)` — callers (app.ts) should call
+ * this on every `set-time` / `set-observer` / `now` intent so the list is
+ * current whenever the user opens the drawer.
+ */
+export function createEventsDrawer(options: EventsDrawerOptions): EventsDrawer {
+  const drawer = createDrawer("Upcoming Events", "events-drawer");
+  const { dispatch } = options;
+
+  let currentEvents: readonly CelestialEvent[] = [];
+
+  function render(): void {
+    drawer.body.replaceChildren(createEventsPanel(currentEvents, dispatch));
+  }
+
+  // Render once with the empty list so the drawer shows "no upcoming events"
+  // even before the first refresh call.
+  render();
+
+  return {
+    element: drawer.element,
+    open: () => drawer.open(),
+    close: () => drawer.close(),
+    isOpen: () => drawer.isOpen(),
+    setEvents(events) {
+      currentEvents = events;
+      render();
+    },
+  };
+}

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -10,6 +10,8 @@ export { createPlanetInfo } from "./planet-info";
 export { createSearch } from "./search";
 export { createFovControls } from "./fov-controls";
 export { createEventsPanel } from "./events-panel";
+export { createEventsDrawer } from "./events-drawer";
+export type { EventsDrawer, EventsDrawerOptions } from "./events-drawer";
 export type { HelpModal } from "./help-modal";
 export { createHelpModal } from "./help-modal";
 export { createBottomHud } from "./bottom-hud";

--- a/src/ui/panel.test.ts
+++ b/src/ui/panel.test.ts
@@ -116,6 +116,34 @@ describe("createPanel", () => {
     });
   });
 
+  describe("events button", () => {
+    it("renders an events (📅) button in the header", () => {
+      const { element } = createPanel(container);
+      const btn = element.querySelector("[data-testid='panel-events']");
+      expect(btn).not.toBeNull();
+    });
+
+    it("displays the 📅 icon", () => {
+      const { element } = createPanel(container);
+      const btn = element.querySelector<HTMLButtonElement>("[data-testid='panel-events']")!;
+      expect(btn.textContent).toBe("\u{1F4C5}");
+    });
+
+    it("clicking the events button invokes the provided onOpenEvents callback", () => {
+      const onOpenEvents = vi.fn();
+      const { element } = createPanel(container, vi.fn(), { onOpenEvents });
+      const btn = element.querySelector<HTMLButtonElement>("[data-testid='panel-events']")!;
+      btn.click();
+      expect(onOpenEvents).toHaveBeenCalledTimes(1);
+    });
+
+    it("clicking the events button is a no-op when no callback is provided", () => {
+      const { element } = createPanel(container);
+      const btn = element.querySelector<HTMLButtonElement>("[data-testid='panel-events']")!;
+      expect(() => btn.click()).not.toThrow();
+    });
+  });
+
   describe("copy-link button", () => {
     beforeEach(() => {
       Object.defineProperty(navigator, "clipboard", {

--- a/src/ui/panel.ts
+++ b/src/ui/panel.ts
@@ -19,6 +19,7 @@ export type Panel = {
 
 export type PanelOptions = {
   onOpenHelp?: () => void;
+  onOpenEvents?: () => void;
 };
 
 export function createPanel(
@@ -72,6 +73,12 @@ export function createPanel(
   copyLinkBtn.title = "Copy link";
   applyButton(copyLinkBtn);
 
+  const eventsBtn = document.createElement("button");
+  eventsBtn.dataset.testid = "panel-events";
+  eventsBtn.textContent = "\u{1F4C5}";
+  eventsBtn.title = "Upcoming events";
+  applyButton(eventsBtn);
+
   const helpBtn = document.createElement("button");
   helpBtn.dataset.testid = "panel-help";
   helpBtn.textContent = "?";
@@ -86,6 +93,7 @@ export function createPanel(
 
   btnGroup.appendChild(nightVisionBtn);
   btnGroup.appendChild(copyLinkBtn);
+  btnGroup.appendChild(eventsBtn);
   btnGroup.appendChild(helpBtn);
   btnGroup.appendChild(toggleBtn);
 
@@ -109,6 +117,10 @@ export function createPanel(
 
   helpBtn.addEventListener("click", () => {
     options.onOpenHelp?.();
+  });
+
+  eventsBtn.addEventListener("click", () => {
+    options.onOpenEvents?.();
   });
 
   copyLinkBtn.addEventListener("click", () => {


### PR DESCRIPTION
## Summary

- Moves the **Upcoming Events** list out of the side-panel body and into a slide-in drawer on the right edge of the viewport, triggered by a new **📅** icon in the side-panel header.
- `createEventsPanel` is unchanged — the drawer is a thin container around it. Same rows, same Go-to button, same empty state.
- Content is refreshed on every `set-time` / `set-observer` / `now` intent regardless of whether the drawer is open, so the list is current whenever the user opens it.
- Closes via **×** button, **Esc** key, or **backdrop click**.
- Mutual exclusion: opening the drawer closes the help modal if it was open. (When #196's settings drawer lands, that rebase should add it here too.)
- Removes the always-on events section from the panel body — the drawer fully replaces it.

## Drawer-primitive reuse status

**Inlined.** #196 (settings drawer) hasn't landed yet in main at the time of this PR, so this PR includes a minimal `createDrawer` helper inside `src/ui/events-drawer.ts` with a `// TODO: consolidate with settings drawer primitive` marker. When #196 merges first and exports `src/ui/drawer.ts`, the rebase should replace this inlined helper with an import from there.

## Expected conflicts on rebase

- **#196 (settings drawer)** — both PRs add a header icon to `src/ui/panel.ts` and wire a drawer in `src/app.ts`. Standard "keep both" resolution. Also switch `events-drawer.ts` to import `createDrawer` from `src/ui/drawer.ts` once #196's version exists.
- **#194 (object cards)** — both may touch `src/app.ts` and the `UIIntent` union in `src/ui/index.ts`. Standard keep-both rebase.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm test:cov` — 867 tests pass (20 new), line coverage 95.12% (pure modules ≥ 90%, integration ≥ 80%, project ≥ 85% all cleared)
- [x] `pnpm build` — clean

New tests:

- `src/ui/events-drawer.test.ts` — open/close/isOpen, setEvents re-renders rows, Esc closes, backdrop click closes, × button closes, dispatch is piped through to Go-to.
- `src/ui/panel.test.ts` — 📅 icon renders, click invokes `onOpenEvents`, no-op when no callback.
- `src/app.test.ts` — events drawer mounts on body, `set-time` / `set-observer` / `now` refresh it, panel's `onOpenEvents` opens the drawer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)