### PR TITLE
feat(ux): settings drawer replaces side-panel layer controls (closes #196)

### DIFF
--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -225,27 +225,25 @@ const eventsDrawerOpen = vi.fn();
 
 // Mock UI modules — they exercise DOM which is fully covered in their own tests
 vi.mock("./ui", () => ({
-  createPanel: vi
-    .fn()
-    .mockImplementation(
-      (
-        _root: HTMLElement,
-        _dispatch: unknown,
-        options?: {
-          onOpenEvents?: () => void;
-          onOpenSettings?: () => void;
-          onOpenHelp?: () => void;
-        },
-      ) => {
-        capturedPanelOptions = options ?? null;
-        return {
-          element: document.createElement("div"),
-          setContent: vi.fn(),
-          setCollapsed: vi.fn(),
-          setNightVision: vi.fn(),
-        };
+  createPanel: vi.fn().mockImplementation(
+    (
+      _root: HTMLElement,
+      _dispatch: unknown,
+      options?: {
+        onOpenEvents?: () => void;
+        onOpenSettings?: () => void;
+        onOpenHelp?: () => void;
       },
-    ),
+    ) => {
+      capturedPanelOptions = options ?? null;
+      return {
+        element: document.createElement("div"),
+        setContent: vi.fn(),
+        setCollapsed: vi.fn(),
+        setNightVision: vi.fn(),
+      };
+    },
+  ),
   createLocationControls: vi.fn().mockReturnValue(document.createElement("div")),
   createViewControls: vi.fn().mockReturnValue(document.createElement("div")),
   createPlanetInfo: vi.fn().mockReturnValue(document.createElement("div")),

--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -207,6 +207,12 @@ vi.mock("../data/boundaries.json", () => ({
 
 // Captured dispatch function from UI mock — used in intent tests
 let capturedDispatch: ((intent: unknown) => void) | null = null;
+let capturedPanelOptions: { onOpenSettings?: () => void; onOpenHelp?: () => void } | null = null;
+let settingsDrawerMock: {
+  open: ReturnType<typeof vi.fn>;
+  close: ReturnType<typeof vi.fn>;
+  isOpen: ReturnType<typeof vi.fn>;
+} | null = null;
 
 // Captured panel options from UI mock — lets tests assert on drawer wiring.
 let capturedPanelOptions: { onOpenEvents?: () => void; onOpenHelp?: () => void } | null = null;
@@ -224,7 +230,11 @@ vi.mock("./ui", () => ({
       (
         _root: HTMLElement,
         _dispatch: unknown,
-        options?: { onOpenEvents?: () => void; onOpenHelp?: () => void },
+        options?: {
+          onOpenEvents?: () => void;
+          onOpenSettings?: () => void;
+          onOpenHelp?: () => void;
+        },
       ) => {
         capturedPanelOptions = options ?? null;
         return {
@@ -236,7 +246,6 @@ vi.mock("./ui", () => ({
       },
     ),
   createLocationControls: vi.fn().mockReturnValue(document.createElement("div")),
-  createLayerControls: vi.fn().mockReturnValue(document.createElement("div")),
   createViewControls: vi.fn().mockReturnValue(document.createElement("div")),
   createPlanetInfo: vi.fn().mockReturnValue(document.createElement("div")),
   createSearch: vi.fn().mockReturnValue(document.createElement("div")),
@@ -264,6 +273,18 @@ vi.mock("./ui", () => ({
     open: vi.fn(),
     close: vi.fn(),
     isOpen: vi.fn().mockReturnValue(false),
+  }),
+  createSettingsDrawer: vi.fn().mockImplementation(() => {
+    const element = document.createElement("div");
+    element.dataset.testid = "settings-drawer-root";
+    const mock = {
+      element,
+      open: vi.fn(),
+      close: vi.fn(),
+      isOpen: vi.fn().mockReturnValue(false),
+    };
+    settingsDrawerMock = mock;
+    return mock;
   }),
   createBottomHud: vi.fn().mockImplementation((_initial: unknown, dispatch: unknown) => {
     capturedDispatch = dispatch as (intent: unknown) => void;
@@ -999,6 +1020,59 @@ describe("handleIntent routing", () => {
     document
       .querySelectorAll("[data-testid='events-drawer']")
       .forEach((el) => el.parentNode?.removeChild(el));
+  });
+
+  it("wires createSettingsDrawer into the panel's onOpenSettings callback", async () => {
+    capturedDispatch = null;
+    capturedPanelOptions = null;
+    settingsDrawerMock = null;
+    const { root, panelRoot } = makeRoot();
+    await bootstrap(root);
+    expect(settingsDrawerMock).not.toBeNull();
+    expect(capturedPanelOptions).not.toBeNull();
+    expect(typeof capturedPanelOptions!.onOpenSettings).toBe("function");
+    capturedPanelOptions!.onOpenSettings!();
+    expect(settingsDrawerMock!.open).toHaveBeenCalled();
+    document.body.removeChild(root);
+    document.body.removeChild(panelRoot);
+  });
+
+  it("settings drawer is mounted on document.body", async () => {
+    capturedDispatch = null;
+    settingsDrawerMock = null;
+    const { root, panelRoot } = makeRoot();
+    await bootstrap(root);
+    expect(document.querySelector("[data-testid='settings-drawer-root']")).not.toBeNull();
+    document.body.removeChild(root);
+    document.body.removeChild(panelRoot);
+    document
+      .querySelectorAll("[data-testid='settings-drawer-root']")
+      .forEach((el) => el.parentNode?.removeChild(el));
+  });
+
+  it("side panel setContent is called without a layer-controls child (moved to drawer)", async () => {
+    const ui = await import("./ui");
+    const panelMock = ui.createPanel as unknown as ReturnType<typeof vi.fn>;
+    const setContent = vi.fn();
+    panelMock.mockReturnValueOnce({
+      element: document.createElement("div"),
+      setContent,
+      setCollapsed: vi.fn(),
+      setNightVision: vi.fn(),
+    });
+    capturedDispatch = null;
+    const { root, panelRoot } = makeRoot();
+    await bootstrap(root);
+    expect(setContent).toHaveBeenCalled();
+    const uiContainer = setContent.mock.calls[0]![0] as HTMLElement;
+    // The drawer-mounted opacity sliders / language selects must NOT appear
+    // in the side panel's UI container anymore.
+    expect(uiContainer.querySelector("select[data-language]")).toBeNull();
+    expect(uiContainer.querySelector("select[data-skyculture]")).toBeNull();
+    expect(uiContainer.querySelector("input[data-mag='limit']")).toBeNull();
+    expect(uiContainer.querySelector("input[data-opacity]")).toBeNull();
+    document.body.removeChild(root);
+    document.body.removeChild(panelRoot);
   });
 
   it("Ctrl+K / Cmd+K opens the command palette via the global keydown handler", async () => {

--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -207,15 +207,16 @@ vi.mock("../data/boundaries.json", () => ({
 
 // Captured dispatch function from UI mock — used in intent tests
 let capturedDispatch: ((intent: unknown) => void) | null = null;
-let capturedPanelOptions: { onOpenSettings?: () => void; onOpenHelp?: () => void } | null = null;
+let capturedPanelOptions: {
+  onOpenEvents?: () => void;
+  onOpenSettings?: () => void;
+  onOpenHelp?: () => void;
+} | null = null;
 let settingsDrawerMock: {
   open: ReturnType<typeof vi.fn>;
   close: ReturnType<typeof vi.fn>;
   isOpen: ReturnType<typeof vi.fn>;
 } | null = null;
-
-// Captured panel options from UI mock — lets tests assert on drawer wiring.
-let capturedPanelOptions: { onOpenEvents?: () => void; onOpenHelp?: () => void } | null = null;
 
 // Captured events-drawer setEvents spy — lets tests assert it was called when
 // `set-time` / `set-observer` / `now` intents fire.

--- a/src/app.ts
+++ b/src/app.ts
@@ -70,7 +70,6 @@ import type { Result } from "./result";
 import {
   createPanel,
   createLocationControls,
-  createLayerControls,
   createViewControls,
   createPlanetInfo,
   createSearch,
@@ -79,6 +78,7 @@ import {
   createHelpModal,
   createBottomHud,
   createCommandPalette,
+  createSettingsDrawer,
 } from "./ui";
 import type { BottomHud, EventsDrawer } from "./ui";
 import type {
@@ -1000,6 +1000,20 @@ export async function bootstrap(
   document.body.appendChild(eventsDrawer.element);
   eventsDrawer.setEvents(cachedEvents);
 
+  // Settings drawer (Plan 07 1E) — slide-in ⚙ drawer that replaces the
+  // Layer block previously rendered in the side panel.
+  const settingsDrawer = createSettingsDrawer({
+    visibility: state.layers,
+    opacity: state.opacity,
+    magLimit: state.magLimit,
+    language: state.language,
+    skyculture: state.skyculture,
+    dispatch: (intent) => {
+      handleIntent(intent);
+    },
+  });
+  document.body.appendChild(settingsDrawer.element);
+
   // Bottom HUD — ambient bar with time, location chip, and compass. Replaces the
   // side-panel Time section (milestone 1A of Plan 07). Appended to <body> so it
   // sits above the cesium canvas independently of the side panel.
@@ -1049,7 +1063,13 @@ export async function bootstrap(
       onOpenEvents: () => {
         // Mutual exclusion: close other open surfaces before opening the drawer.
         if (helpModal.isOpen()) helpModal.close();
+        if (settingsDrawer.isOpen()) settingsDrawer.close();
         eventsDrawer?.open();
+      },
+      onOpenSettings: () => {
+        if (helpModal.isOpen()) helpModal.close();
+        if (eventsDrawer?.isOpen()) eventsDrawer.close();
+        settingsDrawer.open();
       },
     });
     nightVisionPanel = panel;
@@ -1071,16 +1091,6 @@ export async function bootstrap(
 
     const fovEl = createFovControls(state.fov, handleIntent);
     uiContainer.appendChild(fovEl);
-
-    const layerEl = createLayerControls(
-      state.layers,
-      state.opacity,
-      handleIntent,
-      state.magLimit,
-      state.language,
-      state.skyculture,
-    );
-    uiContainer.appendChild(layerEl);
 
     refreshPlanetInfo(state);
     uiContainer.appendChild(planetInfoWrapper);

--- a/src/ui/drawer.test.ts
+++ b/src/ui/drawer.test.ts
@@ -1,0 +1,165 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDrawer } from "./drawer";
+
+describe("createDrawer", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("returns an object with element, open, close, and isOpen", () => {
+    const drawer = createDrawer({ side: "right", width: "320px" });
+    expect(drawer).toHaveProperty("element");
+    expect(typeof drawer.open).toBe("function");
+    expect(typeof drawer.close).toBe("function");
+    expect(typeof drawer.isOpen).toBe("function");
+  });
+
+  it("is hidden initially (not open)", () => {
+    const drawer = createDrawer({ side: "right", width: "320px" });
+    document.body.appendChild(drawer.element);
+    expect(drawer.isOpen()).toBe(false);
+  });
+
+  it("open(content) shows the drawer and mounts the content", () => {
+    const drawer = createDrawer({ side: "right", width: "320px" });
+    document.body.appendChild(drawer.element);
+    const content = document.createElement("div");
+    content.textContent = "hello";
+    content.dataset.testid = "drawer-probe";
+    drawer.open(content);
+    expect(drawer.isOpen()).toBe(true);
+    expect(drawer.element.querySelector("[data-testid='drawer-probe']")).not.toBeNull();
+  });
+
+  it("close() hides the drawer", () => {
+    const drawer = createDrawer({ side: "right", width: "320px" });
+    document.body.appendChild(drawer.element);
+    drawer.open(document.createElement("div"));
+    drawer.close();
+    expect(drawer.isOpen()).toBe(false);
+  });
+
+  it("open() replaces previous content when called again", () => {
+    const drawer = createDrawer({ side: "right", width: "320px" });
+    document.body.appendChild(drawer.element);
+    const a = document.createElement("div");
+    a.dataset.testid = "a";
+    const b = document.createElement("div");
+    b.dataset.testid = "b";
+    drawer.open(a);
+    drawer.open(b);
+    expect(drawer.element.querySelector("[data-testid='a']")).toBeNull();
+    expect(drawer.element.querySelector("[data-testid='b']")).not.toBeNull();
+  });
+
+  it("close button (×) in the drawer closes it", () => {
+    const drawer = createDrawer({ side: "right", width: "320px" });
+    document.body.appendChild(drawer.element);
+    drawer.open(document.createElement("div"));
+    const btn = drawer.element.querySelector<HTMLButtonElement>("[data-testid='drawer-close']");
+    expect(btn).not.toBeNull();
+    btn!.click();
+    expect(drawer.isOpen()).toBe(false);
+  });
+
+  it("Escape key closes the drawer when open", () => {
+    const drawer = createDrawer({ side: "right", width: "320px" });
+    document.body.appendChild(drawer.element);
+    drawer.open(document.createElement("div"));
+    const evt = new KeyboardEvent("keydown", { key: "Escape" });
+    document.dispatchEvent(evt);
+    expect(drawer.isOpen()).toBe(false);
+  });
+
+  it("Escape key is a no-op when drawer is closed", () => {
+    const drawer = createDrawer({ side: "right", width: "320px" });
+    document.body.appendChild(drawer.element);
+    const onClose = vi.fn();
+    const drawer2 = createDrawer({ side: "right", width: "320px", onClose });
+    document.body.appendChild(drawer2.element);
+    const evt = new KeyboardEvent("keydown", { key: "Escape" });
+    document.dispatchEvent(evt);
+    expect(drawer.isOpen()).toBe(false);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("backdrop click closes the drawer", () => {
+    const drawer = createDrawer({ side: "right", width: "320px" });
+    document.body.appendChild(drawer.element);
+    drawer.open(document.createElement("div"));
+    const backdrop = drawer.element.querySelector<HTMLElement>("[data-testid='drawer-backdrop']");
+    expect(backdrop).not.toBeNull();
+    backdrop!.click();
+    expect(drawer.isOpen()).toBe(false);
+  });
+
+  it("clicking inside the drawer panel does NOT close it", () => {
+    const drawer = createDrawer({ side: "right", width: "320px" });
+    document.body.appendChild(drawer.element);
+    const content = document.createElement("div");
+    content.dataset.testid = "inside";
+    drawer.open(content);
+    const inside = drawer.element.querySelector<HTMLElement>("[data-testid='inside']")!;
+    inside.click();
+    expect(drawer.isOpen()).toBe(true);
+  });
+
+  it("onClose callback is fired when the drawer closes via close()", () => {
+    const onClose = vi.fn();
+    const drawer = createDrawer({ side: "right", width: "320px", onClose });
+    document.body.appendChild(drawer.element);
+    drawer.open(document.createElement("div"));
+    drawer.close();
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("onClose fires when closed via Escape", () => {
+    const onClose = vi.fn();
+    const drawer = createDrawer({ side: "right", width: "320px", onClose });
+    document.body.appendChild(drawer.element);
+    drawer.open(document.createElement("div"));
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("onClose fires when closed via backdrop click", () => {
+    const onClose = vi.fn();
+    const drawer = createDrawer({ side: "right", width: "320px", onClose });
+    document.body.appendChild(drawer.element);
+    drawer.open(document.createElement("div"));
+    drawer.element
+      .querySelector<HTMLElement>("[data-testid='drawer-backdrop']")!
+      .click();
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("onClose does NOT fire when closed while already closed (no-op close)", () => {
+    const onClose = vi.fn();
+    const drawer = createDrawer({ side: "right", width: "320px", onClose });
+    document.body.appendChild(drawer.element);
+    drawer.close();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("accepts numeric width (interpreted as px)", () => {
+    const drawer = createDrawer({ side: "right", width: 400 });
+    document.body.appendChild(drawer.element);
+    drawer.open(document.createElement("div"));
+    const panel = drawer.element.querySelector<HTMLElement>("[data-testid='drawer-panel']")!;
+    expect(panel.style.width).toBe("400px");
+  });
+
+  it("supports side='left' by positioning the panel on the left", () => {
+    const drawer = createDrawer({ side: "left", width: "280px" });
+    document.body.appendChild(drawer.element);
+    drawer.open(document.createElement("div"));
+    const panel = drawer.element.querySelector<HTMLElement>("[data-testid='drawer-panel']")!;
+    // Panel should be anchored to left edge for side='left'
+    expect(panel.style.left).toBe("0px");
+  });
+});

--- a/src/ui/drawer.test.ts
+++ b/src/ui/drawer.test.ts
@@ -132,9 +132,7 @@ describe("createDrawer", () => {
     const drawer = createDrawer({ side: "right", width: "320px", onClose });
     document.body.appendChild(drawer.element);
     drawer.open(document.createElement("div"));
-    drawer.element
-      .querySelector<HTMLElement>("[data-testid='drawer-backdrop']")!
-      .click();
+    drawer.element.querySelector<HTMLElement>("[data-testid='drawer-backdrop']")!.click();
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 

--- a/src/ui/drawer.ts
+++ b/src/ui/drawer.ts
@@ -1,0 +1,133 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { PANEL_BG, PANEL_BORDER, TEXT_COLOR } from "./styles";
+
+export type DrawerSide = "left" | "right";
+
+export type DrawerOptions = {
+  side: DrawerSide;
+  width: string | number;
+  onClose?: () => void;
+};
+
+export type Drawer = {
+  element: HTMLElement;
+  open: (content: HTMLElement) => void;
+  close: () => void;
+  isOpen: () => boolean;
+};
+
+/**
+ * A reusable slide-in drawer primitive shared across milestones 1E/1F/1G.
+ *
+ * - `side` controls which edge the drawer is anchored to (`"right"` for the
+ *   settings / events drawers; `"left"` reserved for future use).
+ * - `width` is forwarded to the panel's CSS width (number → px).
+ * - `onClose` fires whenever the drawer transitions from open → closed,
+ *   regardless of trigger (explicit `close()`, Escape, backdrop click).
+ *   It's the caller's hook for syncing "active drawer" state in the composer.
+ *
+ * The DOM is structured as `element > [backdrop, panel]`. `element.style.display`
+ * is used to flip the whole overlay; CSS `translateX` on the panel mirrors
+ * the help-modal slide pattern so future animation work has a hook.
+ */
+export function createDrawer(options: DrawerOptions): Drawer {
+  const { side, width, onClose } = options;
+
+  const root = document.createElement("div");
+  root.dataset.testid = "drawer";
+  root.style.display = "none";
+  root.style.position = "fixed";
+  root.style.inset = "0";
+  root.style.zIndex = "2000";
+
+  const backdrop = document.createElement("div");
+  backdrop.dataset.testid = "drawer-backdrop";
+  backdrop.style.position = "absolute";
+  backdrop.style.inset = "0";
+  backdrop.style.background = "rgba(0,0,0,0.5)";
+
+  const panel = document.createElement("div");
+  panel.dataset.testid = "drawer-panel";
+  panel.style.position = "absolute";
+  panel.style.top = "0";
+  panel.style.bottom = "0";
+  panel.style.width = typeof width === "number" ? `${String(width)}px` : width;
+  panel.style.maxWidth = "100vw";
+  panel.style.background = PANEL_BG;
+  panel.style.boxSizing = "border-box";
+  panel.style.display = "flex";
+  panel.style.flexDirection = "column";
+  if (side === "right") {
+    panel.style.right = "0";
+    panel.style.borderLeft = PANEL_BORDER;
+  } else {
+    panel.style.left = "0";
+    panel.style.borderRight = PANEL_BORDER;
+  }
+
+  // Header with close button. Consumers render their own title inside the body.
+  const header = document.createElement("div");
+  header.dataset.testid = "drawer-header";
+  header.style.display = "flex";
+  header.style.justifyContent = "flex-end";
+  header.style.alignItems = "center";
+  header.style.padding = "8px 12px";
+  header.style.borderBottom = "1px solid rgba(255,255,255,0.15)";
+  header.style.flexShrink = "0";
+
+  const closeBtn = document.createElement("button");
+  closeBtn.dataset.testid = "drawer-close";
+  closeBtn.textContent = "×";
+  closeBtn.title = "Close (Esc)";
+  closeBtn.style.background = "rgba(255,255,255,0.1)";
+  closeBtn.style.border = "1px solid rgba(255,255,255,0.3)";
+  closeBtn.style.borderRadius = "4px";
+  closeBtn.style.color = TEXT_COLOR;
+  closeBtn.style.cursor = "pointer";
+  closeBtn.style.fontSize = "18px";
+  closeBtn.style.lineHeight = "1";
+  closeBtn.style.padding = "2px 10px";
+  header.appendChild(closeBtn);
+
+  const body = document.createElement("div");
+  body.dataset.testid = "drawer-body";
+  body.style.overflowY = "auto";
+  body.style.padding = "12px 14px";
+  body.style.flex = "1 1 auto";
+
+  panel.appendChild(header);
+  panel.appendChild(body);
+  root.appendChild(backdrop);
+  root.appendChild(panel);
+
+  let open = false;
+
+  function doOpen(content: HTMLElement): void {
+    body.replaceChildren(content);
+    open = true;
+    root.style.display = "block";
+  }
+
+  function doClose(): void {
+    if (!open) return;
+    open = false;
+    root.style.display = "none";
+    onClose?.();
+  }
+
+  backdrop.addEventListener("click", doClose);
+  closeBtn.addEventListener("click", doClose);
+
+  document.addEventListener("keydown", (e) => {
+    if (e.key === "Escape" && open) {
+      doClose();
+    }
+  });
+
+  return {
+    element: root,
+    open: doOpen,
+    close: doClose,
+    isOpen: () => open,
+  };
+}

--- a/src/ui/drawer.ts
+++ b/src/ui/drawer.ts
@@ -7,6 +7,13 @@ export type DrawerOptions = {
   side: DrawerSide;
   width: string | number;
   onClose?: () => void;
+  /**
+   * Content to mount into the drawer body at creation time. Callers that hold
+   * a stable content element and mutate its children (e.g. re-rendering on
+   * state changes) should use this so the body is populated even while the
+   * drawer is hidden. `open(content)` still replaces body children on each open.
+   */
+  initialContent?: HTMLElement;
 };
 
 export type Drawer = {
@@ -31,7 +38,7 @@ export type Drawer = {
  * the help-modal slide pattern so future animation work has a hook.
  */
 export function createDrawer(options: DrawerOptions): Drawer {
-  const { side, width, onClose } = options;
+  const { side, width, onClose, initialContent } = options;
 
   const root = document.createElement("div");
   root.dataset.testid = "drawer";
@@ -99,6 +106,10 @@ export function createDrawer(options: DrawerOptions): Drawer {
   panel.appendChild(body);
   root.appendChild(backdrop);
   root.appendChild(panel);
+
+  if (initialContent !== undefined) {
+    body.replaceChildren(initialContent);
+  }
 
   let open = false;
 

--- a/src/ui/events-drawer.ts
+++ b/src/ui/events-drawer.ts
@@ -60,12 +60,10 @@ export function createEventsDrawer(options: EventsDrawerOptions): EventsDrawer {
   // Internal drawer structure test ids also get an events-drawer prefix so the
   // existing events-drawer-backdrop / events-drawer-close / events-drawer-body
   // queries continue to match after swapping in the canonical primitive.
-  drawer.element
-    .querySelectorAll<HTMLElement>("[data-testid^='drawer']")
-    .forEach((el) => {
-      const current = el.dataset.testid!;
-      el.dataset.testid = `events-${current}`;
-    });
+  drawer.element.querySelectorAll<HTMLElement>("[data-testid^='drawer']").forEach((el) => {
+    const current = el.dataset.testid!;
+    el.dataset.testid = `events-${current}`;
+  });
 
   return {
     element: drawer.element,

--- a/src/ui/events-drawer.ts
+++ b/src/ui/events-drawer.ts
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
+import { createDrawer } from "./drawer";
 import { createEventsPanel } from "./events-panel";
-import { PANEL_BG, PANEL_BORDER, TEXT_COLOR } from "./styles";
+import { TEXT_COLOR } from "./styles";
 import type { CelestialEvent } from "../astro/events";
 import type { UIIntent } from "./index";
 
@@ -16,144 +17,50 @@ export type EventsDrawerOptions = {
   dispatch: (intent: UIIntent) => void;
 };
 
-// TODO: consolidate with settings drawer primitive (issue #196).
-// When #196 lands `src/ui/drawer.ts` exporting a generic `createDrawer`,
-// replace this inline implementation with an import from there.
-type Drawer = {
-  element: HTMLElement;
-  body: HTMLElement;
-  open(): void;
-  close(): void;
-  isOpen(): boolean;
-};
-
-function createDrawer(title: string, testidPrefix: string): Drawer {
-  const root = document.createElement("div");
-  root.dataset.testid = `${testidPrefix}`;
-  root.style.display = "none";
-  root.style.position = "fixed";
-  root.style.inset = "0";
-  root.style.zIndex = "1500";
-
-  const backdrop = document.createElement("div");
-  backdrop.dataset.testid = `${testidPrefix}-backdrop`;
-  backdrop.style.position = "absolute";
-  backdrop.style.inset = "0";
-  backdrop.style.background = "rgba(0,0,0,0.4)";
-
-  const panel = document.createElement("aside");
-  panel.dataset.testid = `${testidPrefix}-panel`;
-  panel.style.position = "absolute";
-  panel.style.top = "0";
-  panel.style.right = "0";
-  panel.style.height = "100vh";
-  // Responsive: full viewport on narrow screens, 360px on wider ones. `min` keeps
-  // the drawer from exceeding the viewport on phones while sizing to 360 on desktop.
-  panel.style.width = "min(100vw, 360px)";
-  panel.style.background = PANEL_BG;
-  panel.style.borderLeft = PANEL_BORDER;
-  panel.style.boxSizing = "border-box";
-  panel.style.display = "flex";
-  panel.style.flexDirection = "column";
-
-  const header = document.createElement("div");
-  header.style.display = "flex";
-  header.style.justifyContent = "space-between";
-  header.style.alignItems = "center";
-  header.style.padding = "8px 12px";
-  header.style.borderBottom = "1px solid rgba(255,255,255,0.15)";
-  header.style.flexShrink = "0";
-
-  const titleEl = document.createElement("span");
-  titleEl.textContent = title;
-  titleEl.style.color = TEXT_COLOR;
-  titleEl.style.fontSize = "14px";
-  titleEl.style.fontWeight = "bold";
-  titleEl.style.fontFamily = "sans-serif";
-
-  const closeBtn = document.createElement("button");
-  closeBtn.dataset.testid = `${testidPrefix}-close`;
-  closeBtn.textContent = "×";
-  closeBtn.title = "Close (Esc)";
-  closeBtn.style.background = "rgba(255,255,255,0.1)";
-  closeBtn.style.border = "1px solid rgba(255,255,255,0.3)";
-  closeBtn.style.borderRadius = "4px";
-  closeBtn.style.color = TEXT_COLOR;
-  closeBtn.style.cursor = "pointer";
-  closeBtn.style.fontSize = "18px";
-  closeBtn.style.lineHeight = "1";
-  closeBtn.style.padding = "2px 10px";
-
-  header.appendChild(titleEl);
-  header.appendChild(closeBtn);
-
-  const body = document.createElement("div");
-  body.dataset.testid = `${testidPrefix}-body`;
-  body.style.overflowY = "auto";
-  body.style.padding = "12px";
-  body.style.flex = "1 1 auto";
-
-  panel.appendChild(header);
-  panel.appendChild(body);
-  root.appendChild(backdrop);
-  root.appendChild(panel);
-
-  let open = false;
-
-  function doOpen(): void {
-    open = true;
-    root.style.display = "block";
-  }
-
-  function doClose(): void {
-    open = false;
-    root.style.display = "none";
-  }
-
-  backdrop.addEventListener("click", doClose);
-  closeBtn.addEventListener("click", doClose);
-
-  document.addEventListener("keydown", (e) => {
-    if (e.key === "Escape" && open) {
-      doClose();
-    }
-  });
-
-  return {
-    element: root,
-    body,
-    open: doOpen,
-    close: doClose,
-    isOpen: () => open,
-  };
-}
-
 /**
  * Slide-in drawer holding the celestial-events list.
  *
- * The drawer is a thin container around `createEventsPanel`: same rows, same
- * Go-to button, same empty state. Opened via the 📅 icon on the side panel.
- * Content is refreshed via `setEvents(events)` — callers (app.ts) should call
- * this on every `set-time` / `set-observer` / `now` intent so the list is
- * current whenever the user opens the drawer.
+ * Thin wrapper around `createEventsPanel` hosted inside the shared `createDrawer`
+ * primitive. Content is refreshed via `setEvents(events)` — callers (app.ts)
+ * should call this on every `set-time` / `set-observer` / `now` intent so the
+ * list is current whenever the user opens the drawer.
  */
 export function createEventsDrawer(options: EventsDrawerOptions): EventsDrawer {
-  const drawer = createDrawer("Upcoming Events", "events-drawer");
   const { dispatch } = options;
+
+  // Stable content host. We rebuild its children when setEvents is called so
+  // updates propagate whether the drawer is open or closed.
+  const content = document.createElement("div");
+  content.dataset.testid = "events-drawer-content";
+
+  const title = document.createElement("div");
+  title.textContent = "Upcoming Events";
+  title.style.color = TEXT_COLOR;
+  title.style.fontSize = "14px";
+  title.style.fontWeight = "bold";
+  title.style.fontFamily = "sans-serif";
+  title.style.marginBottom = "8px";
+  content.appendChild(title);
+
+  const panelHost = document.createElement("div");
+  panelHost.dataset.testid = "events-drawer-panel-host";
+  content.appendChild(panelHost);
 
   let currentEvents: readonly CelestialEvent[] = [];
 
   function render(): void {
-    drawer.body.replaceChildren(createEventsPanel(currentEvents, dispatch));
+    panelHost.replaceChildren(createEventsPanel(currentEvents, dispatch));
   }
 
-  // Render once with the empty list so the drawer shows "no upcoming events"
-  // even before the first refresh call.
   render();
+
+  const drawer = createDrawer({ side: "right", width: 360 });
+  // Root element gets a test id so the existing "mounts events drawer" test keeps working.
+  drawer.element.dataset.testid = "events-drawer";
 
   return {
     element: drawer.element,
-    open: () => drawer.open(),
+    open: () => drawer.open(content),
     close: () => drawer.close(),
     isOpen: () => drawer.isOpen(),
     setEvents(events) {

--- a/src/ui/events-drawer.ts
+++ b/src/ui/events-drawer.ts
@@ -54,9 +54,18 @@ export function createEventsDrawer(options: EventsDrawerOptions): EventsDrawer {
 
   render();
 
-  const drawer = createDrawer({ side: "right", width: 360 });
+  const drawer = createDrawer({ side: "right", width: 360, initialContent: content });
   // Root element gets a test id so the existing "mounts events drawer" test keeps working.
   drawer.element.dataset.testid = "events-drawer";
+  // Internal drawer structure test ids also get an events-drawer prefix so the
+  // existing events-drawer-backdrop / events-drawer-close / events-drawer-body
+  // queries continue to match after swapping in the canonical primitive.
+  drawer.element
+    .querySelectorAll<HTMLElement>("[data-testid^='drawer']")
+    .forEach((el) => {
+      const current = el.dataset.testid!;
+      el.dataset.testid = `events-${current}`;
+    });
 
   return {
     element: drawer.element,

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -4,7 +4,17 @@ export { createPanel } from "./panel";
 export { createTimeControls } from "./time-controls";
 export type { TimeControls } from "./time-controls";
 export { createLocationControls } from "./location-controls";
-export { createLayerControls } from "./layer-controls";
+export {
+  createVisibilitySection,
+  createOpacitySection,
+  createMagnitudeFilterSection,
+  createLanguageSection,
+  createSkycultureSection,
+} from "./layer-controls";
+export type { Drawer, DrawerOptions, DrawerSide } from "./drawer";
+export { createDrawer } from "./drawer";
+export type { SettingsDrawer, SettingsDrawerOptions } from "./settings-drawer";
+export { createSettingsDrawer, SETTINGS_SECTION_STORAGE_KEY } from "./settings-drawer";
 export { createViewControls } from "./view-controls";
 export { createPlanetInfo } from "./planet-info";
 export { createSearch } from "./search";

--- a/src/ui/layer-controls.test.ts
+++ b/src/ui/layer-controls.test.ts
@@ -1,6 +1,12 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { createLayerControls } from "./layer-controls";
+import {
+  createVisibilitySection,
+  createOpacitySection,
+  createMagnitudeFilterSection,
+  createLanguageSection,
+  createSkycultureSection,
+} from "./layer-controls";
 import type { UIIntent } from "./index";
 import type { LayerVisibility, LayerOpacity } from "../state/state";
 
@@ -21,20 +27,20 @@ const DEFAULT_OPACITY: LayerOpacity = {
   milkyWay: 0.3,
 };
 
-describe("createLayerControls", () => {
+describe("createVisibilitySection", () => {
   let dispatch: ReturnType<typeof vi.fn>;
   let el: HTMLElement;
 
   beforeEach(() => {
     dispatch = vi.fn();
-    el = createLayerControls(DEFAULT_VISIBILITY, DEFAULT_OPACITY, dispatch);
+    el = createVisibilitySection(DEFAULT_VISIBILITY, dispatch);
   });
 
   it("returns an HTMLElement", () => {
     expect(el).toBeInstanceOf(HTMLElement);
   });
 
-  it("renders a toggle checkbox for each toggle layer (stars, planets, satellites, compass, deepSky)", () => {
+  it("renders a checkbox per toggle layer (stars, planets, satellites, compass, deepSky)", () => {
     const toggles = el.querySelectorAll("input[type='checkbox']");
     expect(toggles.length).toBe(5);
   });
@@ -56,40 +62,37 @@ describe("createLayerControls", () => {
     }
   });
 
-  it("renders opacity sliders for all 6 line layers plus the mag slider", () => {
+  it("does not render checkboxes for constellationLines or constellationBoundaries", () => {
+    const clCheckbox = el.querySelector("input[data-layer='constellationLines']");
+    const cbCheckbox = el.querySelector("input[data-layer='constellationBoundaries']");
+    expect(clCheckbox).toBeNull();
+    expect(cbCheckbox).toBeNull();
+  });
+});
+
+describe("createOpacitySection", () => {
+  let dispatch: ReturnType<typeof vi.fn>;
+  let el: HTMLElement;
+
+  beforeEach(() => {
+    dispatch = vi.fn();
+    el = createOpacitySection(DEFAULT_OPACITY, dispatch);
+  });
+
+  it("renders opacity sliders for all 6 line layers", () => {
     const sliders = el.querySelectorAll("input[type='range']");
-    expect(sliders.length).toBe(7);
+    expect(sliders.length).toBe(6);
   });
 
-  it("has opacity slider for constellationLines", () => {
-    const slider = el.querySelector<HTMLInputElement>("input[data-opacity='constellationLines']");
-    expect(slider).not.toBeNull();
-  });
-
-  it("has opacity slider for constellationBoundaries", () => {
-    const slider = el.querySelector<HTMLInputElement>(
-      "input[data-opacity='constellationBoundaries']",
-    );
-    expect(slider).not.toBeNull();
-  });
-
-  it("has opacity slider for satelliteTrails", () => {
-    const slider = el.querySelector<HTMLInputElement>("input[data-opacity='satelliteTrails']");
-    expect(slider).not.toBeNull();
-  });
-
-  it("has opacity slider for raDecGrid", () => {
-    const slider = el.querySelector<HTMLInputElement>("input[data-opacity='raDecGrid']");
-    expect(slider).not.toBeNull();
-  });
-
-  it("has opacity slider for ecliptic", () => {
-    const slider = el.querySelector<HTMLInputElement>("input[data-opacity='ecliptic']");
-    expect(slider).not.toBeNull();
-  });
-
-  it("has opacity slider for milkyWay", () => {
-    const slider = el.querySelector<HTMLInputElement>("input[data-opacity='milkyWay']");
+  it.each([
+    "constellationLines",
+    "constellationBoundaries",
+    "satelliteTrails",
+    "raDecGrid",
+    "ecliptic",
+    "milkyWay",
+  ])("has opacity slider for %s", (key) => {
+    const slider = el.querySelector<HTMLInputElement>(`input[data-opacity='${key}']`);
     expect(slider).not.toBeNull();
   });
 
@@ -130,126 +133,21 @@ describe("createLayerControls", () => {
     }
   });
 
-  it("line layer sliders are always visible (no parent toggle)", () => {
-    // Since line layers have no toggle, their slider rows are always present
+  it("opacity rows are always visible (no parent toggle)", () => {
     const rows = el.querySelectorAll<HTMLElement>("[data-opacity-row]");
     for (const row of rows) {
       expect(row.style.display).not.toBe("none");
     }
   });
-
-  it("does not render checkboxes for constellationLines or constellationBoundaries", () => {
-    const clCheckbox = el.querySelector("input[data-layer='constellationLines']");
-    const cbCheckbox = el.querySelector("input[data-layer='constellationBoundaries']");
-    expect(clCheckbox).toBeNull();
-    expect(cbCheckbox).toBeNull();
-  });
 });
 
-describe("createLayerControls — language dropdown", () => {
+describe("createMagnitudeFilterSection", () => {
   let dispatch: ReturnType<typeof vi.fn>;
   let el: HTMLElement;
 
   beforeEach(() => {
     dispatch = vi.fn();
-    el = createLayerControls(DEFAULT_VISIBILITY, DEFAULT_OPACITY, dispatch, 6.0, "la");
-  });
-
-  it("renders a language select with data-language attribute", () => {
-    const select = el.querySelector<HTMLSelectElement>("select[data-language]");
-    expect(select).not.toBeNull();
-  });
-
-  it("includes options for la, en, zh, ar, el", () => {
-    const select = el.querySelector<HTMLSelectElement>("select[data-language]")!;
-    const values = [...select.options].map((o) => o.value);
-    expect(values).toEqual(expect.arrayContaining(["la", "en", "zh", "ar", "el"]));
-  });
-
-  it("select initialises to the given language", () => {
-    const elEn = createLayerControls(DEFAULT_VISIBILITY, DEFAULT_OPACITY, dispatch, 6.0, "en");
-    const select = elEn.querySelector<HTMLSelectElement>("select[data-language]")!;
-    expect(select.value).toBe("en");
-  });
-
-  it("changing the select dispatches set-language intent", () => {
-    const select = el.querySelector<HTMLSelectElement>("select[data-language]")!;
-    select.value = "zh";
-    select.dispatchEvent(new Event("change"));
-    expect(dispatch).toHaveBeenCalledOnce();
-    const intent = dispatch.mock.calls[0]![0] as UIIntent;
-    expect(intent.type).toBe("set-language");
-    if (intent.type === "set-language") {
-      expect(intent.language).toBe("zh");
-    }
-  });
-
-  it("defaults to 'la' when no initial language is passed", () => {
-    const elDefault = createLayerControls(DEFAULT_VISIBILITY, DEFAULT_OPACITY, dispatch);
-    const select = elDefault.querySelector<HTMLSelectElement>("select[data-language]")!;
-    expect(select.value).toBe("la");
-  });
-});
-
-describe("createLayerControls — skyculture dropdown", () => {
-  let dispatch: ReturnType<typeof vi.fn>;
-  let el: HTMLElement;
-
-  beforeEach(() => {
-    dispatch = vi.fn();
-    el = createLayerControls(DEFAULT_VISIBILITY, DEFAULT_OPACITY, dispatch, 6.0, "la", "western");
-  });
-
-  it("renders a skyculture select with data-skyculture attribute", () => {
-    const select = el.querySelector<HTMLSelectElement>("select[data-skyculture]");
-    expect(select).not.toBeNull();
-  });
-
-  it("includes options for western and chinese", () => {
-    const select = el.querySelector<HTMLSelectElement>("select[data-skyculture]")!;
-    const values = [...select.options].map((o) => o.value);
-    expect(values).toEqual(expect.arrayContaining(["western", "chinese"]));
-  });
-
-  it("select initialises to the given skyculture", () => {
-    const elCh = createLayerControls(
-      DEFAULT_VISIBILITY,
-      DEFAULT_OPACITY,
-      dispatch,
-      6.0,
-      "la",
-      "chinese",
-    );
-    const select = elCh.querySelector<HTMLSelectElement>("select[data-skyculture]")!;
-    expect(select.value).toBe("chinese");
-  });
-
-  it("changing the select dispatches set-skyculture intent", () => {
-    const select = el.querySelector<HTMLSelectElement>("select[data-skyculture]")!;
-    select.value = "chinese";
-    select.dispatchEvent(new Event("change"));
-    expect(dispatch).toHaveBeenCalledOnce();
-    const intent = dispatch.mock.calls[0]![0] as UIIntent;
-    expect(intent.type).toBe("set-skyculture");
-    if (intent.type === "set-skyculture") {
-      expect(intent.id).toBe("chinese");
-    }
-  });
-
-  it("defaults to 'western' when no initial skyculture is passed", () => {
-    const elDefault = createLayerControls(DEFAULT_VISIBILITY, DEFAULT_OPACITY, dispatch);
-    const select = elDefault.querySelector<HTMLSelectElement>("select[data-skyculture]")!;
-    expect(select.value).toBe("western");
-  });
-});
-
-describe("createLayerControls — magnitude slider", () => {
-  let dispatch: ReturnType<typeof vi.fn>;
-  let el: HTMLElement;
-
-  beforeEach(() => {
-    dispatch = vi.fn();
-    el = createLayerControls(DEFAULT_VISIBILITY, DEFAULT_OPACITY, dispatch, 6.0);
+    el = createMagnitudeFilterSection(6.0, dispatch);
   });
 
   it("renders a magnitude limit slider with data-mag attribute", () => {
@@ -269,7 +167,7 @@ describe("createLayerControls — magnitude slider", () => {
   });
 
   it("magnitude slider initialises to the given magLimit", () => {
-    const elWith4 = createLayerControls(DEFAULT_VISIBILITY, DEFAULT_OPACITY, dispatch, 4.0);
+    const elWith4 = createMagnitudeFilterSection(4.0, dispatch);
     const slider = elWith4.querySelector<HTMLInputElement>("input[data-mag='limit']")!;
     expect(Number(slider.value)).toBeCloseTo(4.0);
   });
@@ -298,5 +196,83 @@ describe("createLayerControls — magnitude slider", () => {
     slider.value = "3.5";
     slider.dispatchEvent(new Event("input"));
     expect(label.textContent).toContain("3.5");
+  });
+});
+
+describe("createLanguageSection", () => {
+  let dispatch: ReturnType<typeof vi.fn>;
+  let el: HTMLElement;
+
+  beforeEach(() => {
+    dispatch = vi.fn();
+    el = createLanguageSection("la", dispatch);
+  });
+
+  it("renders a language select with data-language attribute", () => {
+    const select = el.querySelector<HTMLSelectElement>("select[data-language]");
+    expect(select).not.toBeNull();
+  });
+
+  it("includes options for la, en, zh, ar, el", () => {
+    const select = el.querySelector<HTMLSelectElement>("select[data-language]")!;
+    const values = [...select.options].map((o) => o.value);
+    expect(values).toEqual(expect.arrayContaining(["la", "en", "zh", "ar", "el"]));
+  });
+
+  it("select initialises to the given language", () => {
+    const elEn = createLanguageSection("en", dispatch);
+    const select = elEn.querySelector<HTMLSelectElement>("select[data-language]")!;
+    expect(select.value).toBe("en");
+  });
+
+  it("changing the select dispatches set-language intent", () => {
+    const select = el.querySelector<HTMLSelectElement>("select[data-language]")!;
+    select.value = "zh";
+    select.dispatchEvent(new Event("change"));
+    expect(dispatch).toHaveBeenCalledOnce();
+    const intent = dispatch.mock.calls[0]![0] as UIIntent;
+    expect(intent.type).toBe("set-language");
+    if (intent.type === "set-language") {
+      expect(intent.language).toBe("zh");
+    }
+  });
+});
+
+describe("createSkycultureSection", () => {
+  let dispatch: ReturnType<typeof vi.fn>;
+  let el: HTMLElement;
+
+  beforeEach(() => {
+    dispatch = vi.fn();
+    el = createSkycultureSection("western", dispatch);
+  });
+
+  it("renders a skyculture select with data-skyculture attribute", () => {
+    const select = el.querySelector<HTMLSelectElement>("select[data-skyculture]");
+    expect(select).not.toBeNull();
+  });
+
+  it("includes options for western and chinese", () => {
+    const select = el.querySelector<HTMLSelectElement>("select[data-skyculture]")!;
+    const values = [...select.options].map((o) => o.value);
+    expect(values).toEqual(expect.arrayContaining(["western", "chinese"]));
+  });
+
+  it("select initialises to the given skyculture", () => {
+    const elCh = createSkycultureSection("chinese", dispatch);
+    const select = elCh.querySelector<HTMLSelectElement>("select[data-skyculture]")!;
+    expect(select.value).toBe("chinese");
+  });
+
+  it("changing the select dispatches set-skyculture intent", () => {
+    const select = el.querySelector<HTMLSelectElement>("select[data-skyculture]")!;
+    select.value = "chinese";
+    select.dispatchEvent(new Event("change"));
+    expect(dispatch).toHaveBeenCalledOnce();
+    const intent = dispatch.mock.calls[0]![0] as UIIntent;
+    expect(intent.type).toBe("set-skyculture");
+    if (intent.type === "set-skyculture") {
+      expect(intent.id).toBe("chinese");
+    }
   });
 });

--- a/src/ui/layer-controls.ts
+++ b/src/ui/layer-controls.ts
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: Apache-2.0 */
-import { applyBaseText, ACCENT_COLOR, GAP } from "./styles";
+import { applyBaseText, ACCENT_COLOR } from "./styles";
 import type { UIIntent } from "./index";
 import type { LayerVisibility, LayerOpacity } from "../state/state";
 import { LANGUAGES, type Language } from "../astro/constellation-names";
@@ -50,113 +50,117 @@ const LINE_LAYERS: LineDef[] = [
   { key: "milkyWay", label: "Milky Way", defaultPct: 30 },
 ];
 
-export function createLayerControls(
-  initialVisibility: LayerVisibility,
-  initialOpacity: LayerOpacity,
+function appendToggleRow(
+  section: HTMLElement,
+  layer: LayerDef,
+  initialChecked: boolean,
   dispatch: (intent: UIIntent) => void,
-  initialMagLimit = 6.0,
-  initialLanguage: Language = "la",
-  initialSkyculture: SkycultureId = "western",
+): void {
+  const row = document.createElement("div");
+  row.style.display = "flex";
+  row.style.alignItems = "center";
+  row.style.justifyContent = "space-between";
+  row.style.marginBottom = "6px";
+
+  const lbl = document.createElement("label");
+  lbl.style.display = "flex";
+  lbl.style.alignItems = "center";
+  lbl.style.gap = "6px";
+  lbl.style.cursor = "pointer";
+  applyBaseText(lbl);
+
+  const checkbox = document.createElement("input");
+  checkbox.type = "checkbox";
+  checkbox.dataset.layer = layer.key;
+  checkbox.checked = initialChecked;
+  checkbox.style.accentColor = ACCENT_COLOR;
+  checkbox.style.width = "16px";
+  checkbox.style.height = "16px";
+
+  lbl.appendChild(checkbox);
+  lbl.appendChild(document.createTextNode(layer.label));
+  row.appendChild(lbl);
+  section.appendChild(row);
+
+  checkbox.addEventListener("change", () => {
+    dispatch({ type: "toggle-layer", layer: layer.key });
+  });
+}
+
+function appendOpacityRow(
+  section: HTMLElement,
+  ld: LineDef,
+  initialValue: number,
+  dispatch: (intent: UIIntent) => void,
+): void {
+  const row = document.createElement("div");
+  row.dataset.opacityRow = ld.key;
+  row.style.marginBottom = "6px";
+
+  const lbl = document.createElement("div");
+  lbl.textContent = ld.label;
+  applyBaseText(lbl);
+  lbl.style.fontSize = "12px";
+  lbl.style.marginBottom = "2px";
+
+  const slider = document.createElement("input");
+  slider.type = "range";
+  slider.dataset.opacity = ld.key;
+  slider.min = "0";
+  slider.max = "100";
+  slider.step = "1";
+  slider.value = String(Math.round(initialValue * 100));
+  slider.style.width = "100%";
+  slider.style.accentColor = ACCENT_COLOR;
+
+  slider.addEventListener("input", () => {
+    const value = Number(slider.value) / 100;
+    dispatch({ type: "set-opacity", layer: ld.key, value });
+  });
+
+  row.appendChild(lbl);
+  row.appendChild(slider);
+  section.appendChild(row);
+}
+
+/**
+ * Build a simple container holding one visibility checkbox per toggle layer.
+ * Shared by the legacy side-panel composer and the 1E settings drawer.
+ */
+export function createVisibilitySection(
+  visibility: LayerVisibility,
+  dispatch: (intent: UIIntent) => void,
 ): HTMLElement {
-  const visibility = { ...initialVisibility };
-
   const section = document.createElement("div");
-  section.style.marginBottom = GAP;
-
-  // Layers heading
-  const layersHeading = document.createElement("div");
-  layersHeading.textContent = "Layers";
-  layersHeading.style.fontWeight = "bold";
-  layersHeading.style.marginBottom = GAP;
-  applyBaseText(layersHeading);
-  section.appendChild(layersHeading);
-
-  // Build each toggle layer row (stars, planets, satellites, compass)
   for (const layer of TOGGLE_LAYERS) {
-    const row = document.createElement("div");
-    row.style.display = "flex";
-    row.style.alignItems = "center";
-    row.style.justifyContent = "space-between";
-    row.style.marginBottom = "6px";
-
-    const lbl = document.createElement("label");
-    lbl.style.display = "flex";
-    lbl.style.alignItems = "center";
-    lbl.style.gap = "6px";
-    lbl.style.cursor = "pointer";
-    applyBaseText(lbl);
-
-    const checkbox = document.createElement("input");
-    checkbox.type = "checkbox";
-    checkbox.dataset.layer = layer.key;
-    checkbox.checked = visibility[layer.key];
-    checkbox.style.accentColor = ACCENT_COLOR;
-    checkbox.style.width = "16px";
-    checkbox.style.height = "16px";
-
-    const labelText = document.createTextNode(layer.label);
-
-    lbl.appendChild(checkbox);
-    lbl.appendChild(labelText);
-    row.appendChild(lbl);
-    section.appendChild(row);
-
-    checkbox.addEventListener("change", () => {
-      visibility[layer.key] = checkbox.checked;
-      dispatch({ type: "toggle-layer", layer: layer.key });
-    });
+    appendToggleRow(section, layer, visibility[layer.key], dispatch);
   }
+  return section;
+}
 
-  // Line Layers heading
-  const lineHeading = document.createElement("div");
-  lineHeading.textContent = "Line Layers";
-  lineHeading.style.fontWeight = "bold";
-  lineHeading.style.marginTop = "8px";
-  lineHeading.style.marginBottom = GAP;
-  applyBaseText(lineHeading);
-  section.appendChild(lineHeading);
-
-  // Build each line-layer opacity slider (no toggle, slider to 0 = off)
+/**
+ * Build a container of opacity sliders — one per line layer.
+ * Shared by the legacy composer and the 1E settings drawer.
+ */
+export function createOpacitySection(
+  opacity: LayerOpacity,
+  dispatch: (intent: UIIntent) => void,
+): HTMLElement {
+  const section = document.createElement("div");
   for (const ld of LINE_LAYERS) {
-    const row = document.createElement("div");
-    row.dataset.opacityRow = ld.key;
-    row.style.marginBottom = "6px";
-
-    const lbl = document.createElement("div");
-    lbl.textContent = ld.label;
-    applyBaseText(lbl);
-    lbl.style.fontSize = "12px";
-    lbl.style.marginBottom = "2px";
-
-    const slider = document.createElement("input");
-    slider.type = "range";
-    slider.dataset.opacity = ld.key;
-    slider.min = "0";
-    slider.max = "100";
-    slider.step = "1";
-    slider.value = String(Math.round(initialOpacity[ld.key] * 100));
-    slider.style.width = "100%";
-    slider.style.accentColor = ACCENT_COLOR;
-
-    slider.addEventListener("input", () => {
-      const value = Number(slider.value) / 100;
-      dispatch({ type: "set-opacity", layer: ld.key, value });
-    });
-
-    row.appendChild(lbl);
-    row.appendChild(slider);
-    section.appendChild(row);
+    appendOpacityRow(section, ld, opacity[ld.key], dispatch);
   }
+  return section;
+}
 
-  // Magnitude limit slider
-  const magHeading = document.createElement("div");
-  magHeading.textContent = "Star Filter";
-  magHeading.style.fontWeight = "bold";
-  magHeading.style.marginTop = "8px";
-  magHeading.style.marginBottom = GAP;
-  applyBaseText(magHeading);
-  section.appendChild(magHeading);
-
+/**
+ * Build the magnitude-filter slider with its live-updating label.
+ */
+export function createMagnitudeFilterSection(
+  initialMagLimit: number,
+  dispatch: (intent: UIIntent) => void,
+): HTMLElement {
+  const section = document.createElement("div");
   const magRow = document.createElement("div");
   magRow.style.marginBottom = "6px";
 
@@ -186,74 +190,76 @@ export function createLayerControls(
   magRow.appendChild(magLabel);
   magRow.appendChild(magSlider);
   section.appendChild(magRow);
+  return section;
+}
 
-  // Language dropdown (constellation label language)
-  const langHeading = document.createElement("div");
-  langHeading.textContent = "Constellation Names";
-  langHeading.style.fontWeight = "bold";
-  langHeading.style.marginTop = "8px";
-  langHeading.style.marginBottom = GAP;
-  applyBaseText(langHeading);
-  section.appendChild(langHeading);
+/**
+ * Build the constellation-names language dropdown.
+ */
+export function createLanguageSection(
+  initialLanguage: Language,
+  dispatch: (intent: UIIntent) => void,
+): HTMLElement {
+  const section = document.createElement("div");
+  const row = document.createElement("div");
+  row.style.marginBottom = "6px";
 
-  const langRow = document.createElement("div");
-  langRow.style.marginBottom = "6px";
-
-  const langSelect = document.createElement("select");
-  langSelect.dataset.language = "";
-  langSelect.style.width = "100%";
-  applyBaseText(langSelect);
-  langSelect.style.fontSize = "12px";
+  const select = document.createElement("select");
+  select.dataset.language = "";
+  select.style.width = "100%";
+  applyBaseText(select);
+  select.style.fontSize = "12px";
 
   for (const code of LANGUAGES) {
     const option = document.createElement("option");
     option.value = code;
     option.textContent = LANGUAGE_LABELS[code];
     if (code === initialLanguage) option.selected = true;
-    langSelect.appendChild(option);
+    select.appendChild(option);
   }
 
-  langSelect.addEventListener("change", () => {
-    const value = langSelect.value as Language;
+  select.addEventListener("change", () => {
+    const value = select.value as Language;
     dispatch({ type: "set-language", language: value });
   });
 
-  langRow.appendChild(langSelect);
-  section.appendChild(langRow);
+  row.appendChild(select);
+  section.appendChild(row);
+  return section;
+}
 
-  // Skyculture dropdown (asterism stick-figure set)
-  const skyHeading = document.createElement("div");
-  skyHeading.textContent = "Skyculture";
-  skyHeading.style.fontWeight = "bold";
-  skyHeading.style.marginTop = "8px";
-  skyHeading.style.marginBottom = GAP;
-  applyBaseText(skyHeading);
-  section.appendChild(skyHeading);
+/**
+ * Build the asterism-stick-figure skyculture dropdown.
+ */
+export function createSkycultureSection(
+  initialSkyculture: SkycultureId,
+  dispatch: (intent: UIIntent) => void,
+): HTMLElement {
+  const section = document.createElement("div");
+  const row = document.createElement("div");
+  row.style.marginBottom = "6px";
 
-  const skyRow = document.createElement("div");
-  skyRow.style.marginBottom = "6px";
-
-  const skySelect = document.createElement("select");
-  skySelect.dataset.skyculture = "";
-  skySelect.style.width = "100%";
-  applyBaseText(skySelect);
-  skySelect.style.fontSize = "12px";
+  const select = document.createElement("select");
+  select.dataset.skyculture = "";
+  select.style.width = "100%";
+  applyBaseText(select);
+  select.style.fontSize = "12px";
 
   for (const id of SKYCULTURES) {
     const option = document.createElement("option");
     option.value = id;
     option.textContent = SKYCULTURE_LABELS[id];
     if (id === initialSkyculture) option.selected = true;
-    skySelect.appendChild(option);
+    select.appendChild(option);
   }
 
-  skySelect.addEventListener("change", () => {
-    const value = skySelect.value as SkycultureId;
+  select.addEventListener("change", () => {
+    const value = select.value as SkycultureId;
     dispatch({ type: "set-skyculture", id: value });
   });
 
-  skyRow.appendChild(skySelect);
-  section.appendChild(skyRow);
-
+  row.appendChild(select);
+  section.appendChild(row);
   return section;
 }
+

--- a/src/ui/layer-controls.ts
+++ b/src/ui/layer-controls.ts
@@ -262,4 +262,3 @@ export function createSkycultureSection(
   section.appendChild(row);
   return section;
 }
-

--- a/src/ui/panel.test.ts
+++ b/src/ui/panel.test.ts
@@ -144,6 +144,34 @@ describe("createPanel", () => {
     });
   });
 
+  describe("settings button", () => {
+    it("renders a settings button in the header", () => {
+      const { element } = createPanel(container);
+      const btn = element.querySelector("[data-testid='panel-settings']");
+      expect(btn).not.toBeNull();
+    });
+
+    it("displays the gear icon", () => {
+      const { element } = createPanel(container);
+      const btn = element.querySelector<HTMLButtonElement>("[data-testid='panel-settings']")!;
+      expect(btn.textContent).toBe("\u2699");
+    });
+
+    it("clicking the settings button invokes onOpenSettings", () => {
+      const onOpenSettings = vi.fn();
+      const { element } = createPanel(container, vi.fn(), { onOpenSettings });
+      const btn = element.querySelector<HTMLButtonElement>("[data-testid='panel-settings']")!;
+      btn.click();
+      expect(onOpenSettings).toHaveBeenCalledTimes(1);
+    });
+
+    it("clicking the settings button is a no-op when no callback is provided", () => {
+      const { element } = createPanel(container);
+      const btn = element.querySelector<HTMLButtonElement>("[data-testid='panel-settings']")!;
+      expect(() => btn.click()).not.toThrow();
+    });
+  });
+
   describe("copy-link button", () => {
     beforeEach(() => {
       Object.defineProperty(navigator, "clipboard", {

--- a/src/ui/panel.ts
+++ b/src/ui/panel.ts
@@ -20,6 +20,7 @@ export type Panel = {
 export type PanelOptions = {
   onOpenHelp?: () => void;
   onOpenEvents?: () => void;
+  onOpenSettings?: () => void;
 };
 
 export function createPanel(
@@ -85,9 +86,15 @@ export function createPanel(
   helpBtn.title = "Help";
   applyButton(helpBtn);
 
+  const settingsBtn = document.createElement("button");
+  settingsBtn.dataset.testid = "panel-settings";
+  settingsBtn.textContent = "\u2699";
+  settingsBtn.title = "Settings";
+  applyButton(settingsBtn);
+
   const toggleBtn = document.createElement("button");
   toggleBtn.dataset.testid = "panel-toggle";
-  toggleBtn.textContent = "⚙";
+  toggleBtn.textContent = "\u2212";
   toggleBtn.title = "Toggle panel";
   applyButton(toggleBtn);
 
@@ -95,6 +102,7 @@ export function createPanel(
   btnGroup.appendChild(copyLinkBtn);
   btnGroup.appendChild(eventsBtn);
   btnGroup.appendChild(helpBtn);
+  btnGroup.appendChild(settingsBtn);
   btnGroup.appendChild(toggleBtn);
 
   header.appendChild(title);
@@ -121,6 +129,10 @@ export function createPanel(
 
   eventsBtn.addEventListener("click", () => {
     options.onOpenEvents?.();
+  });
+
+  settingsBtn.addEventListener("click", () => {
+    options.onOpenSettings?.();
   });
 
   copyLinkBtn.addEventListener("click", () => {
@@ -150,13 +162,13 @@ export function createPanel(
   toggleBtn.addEventListener("click", () => {
     collapsed = !collapsed;
     body.style.display = collapsed ? "none" : "";
-    toggleBtn.textContent = collapsed ? "⚙" : "×";
+    toggleBtn.textContent = collapsed ? "\u002B" : "\u2212";
   });
 
   function setCollapsed(value: boolean): void {
     collapsed = value;
     body.style.display = value ? "none" : "";
-    toggleBtn.textContent = value ? "⚙" : "×";
+    toggleBtn.textContent = value ? "\u002B" : "\u2212";
   }
 
   function setContent(child: HTMLElement): void {

--- a/src/ui/settings-drawer.test.ts
+++ b/src/ui/settings-drawer.test.ts
@@ -1,0 +1,277 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createSettingsDrawer, SETTINGS_SECTION_STORAGE_KEY } from "./settings-drawer";
+import type { UIIntent } from "./index";
+import type { LayerVisibility, LayerOpacity } from "../state/state";
+
+const DEFAULT_VISIBILITY: LayerVisibility = {
+  stars: true,
+  planets: true,
+  satellites: true,
+  compass: true,
+  deepSky: true,
+};
+
+const DEFAULT_OPACITY: LayerOpacity = {
+  constellationLines: 1.0,
+  constellationBoundaries: 1.0,
+  satelliteTrails: 1.0,
+  raDecGrid: 0.2,
+  ecliptic: 0.4,
+  milkyWay: 0.3,
+};
+
+function makeDrawer(dispatch: (i: UIIntent) => void = () => {}) {
+  return createSettingsDrawer({
+    visibility: DEFAULT_VISIBILITY,
+    opacity: DEFAULT_OPACITY,
+    magLimit: 6.0,
+    language: "la",
+    skyculture: "western",
+    dispatch,
+  });
+}
+
+describe("createSettingsDrawer", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    globalThis.localStorage?.removeItem(SETTINGS_SECTION_STORAGE_KEY);
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+    globalThis.localStorage?.removeItem(SETTINGS_SECTION_STORAGE_KEY);
+  });
+
+  it("returns an object with element, open, close, isOpen", () => {
+    const sd = makeDrawer();
+    expect(sd).toHaveProperty("element");
+    expect(typeof sd.open).toBe("function");
+    expect(typeof sd.close).toBe("function");
+    expect(typeof sd.isOpen).toBe("function");
+  });
+
+  it("is not open initially", () => {
+    const sd = makeDrawer();
+    document.body.appendChild(sd.element);
+    expect(sd.isOpen()).toBe(false);
+  });
+
+  it("open() renders the settings sections and flips isOpen true", () => {
+    const sd = makeDrawer();
+    document.body.appendChild(sd.element);
+    sd.open();
+    expect(sd.isOpen()).toBe(true);
+    expect(sd.element.querySelector("[data-testid='settings-section-visibility']")).not.toBeNull();
+    expect(sd.element.querySelector("[data-testid='settings-section-opacity']")).not.toBeNull();
+    expect(sd.element.querySelector("[data-testid='settings-section-filters']")).not.toBeNull();
+    expect(sd.element.querySelector("[data-testid='settings-section-display']")).not.toBeNull();
+  });
+
+  it("close() hides the drawer", () => {
+    const sd = makeDrawer();
+    document.body.appendChild(sd.element);
+    sd.open();
+    sd.close();
+    expect(sd.isOpen()).toBe(false);
+  });
+
+  it("renders all 5 visibility toggles (stars, planets, satellites, compass, deepSky)", () => {
+    const sd = makeDrawer();
+    document.body.appendChild(sd.element);
+    sd.open();
+    const toggles = sd.element.querySelectorAll("input[type='checkbox'][data-layer]");
+    expect(toggles.length).toBe(5);
+  });
+
+  it("renders all 6 opacity sliders", () => {
+    const sd = makeDrawer();
+    document.body.appendChild(sd.element);
+    sd.open();
+    const sliders = sd.element.querySelectorAll("input[type='range'][data-opacity]");
+    expect(sliders.length).toBe(6);
+  });
+
+  it("renders the magnitude-limit slider", () => {
+    const sd = makeDrawer();
+    document.body.appendChild(sd.element);
+    sd.open();
+    const mag = sd.element.querySelector("input[data-mag='limit']");
+    expect(mag).not.toBeNull();
+  });
+
+  it("renders the language dropdown", () => {
+    const sd = makeDrawer();
+    document.body.appendChild(sd.element);
+    sd.open();
+    const sel = sd.element.querySelector("select[data-language]");
+    expect(sel).not.toBeNull();
+  });
+
+  it("renders the skyculture dropdown", () => {
+    const sd = makeDrawer();
+    document.body.appendChild(sd.element);
+    sd.open();
+    const sel = sd.element.querySelector("select[data-skyculture]");
+    expect(sel).not.toBeNull();
+  });
+
+  it("toggle-layer intent dispatches when a visibility checkbox changes", () => {
+    const dispatch = vi.fn();
+    const sd = makeDrawer(dispatch);
+    document.body.appendChild(sd.element);
+    sd.open();
+    const cb = sd.element.querySelector<HTMLInputElement>("input[data-layer='stars']")!;
+    cb.checked = false;
+    cb.dispatchEvent(new Event("change"));
+    expect(dispatch).toHaveBeenCalledWith({ type: "toggle-layer", layer: "stars" });
+  });
+
+  it("set-opacity intent dispatches when an opacity slider moves", () => {
+    const dispatch = vi.fn();
+    const sd = makeDrawer(dispatch);
+    document.body.appendChild(sd.element);
+    sd.open();
+    const slider = sd.element.querySelector<HTMLInputElement>(
+      "input[data-opacity='constellationLines']",
+    )!;
+    slider.value = "50";
+    slider.dispatchEvent(new Event("input"));
+    expect(dispatch).toHaveBeenCalledWith({
+      type: "set-opacity",
+      layer: "constellationLines",
+      value: 0.5,
+    });
+  });
+
+  it("set-mag-limit intent dispatches when the magnitude slider moves", () => {
+    const dispatch = vi.fn();
+    const sd = makeDrawer(dispatch);
+    document.body.appendChild(sd.element);
+    sd.open();
+    const slider = sd.element.querySelector<HTMLInputElement>("input[data-mag='limit']")!;
+    slider.value = "4";
+    slider.dispatchEvent(new Event("input"));
+    expect(dispatch).toHaveBeenCalledWith({ type: "set-mag-limit", value: 4 });
+  });
+
+  it("set-language intent dispatches when the language dropdown changes", () => {
+    const dispatch = vi.fn();
+    const sd = makeDrawer(dispatch);
+    document.body.appendChild(sd.element);
+    sd.open();
+    const sel = sd.element.querySelector<HTMLSelectElement>("select[data-language]")!;
+    sel.value = "zh";
+    sel.dispatchEvent(new Event("change"));
+    expect(dispatch).toHaveBeenCalledWith({ type: "set-language", language: "zh" });
+  });
+
+  it("set-skyculture intent dispatches when the skyculture dropdown changes", () => {
+    const dispatch = vi.fn();
+    const sd = makeDrawer(dispatch);
+    document.body.appendChild(sd.element);
+    sd.open();
+    const sel = sd.element.querySelector<HTMLSelectElement>("select[data-skyculture]")!;
+    sel.value = "chinese";
+    sel.dispatchEvent(new Event("change"));
+    expect(dispatch).toHaveBeenCalledWith({ type: "set-skyculture", id: "chinese" });
+  });
+
+  describe("collapsible sections", () => {
+    it("Visibility section is expanded on first open (no stored preference)", () => {
+      const sd = makeDrawer();
+      document.body.appendChild(sd.element);
+      sd.open();
+      const section = sd.element.querySelector<HTMLElement>(
+        "[data-testid='settings-section-visibility']",
+      )!;
+      expect(section.dataset.expanded).toBe("true");
+    });
+
+    it("Opacity, Filters, Display sections are collapsed on first open", () => {
+      const sd = makeDrawer();
+      document.body.appendChild(sd.element);
+      sd.open();
+      for (const id of ["opacity", "filters", "display"]) {
+        const section = sd.element.querySelector<HTMLElement>(
+          `[data-testid='settings-section-${id}']`,
+        )!;
+        expect(section.dataset.expanded).toBe("false");
+      }
+    });
+
+    it("clicking a section header toggles it open and collapses the others", () => {
+      const sd = makeDrawer();
+      document.body.appendChild(sd.element);
+      sd.open();
+      const opacityHeader = sd.element.querySelector<HTMLElement>(
+        "[data-testid='settings-header-opacity']",
+      )!;
+      opacityHeader.click();
+      expect(
+        sd.element.querySelector<HTMLElement>("[data-testid='settings-section-opacity']")!.dataset
+          .expanded,
+      ).toBe("true");
+      expect(
+        sd.element.querySelector<HTMLElement>("[data-testid='settings-section-visibility']")!
+          .dataset.expanded,
+      ).toBe("false");
+    });
+
+    it("remembers the last-opened section in localStorage", () => {
+      const sd = makeDrawer();
+      document.body.appendChild(sd.element);
+      sd.open();
+      const displayHeader = sd.element.querySelector<HTMLElement>(
+        "[data-testid='settings-header-display']",
+      )!;
+      displayHeader.click();
+      expect(globalThis.localStorage?.getItem(SETTINGS_SECTION_STORAGE_KEY)).toBe("display");
+    });
+
+    it("restores the last-opened section from localStorage on next open", () => {
+      globalThis.localStorage?.setItem(SETTINGS_SECTION_STORAGE_KEY, "filters");
+      const sd = makeDrawer();
+      document.body.appendChild(sd.element);
+      sd.open();
+      const filters = sd.element.querySelector<HTMLElement>(
+        "[data-testid='settings-section-filters']",
+      )!;
+      expect(filters.dataset.expanded).toBe("true");
+      const visibility = sd.element.querySelector<HTMLElement>(
+        "[data-testid='settings-section-visibility']",
+      )!;
+      expect(visibility.dataset.expanded).toBe("false");
+    });
+
+    it("ignores an invalid stored section value and falls back to visibility", () => {
+      globalThis.localStorage?.setItem(SETTINGS_SECTION_STORAGE_KEY, "not-a-section");
+      const sd = makeDrawer();
+      document.body.appendChild(sd.element);
+      sd.open();
+      const visibility = sd.element.querySelector<HTMLElement>(
+        "[data-testid='settings-section-visibility']",
+      )!;
+      expect(visibility.dataset.expanded).toBe("true");
+    });
+  });
+
+  it("respects initial language/skyculture/magLimit values", () => {
+    const sd = createSettingsDrawer({
+      visibility: DEFAULT_VISIBILITY,
+      opacity: DEFAULT_OPACITY,
+      magLimit: 4.5,
+      language: "zh",
+      skyculture: "chinese",
+      dispatch: () => {},
+    });
+    document.body.appendChild(sd.element);
+    sd.open();
+    const mag = sd.element.querySelector<HTMLInputElement>("input[data-mag='limit']")!;
+    expect(Number(mag.value)).toBeCloseTo(4.5);
+    const lang = sd.element.querySelector<HTMLSelectElement>("select[data-language]")!;
+    expect(lang.value).toBe("zh");
+    const sky = sd.element.querySelector<HTMLSelectElement>("select[data-skyculture]")!;
+    expect(sky.value).toBe("chinese");
+  });
+});

--- a/src/ui/settings-drawer.ts
+++ b/src/ui/settings-drawer.ts
@@ -131,10 +131,18 @@ export function createSettingsDrawer(options: SettingsDrawerOptions): SettingsDr
   container.appendChild(title);
 
   const sections: Record<SectionId, SectionHandle> = {
-    visibility: buildSection("visibility", "Visibility", createVisibilitySection(visibility, dispatch)),
+    visibility: buildSection(
+      "visibility",
+      "Visibility",
+      createVisibilitySection(visibility, dispatch),
+    ),
     opacity: buildSection("opacity", "Opacity", createOpacitySection(opacity, dispatch)),
     filters: buildSection("filters", "Filters", createMagnitudeFilterSection(magLimit, dispatch)),
-    display: buildSection("display", "Display", buildDisplaySection(language, skyculture, dispatch)),
+    display: buildSection(
+      "display",
+      "Display",
+      buildDisplaySection(language, skyculture, dispatch),
+    ),
   };
 
   for (const id of SECTION_IDS) {

--- a/src/ui/settings-drawer.ts
+++ b/src/ui/settings-drawer.ts
@@ -1,0 +1,204 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { createDrawer, type Drawer } from "./drawer";
+import {
+  createVisibilitySection,
+  createOpacitySection,
+  createMagnitudeFilterSection,
+  createLanguageSection,
+  createSkycultureSection,
+} from "./layer-controls";
+import { applyBaseText, GAP, TEXT_COLOR } from "./styles";
+import type { UIIntent } from "./index";
+import type { LayerVisibility, LayerOpacity } from "../state/state";
+import type { Language } from "../astro/constellation-names";
+import type { SkycultureId } from "../astro/skycultures";
+
+export const SETTINGS_SECTION_STORAGE_KEY = "planisphere.settings.lastSection.v1";
+
+type SectionId = "visibility" | "opacity" | "filters" | "display";
+const SECTION_IDS: readonly SectionId[] = ["visibility", "opacity", "filters", "display"];
+
+function isSectionId(v: string | null): v is SectionId {
+  return v !== null && (SECTION_IDS as readonly string[]).includes(v);
+}
+
+function loadLastSection(): SectionId {
+  try {
+    const raw = globalThis.localStorage?.getItem(SETTINGS_SECTION_STORAGE_KEY);
+    if (isSectionId(raw)) return raw;
+  } catch {
+    // localStorage disabled / quota — fall through to default.
+  }
+  return "visibility";
+}
+
+function persistLastSection(section: SectionId): void {
+  try {
+    globalThis.localStorage?.setItem(SETTINGS_SECTION_STORAGE_KEY, section);
+  } catch {
+    // Ignore storage errors — the preference is a nice-to-have.
+  }
+}
+
+export type SettingsDrawerOptions = {
+  visibility: LayerVisibility;
+  opacity: LayerOpacity;
+  magLimit: number;
+  language: Language;
+  skyculture: SkycultureId;
+  dispatch: (intent: UIIntent) => void;
+};
+
+export type SettingsDrawer = {
+  element: HTMLElement;
+  open: () => void;
+  close: () => void;
+  isOpen: () => boolean;
+};
+
+type SectionHandle = {
+  wrapper: HTMLElement;
+  header: HTMLElement;
+  body: HTMLElement;
+};
+
+function buildSection(id: SectionId, title: string, content: HTMLElement): SectionHandle {
+  const wrapper = document.createElement("div");
+  wrapper.dataset.testid = `settings-section-${id}`;
+  wrapper.dataset.expanded = "false";
+  wrapper.style.marginBottom = GAP;
+  wrapper.style.border = "1px solid rgba(255,255,255,0.15)";
+  wrapper.style.borderRadius = "6px";
+  wrapper.style.overflow = "hidden";
+
+  const header = document.createElement("button");
+  header.dataset.testid = `settings-header-${id}`;
+  header.type = "button";
+  header.style.width = "100%";
+  header.style.display = "flex";
+  header.style.justifyContent = "space-between";
+  header.style.alignItems = "center";
+  header.style.padding = "8px 10px";
+  header.style.background = "rgba(255,255,255,0.04)";
+  header.style.border = "none";
+  header.style.color = TEXT_COLOR;
+  header.style.cursor = "pointer";
+  header.style.textAlign = "left";
+  applyBaseText(header);
+  header.style.fontWeight = "bold";
+
+  const titleEl = document.createElement("span");
+  titleEl.textContent = title;
+  const chevron = document.createElement("span");
+  chevron.dataset.testid = `settings-chevron-${id}`;
+  chevron.textContent = "▸";
+  chevron.style.transition = "transform 120ms ease";
+  header.appendChild(titleEl);
+  header.appendChild(chevron);
+
+  const body = document.createElement("div");
+  body.dataset.testid = `settings-body-${id}`;
+  body.style.padding = "8px 10px";
+  body.style.display = "none";
+  body.appendChild(content);
+
+  wrapper.appendChild(header);
+  wrapper.appendChild(body);
+
+  return { wrapper, header, body };
+}
+
+/**
+ * The 1E settings drawer. Wraps the shared drawer primitive and composes
+ * the moved-from-side-panel controls into four collapsible sections. The
+ * user's last-open section is remembered via localStorage so returning
+ * users land on what they last touched.
+ *
+ * The drawer owns an always-live section DOM so dispatch handlers remain
+ * wired across open/close cycles. `open()` just flips the shared drawer.
+ */
+export function createSettingsDrawer(options: SettingsDrawerOptions): SettingsDrawer {
+  const { visibility, opacity, magLimit, language, skyculture, dispatch } = options;
+
+  const container = document.createElement("div");
+  container.dataset.testid = "settings-drawer-content";
+
+  const title = document.createElement("h2");
+  title.textContent = "Settings";
+  applyBaseText(title);
+  title.style.margin = "0 0 12px 0";
+  title.style.fontSize = "16px";
+  container.appendChild(title);
+
+  const sections: Record<SectionId, SectionHandle> = {
+    visibility: buildSection("visibility", "Visibility", createVisibilitySection(visibility, dispatch)),
+    opacity: buildSection("opacity", "Opacity", createOpacitySection(opacity, dispatch)),
+    filters: buildSection("filters", "Filters", createMagnitudeFilterSection(magLimit, dispatch)),
+    display: buildSection("display", "Display", buildDisplaySection(language, skyculture, dispatch)),
+  };
+
+  for (const id of SECTION_IDS) {
+    container.appendChild(sections[id].wrapper);
+  }
+
+  function expand(id: SectionId): void {
+    for (const other of SECTION_IDS) {
+      const s = sections[other];
+      const expanded = other === id;
+      s.wrapper.dataset.expanded = expanded ? "true" : "false";
+      s.body.style.display = expanded ? "block" : "none";
+      const chev = s.header.querySelector<HTMLElement>(`[data-testid='settings-chevron-${other}']`);
+      if (chev !== null) chev.style.transform = expanded ? "rotate(90deg)" : "rotate(0deg)";
+    }
+  }
+
+  for (const id of SECTION_IDS) {
+    sections[id].header.addEventListener("click", () => {
+      expand(id);
+      persistLastSection(id);
+    });
+  }
+
+  // Initial expanded section follows stored preference, defaulting to visibility.
+  expand(loadLastSection());
+
+  const drawer: Drawer = createDrawer({ side: "right", width: "320px" });
+
+  function doOpen(): void {
+    drawer.open(container);
+  }
+
+  return {
+    element: drawer.element,
+    open: doOpen,
+    close: drawer.close,
+    isOpen: drawer.isOpen,
+  };
+}
+
+function buildDisplaySection(
+  language: Language,
+  skyculture: SkycultureId,
+  dispatch: (intent: UIIntent) => void,
+): HTMLElement {
+  const wrapper = document.createElement("div");
+
+  const langHeading = document.createElement("div");
+  langHeading.textContent = "Constellation Names";
+  applyBaseText(langHeading);
+  langHeading.style.fontSize = "12px";
+  langHeading.style.marginBottom = "2px";
+  wrapper.appendChild(langHeading);
+  wrapper.appendChild(createLanguageSection(language, dispatch));
+
+  const skyHeading = document.createElement("div");
+  skyHeading.textContent = "Skyculture";
+  applyBaseText(skyHeading);
+  skyHeading.style.fontSize = "12px";
+  skyHeading.style.marginTop = "8px";
+  skyHeading.style.marginBottom = "2px";
+  wrapper.appendChild(skyHeading);
+  wrapper.appendChild(createSkycultureSection(skyculture, dispatch));
+
+  return wrapper;
+}


### PR DESCRIPTION
## Summary

- Plan 07 milestone 1E: ⚙ icon in the side-panel header now opens a right-anchored slide-in drawer that consolidates everything the side panel's Layer block used to show — visibility toggles, opacity sliders, magnitude filter, language, skyculture — into four collapsible sections (**Visibility**, **Opacity**, **Filters**, **Display**).
- Introduces a new, reusable `src/ui/drawer.ts` primitive (generic `createDrawer({ side, width, onClose })`) that #197 (events drawer) and #198 (tonight's sky card) will rebase onto — keep the drawer close / backdrop / Escape / onClose semantics in mind when resolving conflicts.
- Remembered section state lives in `localStorage` under the key **`planisphere.settings.lastSection.v1`** (exported as `SETTINGS_SECTION_STORAGE_KEY`), first-open defaults to Visibility; invalid values fall back to Visibility.

## Key decisions

- Split the old `createLayerControls` into focused builders (`createVisibilitySection`, `createOpacitySection`, `createMagnitudeFilterSection`, `createLanguageSection`, `createSkycultureSection`) that the settings drawer composes directly — cleaner than passing an optional host element.
- Removed `createLayerControls` from `app.ts`'s side-panel composition and from the `./ui` barrel; the drawer is mounted on `<body>` and wired via `createPanel({ onOpenSettings })`. The original `⚙` collapse button in the side-panel header moved to `−` / `+` so it doesn't clash.
- Every existing intent (`toggle-layer`, `set-opacity`, `set-mag-limit`, `set-language`, `set-skyculture`) flows through the same `handleIntent` — no state-handling changes needed in `app.ts`.
- No new runtime deps.

## Drawer API surface

```ts
// src/ui/drawer.ts
type DrawerOptions = {
  side: "left" | "right";
  width: string | number;
  onClose?: () => void;
};

type Drawer = {
  element: HTMLElement;
  open: (content: HTMLElement) => void;
  close: () => void;
  isOpen: () => boolean;
};

function createDrawer(options: DrawerOptions): Drawer;
```

`onClose` fires once per open → closed transition (whether via `close()`, `Escape`, or backdrop click). Clicking inside the panel does **not** close.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint` (incl. SPDX check)
- [x] `pnpm test` (891 → 889 tests, all green)
- [x] `pnpm test:cov` — `src/ui` 96.98% line / 90.05% branch; `app.ts` 93.32% line; project floor 95.14%
- [x] `pnpm build`
- [x] Drawer primitive: 16 tests (open / close / Esc / backdrop / onClose dedupe / side / width)
- [x] Settings drawer: 21 tests (sections render, all intents dispatch, localStorage persistence, invalid key fallback)
- [x] Panel: ⚙ button presence, click invokes `onOpenSettings`, no-op when no callback
- [x] App: drawer mounted on body; `onOpenSettings` wired; side-panel UI container no longer renders layer / opacity / mag / language / skyculture controls

🤖 Generated with [Claude Code](https://claude.com/claude-code)