### PR TITLE
feat(ux): object-click floating cards replace pinned tooltip (closes #194)

### DIFF
--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -1103,8 +1103,11 @@ describe("handleIntent routing", () => {
     document.body.removeChild(panelRoot);
   });
 
-  it("picking an object in the scene dispatches open-object-card + opens a card", async () => {
-    capturedDispatch = null;
+  async function driveScenePick(pickedId: Record<string, unknown>): Promise<{
+    openMock: ReturnType<typeof vi.fn>;
+    root: HTMLElement;
+    panelRoot: HTMLElement;
+  }> {
     const ui = await import("./ui");
     const openMock = vi.fn();
     (
@@ -1120,12 +1123,7 @@ describe("handleIntent routing", () => {
     const { root, panelRoot } = makeRoot();
     await bootstrap(root);
 
-    // Find the LEFT_CLICK handler on the tooltip's ScreenSpaceEventHandler so we
-    // can drive it directly. It's the handler whose `pick` flow returns an id.
     const cesium = await import("cesium");
-    const scene = await import("./scene");
-    // Set the shared scene pick to return a star record
-    scene; // reference to silence linter
     const handlerCtor = cesium.ScreenSpaceEventHandler as unknown as ReturnType<typeof vi.fn>;
     const handlers = handlerCtor.mock.results.map(
       (r) => r.value as { setInputAction: ReturnType<typeof vi.fn> },
@@ -1141,28 +1139,88 @@ describe("handleIntent routing", () => {
     }
 
     if (clickFn !== null) {
-      // The scene `.pick` is the vi.fn() inside the cesium mock — return a star id
       const viewerCtor = cesium.Viewer as unknown as ReturnType<typeof vi.fn>;
       const lastViewer = viewerCtor.mock.results[viewerCtor.mock.results.length - 1]?.value as {
         scene?: { pick?: ReturnType<typeof vi.fn> };
       };
-      lastViewer?.scene?.pick?.mockReturnValueOnce({
-        id: {
-          hip: 32349,
-          ra: 101.2872,
-          dec: -16.7161,
-          alt: 45,
-          az: 180,
-          mag: -1.44,
-          name: "Sirius",
-          size: 16,
-          opacity: 1,
-        },
-      });
+      lastViewer?.scene?.pick?.mockReturnValueOnce({ id: pickedId });
       clickFn({ position: { x: 140, y: 260 } });
-      expect(openMock).toHaveBeenCalled();
     }
 
+    return { openMock, root, panelRoot };
+  }
+
+  it("picking a star dispatches open-object-card + opens a card", async () => {
+    capturedDispatch = null;
+    const { openMock, root, panelRoot } = await driveScenePick({
+      hip: 32349,
+      ra: 101.2872,
+      dec: -16.7161,
+      alt: 45,
+      az: 180,
+      mag: -1.44,
+      name: "Sirius",
+      size: 16,
+      opacity: 1,
+    });
+    expect(openMock).toHaveBeenCalled();
+    document.body.removeChild(root);
+    document.body.removeChild(panelRoot);
+  });
+
+  it("picking a planet (body) dispatches open-object-card + opens a card", async () => {
+    capturedDispatch = null;
+    const { openMock, root, panelRoot } = await driveScenePick({
+      id: "Mars",
+      ra: 120,
+      dec: 20,
+      alt: 30,
+      az: 90,
+      mag: 0.4,
+    });
+    expect(openMock).toHaveBeenCalled();
+    document.body.removeChild(root);
+    document.body.removeChild(panelRoot);
+  });
+
+  it("picking a satellite dispatches open-object-card + opens a card", async () => {
+    capturedDispatch = null;
+    const { openMock, root, panelRoot } = await driveScenePick({
+      noradId: 25544,
+      name: "ISS",
+      alt: 40,
+      az: 160,
+      velocity: 7.66,
+    });
+    expect(openMock).toHaveBeenCalled();
+    document.body.removeChild(root);
+    document.body.removeChild(panelRoot);
+  });
+
+  it("picking a Messier object dispatches open-object-card + opens a card", async () => {
+    capturedDispatch = null;
+    const { openMock, root, panelRoot } = await driveScenePick({
+      m: 31,
+      type: "Galaxy",
+      name: "Andromeda",
+      alt: 50,
+      az: 70,
+      mag: 3.4,
+    });
+    expect(openMock).toHaveBeenCalled();
+    document.body.removeChild(root);
+    document.body.removeChild(panelRoot);
+  });
+
+  it("picking a constellation label dispatches open-object-card + opens a card", async () => {
+    capturedDispatch = null;
+    const { openMock, root, panelRoot } = await driveScenePick({
+      id: "Ori",
+      name: "Orion",
+      centroid: { alt: 25, az: 180 },
+      lines: [],
+    });
+    expect(openMock).toHaveBeenCalled();
     document.body.removeChild(root);
     document.body.removeChild(panelRoot);
   });

--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -124,6 +124,9 @@ vi.mock("cesium", () => {
     })),
     LabelStyle: { FILL: 0 },
     Material: { fromType: vi.fn().mockReturnValue({ uniforms: { color: { alpha: 1 } } }) },
+    SceneTransforms: {
+      worldToWindowCoordinates: vi.fn().mockReturnValue({ x: 0, y: 0 }),
+    },
   };
 });
 
@@ -316,6 +319,15 @@ vi.mock("./ui", () => ({
         };
       },
     ),
+  // Object-cards manager — capture the dispatch + projector so tests can exercise
+  // the click-to-card intent pathway without a real Cesium scene.
+  createObjectCardsManager: vi.fn().mockImplementation(() => ({
+    open: vi.fn(),
+    close: vi.fn(),
+    closeActive: vi.fn(),
+    update: vi.fn(),
+    destroy: vi.fn(),
+  })),
 }));
 
 // Mock the TLE bundled data
@@ -1036,6 +1048,23 @@ describe("handleIntent routing", () => {
     document.body.removeChild(panelRoot);
   });
 
+  it("open-object-card intent is handled without throwing when no card data is pending", async () => {
+    capturedDispatch = null;
+    const { root, panelRoot } = makeRoot();
+    await bootstrap(root);
+    expect(() =>
+      capturedDispatch!({
+        type: "open-object-card",
+        objectKind: "star",
+        id: "Sirius",
+        screenX: 100,
+        screenY: 200,
+      }),
+    ).not.toThrow();
+    document.body.removeChild(root);
+    document.body.removeChild(panelRoot);
+  });
+
   it("settings drawer is mounted on document.body", async () => {
     capturedDispatch = null;
     settingsDrawerMock = null;
@@ -1070,6 +1099,70 @@ describe("handleIntent routing", () => {
     expect(uiContainer.querySelector("select[data-skyculture]")).toBeNull();
     expect(uiContainer.querySelector("input[data-mag='limit']")).toBeNull();
     expect(uiContainer.querySelector("input[data-opacity]")).toBeNull();
+    document.body.removeChild(root);
+    document.body.removeChild(panelRoot);
+  });
+
+  it("picking an object in the scene dispatches open-object-card + opens a card", async () => {
+    capturedDispatch = null;
+    const ui = await import("./ui");
+    const openMock = vi.fn();
+    (
+      ui.createObjectCardsManager as unknown as { mockReturnValueOnce: (v: unknown) => void }
+    ).mockReturnValueOnce({
+      open: openMock,
+      close: vi.fn(),
+      closeActive: vi.fn(),
+      update: vi.fn(),
+      destroy: vi.fn(),
+    });
+
+    const { root, panelRoot } = makeRoot();
+    await bootstrap(root);
+
+    // Find the LEFT_CLICK handler on the tooltip's ScreenSpaceEventHandler so we
+    // can drive it directly. It's the handler whose `pick` flow returns an id.
+    const cesium = await import("cesium");
+    const scene = await import("./scene");
+    // Set the shared scene pick to return a star record
+    scene; // reference to silence linter
+    const handlerCtor = cesium.ScreenSpaceEventHandler as unknown as ReturnType<typeof vi.fn>;
+    const handlers = handlerCtor.mock.results.map(
+      (r) => r.value as { setInputAction: ReturnType<typeof vi.fn> },
+    );
+    let clickFn: ((ev: { position: { x: number; y: number } }) => void) | null = null;
+    for (const h of handlers) {
+      for (const call of h.setInputAction.mock.calls) {
+        const [fn, type] = call as [unknown, unknown];
+        if (type === cesium.ScreenSpaceEventType.LEFT_CLICK) {
+          clickFn = fn as (ev: { position: { x: number; y: number } }) => void;
+        }
+      }
+    }
+
+    if (clickFn !== null) {
+      // The scene `.pick` is the vi.fn() inside the cesium mock — return a star id
+      const viewerCtor = cesium.Viewer as unknown as ReturnType<typeof vi.fn>;
+      const lastViewer = viewerCtor.mock.results[viewerCtor.mock.results.length - 1]?.value as {
+        scene?: { pick?: ReturnType<typeof vi.fn> };
+      };
+      lastViewer?.scene?.pick?.mockReturnValueOnce({
+        id: {
+          hip: 32349,
+          ra: 101.2872,
+          dec: -16.7161,
+          alt: 45,
+          az: 180,
+          mag: -1.44,
+          name: "Sirius",
+          size: 16,
+          opacity: 1,
+        },
+      });
+      clickFn({ position: { x: 140, y: 260 } });
+      expect(openMock).toHaveBeenCalled();
+    }
+
     document.body.removeChild(root);
     document.body.removeChild(panelRoot);
   });

--- a/src/app.ts
+++ b/src/app.ts
@@ -48,8 +48,9 @@ import {
   createReticleLayer,
   setCameraView,
   getCameraHeadingDeg,
+  projectAltAzToScreen,
 } from "./scene";
-import type { AzAltPosition } from "./scene";
+import type { AzAltPosition, PickedObject } from "./scene";
 import type {
   StarLayer,
   BodyLayer,
@@ -79,8 +80,16 @@ import {
   createBottomHud,
   createCommandPalette,
   createSettingsDrawer,
+  createObjectCardsManager,
 } from "./ui";
-import type { BottomHud, EventsDrawer } from "./ui";
+import type {
+  BottomHud,
+  EventsDrawer,
+  ObjectCardsManager,
+  ObjectCardData,
+  ObjectPosition,
+  CardKey,
+} from "./ui";
 import type {
   CommandPalette,
   PaletteSources,
@@ -364,6 +373,56 @@ type ParsedData = {
   activeAsterisms: AsterismSet | null;
 };
 
+/** Live alt/az positions for every object currently visible in the sky — populated
+ *  on each rerender and consulted by the object-cards manager so open cards follow
+ *  their target objects as time advances. Keys are `objectKind + '|' + id`. */
+type LatestPositions = Map<string, ObjectPosition>;
+
+function positionKey(kind: string, id: string): string {
+  return `${kind}|${id}`;
+}
+
+function fillLatestFromVisible(
+  latest: LatestPositions,
+  visibleStars: ReturnType<typeof filterVisibleStars>,
+  bodies: ReturnType<typeof computeBodyPositions>,
+  visibleMessier: ReturnType<typeof filterVisibleMessier>,
+  visibleSats: ReturnType<typeof propagateSatellites> | null,
+  visibleConstellations: readonly { id: string; centroid: { alt: number; az: number } }[],
+): void {
+  latest.clear();
+  for (const s of visibleStars) {
+    const id = s.name ?? `HIP ${String(s.hip)}`;
+    latest.set(positionKey("star", id), { alt: s.alt, az: s.az, belowHorizon: s.alt <= 0 });
+  }
+  for (const b of bodies) {
+    latest.set(positionKey("body", b.id), { alt: b.alt, az: b.az, belowHorizon: b.alt <= 0 });
+  }
+  for (const m of visibleMessier) {
+    latest.set(positionKey("messier", `M${String(m.m)}`), {
+      alt: m.alt,
+      az: m.az,
+      belowHorizon: m.alt <= 0,
+    });
+  }
+  if (visibleSats) {
+    for (const sat of visibleSats) {
+      latest.set(positionKey("satellite", sat.name), {
+        alt: sat.alt,
+        az: sat.az,
+        belowHorizon: sat.alt <= 0,
+      });
+    }
+  }
+  for (const c of visibleConstellations) {
+    latest.set(positionKey("constellation", c.id), {
+      alt: c.centroid.alt,
+      az: c.centroid.az,
+      belowHorizon: c.centroid.alt <= 0,
+    });
+  }
+}
+
 let rerenderTimer: ReturnType<typeof setTimeout> | null = null;
 
 /**
@@ -384,10 +443,11 @@ function rerenderSatellites(
   lat: number,
   lon: number,
   time: Date,
-): void {
-  if (!data.satelliteRecords?.ok || !layers.satellite) return;
+): ReturnType<typeof propagateSatellites> | null {
+  if (!data.satelliteRecords?.ok || !layers.satellite) return null;
   const visibleSats = propagateSatellites(data.satelliteRecords.value, lat, lon, time, true);
   layers.satellite.update(visibleSats, lat, lon);
+  return visibleSats;
 }
 
 function updateConstellationLayer(
@@ -396,19 +456,26 @@ function updateConstellationLayer(
   visibleStars: ReturnType<typeof filterVisibleStars>,
   lat: number,
   lon: number,
-): void {
+): readonly { id: string; centroid: { alt: number; az: number } }[] {
   if (data.activeAsterisms !== null) {
     const visible = filterVisibleAsterisms(data.activeAsterisms, visibleStars);
     layers.constellation.update(visible, lat, lon);
-    return;
+    return visible;
   }
   if (data.constellations.ok) {
     const visible = filterVisibleConstellations(data.constellations.value, visibleStars);
     layers.constellation.update(visible, lat, lon);
+    return visible;
   }
+  return [];
 }
 
-function doRerender(state: AppState, layers: Layers, data: ParsedData): void {
+function doRerender(
+  state: AppState,
+  layers: Layers,
+  data: ParsedData,
+  latest?: LatestPositions,
+): void {
   if (!data.stars.ok) return;
   const { observer, timeUtc } = state;
 
@@ -424,7 +491,13 @@ function doRerender(state: AppState, layers: Layers, data: ParsedData): void {
   const bodies = computeBodyPositions(observer.lat, observer.lon, timeUtc, true);
   layers.body.update(bodies, observer.lat, observer.lon);
 
-  updateConstellationLayer(layers, data, visibleStars, observer.lat, observer.lon);
+  const visibleConstellations = updateConstellationLayer(
+    layers,
+    data,
+    visibleStars,
+    observer.lat,
+    observer.lon,
+  );
 
   if (data.boundaries.ok) {
     const visibleBoundaries = filterVisibleBoundaries(
@@ -436,10 +509,11 @@ function doRerender(state: AppState, layers: Layers, data: ParsedData): void {
     layers.boundary.update(visibleBoundaries, observer.lat, observer.lon);
   }
 
-  rerenderSatellites(layers, data, observer.lat, observer.lon, timeUtc);
+  const visibleSats = rerenderSatellites(layers, data, observer.lat, observer.lon, timeUtc);
 
+  let visibleMessier: ReturnType<typeof filterVisibleMessier> = [];
   if (data.messierObjects.ok) {
-    const visibleMessier = filterVisibleMessier(
+    visibleMessier = filterVisibleMessier(
       data.messierObjects.value,
       observer.lat,
       observer.lon,
@@ -466,6 +540,17 @@ function doRerender(state: AppState, layers: Layers, data: ParsedData): void {
   layers.ecliptic.setOpacity(state.opacity.ecliptic);
   layers.milkyWay.setOpacity(state.opacity.milkyWay);
   if (layers.satellite) layers.satellite.setOpacity(state.opacity.satelliteTrails * 0.3);
+
+  if (latest !== undefined) {
+    fillLatestFromVisible(
+      latest,
+      visibleStars,
+      bodies,
+      visibleMessier,
+      visibleSats,
+      visibleConstellations,
+    );
+  }
 }
 
 /**
@@ -482,6 +567,7 @@ async function doRerenderWithWorker(
   worker: AstroWorkerClient,
   catalog: StarRecord[],
   capturedState: AppState,
+  latest?: LatestPositions,
 ): Promise<void> {
   if (!data.stars.ok) return;
   const { observer, timeUtc } = capturedState;
@@ -494,7 +580,7 @@ async function doRerenderWithWorker(
   const bodies = computeBodyPositions(observer.lat, observer.lon, timeUtc, true);
   layers.body.update(bodies, observer.lat, observer.lon);
 
-  rerenderSatellites(layers, data, observer.lat, observer.lon, timeUtc);
+  const visibleSats = rerenderSatellites(layers, data, observer.lat, observer.lon, timeUtc);
 
   const gridData = computeRaDecGrid(observer.lat, observer.lon, timeUtc);
   layers.grid.update(gridData, observer.lat, observer.lon);
@@ -515,8 +601,9 @@ async function doRerenderWithWorker(
     layers.boundary.update(visibleBoundaries, observer.lat, observer.lon);
   }
 
+  let visibleMessier: ReturnType<typeof filterVisibleMessier> = [];
   if (data.messierObjects.ok) {
-    const visibleMessier = filterVisibleMessier(
+    visibleMessier = filterVisibleMessier(
       data.messierObjects.value,
       observer.lat,
       observer.lon,
@@ -537,16 +624,24 @@ async function doRerenderWithWorker(
   if (layers.satellite) layers.satellite.setOpacity(capturedState.opacity.satelliteTrails * 0.3);
 
   // Wait for worker result, then update stars + constellations
+  let visibleStars: ReturnType<typeof filterVisibleStars> = [];
+  let visibleConstellations: readonly { id: string; centroid: { alt: number; az: number } }[] = [];
   try {
     const { altAzs, visibleIndices } = await workerPromise;
     // Check that state hasn't changed since we started (avoid stale updates)
     if (capturedState !== state) return;
-    const visibleStars = buildAltAzStars(catalog, altAzs, visibleIndices, capturedState.magLimit);
+    visibleStars = buildAltAzStars(catalog, altAzs, visibleIndices, capturedState.magLimit);
     layers.star.update(visibleStars, observer.lat, observer.lon);
-    updateConstellationLayer(layers, data, visibleStars, observer.lat, observer.lon);
+    visibleConstellations = updateConstellationLayer(
+      layers,
+      data,
+      visibleStars,
+      observer.lat,
+      observer.lon,
+    );
   } catch {
     // Worker failed — fall back to synchronous star computation
-    const visibleStars = filterVisibleStars(
+    visibleStars = filterVisibleStars(
       catalog,
       observer.lat,
       observer.lon,
@@ -554,7 +649,88 @@ async function doRerenderWithWorker(
       capturedState.magLimit,
     );
     layers.star.update(visibleStars, observer.lat, observer.lon);
-    updateConstellationLayer(layers, data, visibleStars, observer.lat, observer.lon);
+    visibleConstellations = updateConstellationLayer(
+      layers,
+      data,
+      visibleStars,
+      observer.lat,
+      observer.lon,
+    );
+  }
+
+  if (latest !== undefined) {
+    fillLatestFromVisible(
+      latest,
+      visibleStars,
+      bodies,
+      visibleMessier,
+      visibleSats,
+      visibleConstellations,
+    );
+  }
+}
+
+function findUpcomingEventForKey(
+  key: CardKey,
+  events: readonly CelestialEvent[],
+): { when: Date; viewAz: number; viewAlt: number } | undefined {
+  for (const e of events) {
+    if (key.objectKind === "satellite" && e.kind === "iss-pass" && key.id.startsWith("ISS")) {
+      return { when: e.when, viewAz: e.peakAzDeg, viewAlt: e.peakAltDeg };
+    }
+    if (
+      key.objectKind === "body" &&
+      e.kind === "conjunction" &&
+      (e.body1 === key.id || e.body2 === key.id) &&
+      e.viewAz !== undefined &&
+      e.viewAlt !== undefined
+    ) {
+      return { when: e.when, viewAz: e.viewAz, viewAlt: e.viewAlt };
+    }
+    if (
+      key.objectKind === "body" &&
+      key.id === "Moon" &&
+      e.kind === "lunar-eclipse" &&
+      e.viewAz !== undefined &&
+      e.viewAlt !== undefined
+    ) {
+      return { when: e.when, viewAz: e.viewAz, viewAlt: e.viewAlt };
+    }
+  }
+  return undefined;
+}
+
+function pickedToCardData(
+  picked: PickedObject,
+  observer: { lat: number; lon: number },
+  time: Date,
+): ObjectCardData {
+  switch (picked.kind) {
+    case "star":
+      return { kind: "star", star: picked.star };
+    case "body":
+      return { kind: "body", body: picked.body, observer, time };
+    case "satellite":
+      return { kind: "satellite", satellite: picked.satellite };
+    case "messier":
+      return { kind: "messier", messier: picked.messier };
+    case "constellation":
+      return { kind: "constellation", constellation: picked.constellation };
+  }
+}
+
+function idForCardData(data: ObjectCardData): string {
+  switch (data.kind) {
+    case "star":
+      return data.star.name ?? `HIP ${String(data.star.hip)}`;
+    case "body":
+      return data.body.id;
+    case "satellite":
+      return data.satellite.name;
+    case "messier":
+      return `M${String(data.messier.m)}`;
+    case "constellation":
+      return data.constellation.id;
   }
 }
 
@@ -668,8 +844,12 @@ export async function bootstrap(
   // Apply initial constellation name overrides based on language
   layers.constellation.setNameOverrides(loadNameOverridesForLanguage(state.language));
 
+  // Live positions of every visible object, refreshed on every rerender. The
+  // object-cards manager consults this to follow pinned objects as time advances.
+  const latestPositions: LatestPositions = new Map();
+
   // Initial render (synchronous, no debounce — ensures immediate display)
-  doRerender(state, layers, data);
+  doRerender(state, layers, data, latestPositions);
 
   // Initialise worker for subsequent rerenders (falls back to sync if unavailable)
   const worker = tryCreateWorker();
@@ -682,10 +862,21 @@ export async function bootstrap(
       rerenderTimer = null;
       if (worker !== null) {
         // Worker path: star math off main thread
-        void doRerenderWithWorker(state, layers, data, worker, catalog, capturedState);
+        void doRerenderWithWorker(
+          state,
+          layers,
+          data,
+          worker,
+          catalog,
+          capturedState,
+          latestPositions,
+        ).then(() => {
+          objectCardsManager?.update();
+        });
       } else {
         // Fallback: synchronous (also used in test environment)
-        doRerender(capturedState, layers, data);
+        doRerender(capturedState, layers, data, latestPositions);
+        objectCardsManager?.update();
       }
     }, 50);
   }
@@ -727,10 +918,43 @@ export async function bootstrap(
     state.timeUtc,
   );
 
-  // Tooltip
+  // Object cards manager — floating cards pinned on click. Replaces the previous
+  // single pinned tooltip. The manager is created before the tooltip so the click
+  // callback can dispatch open-object-card intents into a live target.
+  //
+  // Pending card data: the tooltip's click callback stashes the freshly-picked
+  // ObjectCardData here, then dispatches an `open-object-card` intent. The intent
+  // handler pops this and feeds it to the manager. This keeps the intent shape
+  // URL-safe (just id + kind + coords) while preserving the typed data the card
+  // needs to render its initial content.
+  const pendingCardData = new Map<string, ObjectCardData>();
+  let objectCardsManager: ObjectCardsManager | null = null;
   const cesiumContainer = document.getElementById("cesium-container");
   if (cesiumContainer) {
-    createTooltip(viewer, cesiumContainer);
+    objectCardsManager = createObjectCardsManager({
+      container: cesiumContainer,
+      dispatch: (intent) => {
+        handleIntent(intent);
+      },
+      projector: (alt, az) =>
+        projectAltAzToScreen(viewer.scene, alt, az, state.observer.lat, state.observer.lon),
+      resolver: (key: CardKey) => latestPositions.get(positionKey(key.objectKind, key.id)) ?? null,
+      getViewport: () => ({
+        width: cesiumContainer.clientWidth || window.innerWidth,
+        height: cesiumContainer.clientHeight || window.innerHeight,
+      }),
+      findUpcomingEvent: (key: CardKey) => findUpcomingEventForKey(key, cachedEvents),
+    });
+
+    createTooltip(viewer, cesiumContainer, {
+      onObjectClicked: (picked: PickedObject, screenX: number, screenY: number) => {
+        const cardData = pickedToCardData(picked, state.observer, state.timeUtc);
+        const objectKind = cardData.kind;
+        const id = idForCardData(cardData);
+        pendingCardData.set(positionKey(objectKind, id), cardData);
+        handleIntent({ type: "open-object-card", objectKind, id, screenX, screenY });
+      },
+    });
   }
 
   // Gesture polish (Plan 07 1J):
@@ -979,6 +1203,19 @@ export async function bootstrap(
       case "toggle-animation": {
         // Plan 08 / issue #136 will wire the actual play/pause animator.
         // TODO(#136): start/stop the time-advance loop here.
+        break;
+      }
+      case "open-object-card": {
+        if (objectCardsManager === null) break;
+        const key = positionKey(intent.objectKind, intent.id);
+        const data = pendingCardData.get(key);
+        if (data === undefined) break;
+        pendingCardData.delete(key);
+        objectCardsManager.open({
+          data,
+          screenX: intent.screenX,
+          screenY: intent.screenY,
+        });
         break;
       }
     }

--- a/src/scene/constellations.ts
+++ b/src/scene/constellations.ts
@@ -72,6 +72,9 @@ export function createConstellationLayer(scene: Scene): ConstellationLayer {
         horizontalOrigin: HorizontalOrigin.CENTER,
         verticalOrigin: VerticalOrigin.CENTER,
         disableDepthTestDistance: Number.POSITIVE_INFINITY,
+        // Attach the VisibleConstellation as the picked id so scene/tooltip can
+        // resolve clicks on the label back to a typed structured payload.
+        id: constellation,
       });
     }
   }

--- a/src/scene/index.ts
+++ b/src/scene/index.ts
@@ -21,7 +21,8 @@ export {
 } from "./animation-math";
 export type { AzAlt } from "./animation-math";
 export { type StarLayer, createStarLayer } from "./stars";
-export { type Tooltip, createTooltip } from "./tooltip";
+export { type Tooltip, type TooltipOptions, type PickedObject, createTooltip } from "./tooltip";
+export { type ScreenProjection, projectAltAzToScreen } from "./project";
 export { type BodyLayer, createBodyLayer } from "./bodies";
 export {
   type ConstellationLayer,

--- a/src/scene/project.test.ts
+++ b/src/scene/project.test.ts
@@ -1,0 +1,77 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { describe, expect, it, vi } from "vitest";
+import type { Scene } from "cesium";
+import { projectAltAzToScreen } from "./project";
+
+vi.mock("cesium", () => {
+  const Cartesian3Ctor = vi
+    .fn()
+    .mockImplementation((x: number, y: number, z: number) => ({ x, y, z }));
+  (Cartesian3Ctor as unknown as { fromDegrees: ReturnType<typeof vi.fn> }).fromDegrees = vi
+    .fn()
+    .mockReturnValue({ x: 1, y: 2, z: 3 });
+  return {
+    SceneTransforms: {
+      worldToWindowCoordinates: vi.fn().mockReturnValue({ x: 400, y: 300 }),
+    },
+    Cartesian3: Cartesian3Ctor,
+    Math: {
+      toRadians: (d: number) => (d * Math.PI) / 180,
+    },
+    Transforms: {
+      eastNorthUpToFixedFrame: vi
+        .fn()
+        .mockReturnValue([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]),
+    },
+    Matrix4: {
+      multiplyByPoint: vi.fn().mockReturnValue({ x: 10, y: 20, z: 30 }),
+    },
+  };
+});
+
+function makeScene(width: number, height: number): Scene {
+  const canvas = document.createElement("canvas");
+  Object.defineProperty(canvas, "clientWidth", { value: width });
+  Object.defineProperty(canvas, "clientHeight", { value: height });
+  return { canvas } as unknown as Scene;
+}
+
+describe("projectAltAzToScreen", () => {
+  it("returns the window coordinates from SceneTransforms", () => {
+    const scene = makeScene(800, 600);
+    const result = projectAltAzToScreen(scene, 45, 180, 34, -118);
+    expect(result).not.toBeNull();
+    expect(result?.x).toBe(400);
+    expect(result?.y).toBe(300);
+  });
+
+  it("marks the point on-screen when within canvas bounds", () => {
+    const scene = makeScene(800, 600);
+    const result = projectAltAzToScreen(scene, 45, 180, 34, -118);
+    expect(result?.onScreen).toBe(true);
+  });
+
+  it("marks the point off-screen when SceneTransforms returns coords outside the canvas", async () => {
+    const cesium = await import("cesium");
+    (
+      cesium.SceneTransforms.worldToWindowCoordinates as unknown as {
+        mockReturnValueOnce: (v: unknown) => void;
+      }
+    ).mockReturnValueOnce({ x: -50, y: 1000 });
+    const scene = makeScene(800, 600);
+    const result = projectAltAzToScreen(scene, 45, 180, 34, -118);
+    expect(result?.onScreen).toBe(false);
+  });
+
+  it("returns null when Cesium cannot project the point", async () => {
+    const cesium = await import("cesium");
+    (
+      cesium.SceneTransforms.worldToWindowCoordinates as unknown as {
+        mockReturnValueOnce: (v: unknown) => void;
+      }
+    ).mockReturnValueOnce(undefined);
+    const scene = makeScene(800, 600);
+    const result = projectAltAzToScreen(scene, 45, 180, 34, -118);
+    expect(result).toBeNull();
+  });
+});

--- a/src/scene/project.ts
+++ b/src/scene/project.ts
@@ -1,0 +1,38 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { SceneTransforms } from "cesium";
+import type { Scene } from "cesium";
+import { altAzToCartesian } from "./stars";
+
+export type ScreenProjection = {
+  readonly x: number;
+  readonly y: number;
+  readonly onScreen: boolean;
+};
+
+/**
+ * Project a local horizontal direction (alt/az) to window coordinates in the Cesium viewer.
+ *
+ * Returns `null` if Cesium cannot produce window coordinates (for example when the point
+ * is behind the camera). The `onScreen` flag is `true` when the projected point sits
+ * inside the scene canvas; cards using this result can hide themselves off-screen.
+ *
+ * We re-use `altAzToCartesian` (already exported from `scene/stars`) so projection uses
+ * the same world-space frame as every other layer — guaranteed pixel-consistent with the
+ * billboards the user clicked.
+ */
+export function projectAltAzToScreen(
+  scene: Scene,
+  alt: number,
+  az: number,
+  lat: number,
+  lon: number,
+): ScreenProjection | null {
+  const world = altAzToCartesian(alt, az, lat, lon);
+  const win = SceneTransforms.worldToWindowCoordinates(scene, world);
+  if (win === undefined) return null;
+  const canvas = scene.canvas as HTMLCanvasElement | undefined;
+  const width = canvas?.clientWidth ?? Number.POSITIVE_INFINITY;
+  const height = canvas?.clientHeight ?? Number.POSITIVE_INFINITY;
+  const onScreen = win.x >= 0 && win.x <= width && win.y >= 0 && win.y <= height;
+  return { x: win.x, y: win.y, onScreen };
+}

--- a/src/scene/tooltip.test.ts
+++ b/src/scene/tooltip.test.ts
@@ -31,13 +31,21 @@ describe("createTooltip", () => {
     mockPick.mockClear();
   });
 
-  it("creates a tooltip div inside the container", () => {
+  it("creates a hover tooltip div inside the container", () => {
     const container = document.createElement("div");
     const viewer = makeMockViewer();
     createTooltip(viewer as never, container);
     const tooltipDiv = container.querySelector("div");
     expect(tooltipDiv).toBeTruthy();
     expect(tooltipDiv!.style.display).toBe("none");
+  });
+
+  it("creates exactly one DOM element (hover only — no pinned tooltip any more)", () => {
+    const container = document.createElement("div");
+    const viewer = makeMockViewer();
+    createTooltip(viewer as never, container);
+    expect(container.querySelectorAll("div").length).toBe(1);
+    expect(container.querySelector("[data-pinned]")).toBeNull();
   });
 
   it("registers a MOUSE_MOVE handler and a LEFT_CLICK handler", () => {
@@ -47,7 +55,7 @@ describe("createTooltip", () => {
     expect(mockSetInputAction).toHaveBeenCalledTimes(2);
   });
 
-  it("shows tooltip with star info when a billboard is picked", () => {
+  it("shows hover tooltip with star info when a billboard is picked", () => {
     const container = document.createElement("div");
     const viewer = makeMockViewer();
     createTooltip(viewer as never, container);
@@ -100,7 +108,6 @@ describe("createTooltip", () => {
     const tooltip = createTooltip(viewer as never, container);
     tooltip.destroy();
     expect(mockDestroy).toHaveBeenCalledOnce();
-    // Both hover and pinned tooltips removed
     expect(container.querySelectorAll("div").length).toBe(0);
   });
 
@@ -165,187 +172,6 @@ describe("createTooltip", () => {
     expect(tooltipDiv.innerHTML).toContain("420");
   });
 
-  // --- Click-to-pin tests ---
-
-  it("clicking a star pins the tooltip — it stays visible and has a close button", () => {
-    const container = document.createElement("div");
-    const viewer = makeMockViewer();
-    createTooltip(viewer as never, container);
-
-    const clickCallback = mockSetInputAction.mock.calls[1]![0] as (movement: {
-      position: { x: number; y: number };
-    }) => void;
-
-    mockPick.mockReturnValueOnce({
-      id: {
-        hip: 32349,
-        ra: 101.2872,
-        dec: -16.7161,
-        alt: 45.2,
-        az: 180.3,
-        mag: -1.44,
-        name: "Sirius",
-        size: 16,
-        opacity: 1,
-      },
-    });
-    clickCallback({ position: { x: 100, y: 200 } });
-
-    const pinnedDiv = container.querySelector<HTMLElement>("[data-pinned]");
-    expect(pinnedDiv).toBeTruthy();
-    expect(pinnedDiv!.style.display).toBe("block");
-    expect(pinnedDiv!.innerHTML).toContain("Sirius");
-    // Close button present
-    const closeBtn = pinnedDiv!.querySelector("button");
-    expect(closeBtn).toBeTruthy();
-  });
-
-  it("clicking the × button dismisses the pinned tooltip", () => {
-    const container = document.createElement("div");
-    const viewer = makeMockViewer();
-    createTooltip(viewer as never, container);
-
-    const clickCallback = mockSetInputAction.mock.calls[1]![0] as (movement: {
-      position: { x: number; y: number };
-    }) => void;
-
-    mockPick.mockReturnValueOnce({
-      id: {
-        hip: 32349,
-        ra: 101.2872,
-        dec: -16.7161,
-        alt: 45.2,
-        az: 180.3,
-        mag: -1.44,
-        name: "Sirius",
-        size: 16,
-        opacity: 1,
-      },
-    });
-    clickCallback({ position: { x: 100, y: 200 } });
-
-    const pinnedDiv = container.querySelector<HTMLElement>("[data-pinned]");
-    expect(pinnedDiv).toBeTruthy();
-
-    const closeBtn = pinnedDiv!.querySelector("button")!;
-    closeBtn.click();
-
-    expect(pinnedDiv!.style.display).toBe("none");
-  });
-
-  it("clicking empty space dismisses the pinned tooltip", () => {
-    const container = document.createElement("div");
-    const viewer = makeMockViewer();
-    createTooltip(viewer as never, container);
-
-    const clickCallback = mockSetInputAction.mock.calls[1]![0] as (movement: {
-      position: { x: number; y: number };
-    }) => void;
-
-    // First click pins
-    mockPick.mockReturnValueOnce({
-      id: {
-        hip: 32349,
-        ra: 101.2872,
-        dec: -16.7161,
-        alt: 45.2,
-        az: 180.3,
-        mag: -1.44,
-        name: "Sirius",
-        size: 16,
-        opacity: 1,
-      },
-    });
-    clickCallback({ position: { x: 100, y: 200 } });
-
-    const pinnedDiv = container.querySelector<HTMLElement>("[data-pinned]");
-    expect(pinnedDiv!.style.display).toBe("block");
-
-    // Second click on empty space (no pick result) dismisses
-    mockPick.mockReturnValueOnce(undefined);
-    clickCallback({ position: { x: 300, y: 400 } });
-
-    expect(pinnedDiv!.style.display).toBe("none");
-  });
-
-  it("hover tooltip is hidden when a tooltip is pinned", () => {
-    const container = document.createElement("div");
-    const viewer = makeMockViewer();
-    createTooltip(viewer as never, container);
-
-    const moveCallback = mockSetInputAction.mock.calls[0]![0] as (movement: {
-      endPosition: { x: number; y: number };
-    }) => void;
-    const clickCallback = mockSetInputAction.mock.calls[1]![0] as (movement: {
-      position: { x: number; y: number };
-    }) => void;
-
-    // Pin a tooltip first
-    mockPick.mockReturnValueOnce({
-      id: {
-        hip: 32349,
-        ra: 101.2872,
-        dec: -16.7161,
-        alt: 45.2,
-        az: 180.3,
-        mag: -1.44,
-        name: "Sirius",
-        size: 16,
-        opacity: 1,
-      },
-    });
-    clickCallback({ position: { x: 100, y: 200 } });
-
-    // Hover over another star — hover tooltip should stay hidden
-    mockPick.mockReturnValueOnce({
-      id: {
-        hip: 11111,
-        ra: 50.0,
-        dec: 20.0,
-        alt: 30.0,
-        az: 90.0,
-        mag: 2.0,
-        name: "Vega",
-        size: 10,
-        opacity: 1,
-      },
-    });
-    moveCallback({ endPosition: { x: 200, y: 300 } });
-
-    // The first (hover) div should remain hidden
-    const hoverDiv = container.querySelector<HTMLElement>("div:not([data-pinned])")!;
-    expect(hoverDiv.style.display).toBe("none");
-  });
-
-  it("pinned tooltip has a solid border style to distinguish from hover", () => {
-    const container = document.createElement("div");
-    const viewer = makeMockViewer();
-    createTooltip(viewer as never, container);
-
-    const clickCallback = mockSetInputAction.mock.calls[1]![0] as (movement: {
-      position: { x: number; y: number };
-    }) => void;
-
-    mockPick.mockReturnValueOnce({
-      id: {
-        hip: 32349,
-        ra: 101.2872,
-        dec: -16.7161,
-        alt: 45.2,
-        az: 180.3,
-        mag: -1.44,
-        name: "Sirius",
-        size: 16,
-        opacity: 1,
-      },
-    });
-    clickCallback({ position: { x: 100, y: 200 } });
-
-    const pinnedDiv = container.querySelector<HTMLElement>("[data-pinned]")!;
-    // Should have pointer-events enabled (not none) so close button is clickable
-    expect(pinnedDiv.style.pointerEvents).not.toBe("none");
-  });
-
   it("shows tooltip with Messier object info when a VisibleMessier billboard is picked", () => {
     const container = document.createElement("div");
     const viewer = makeMockViewer();
@@ -376,5 +202,98 @@ describe("createTooltip", () => {
     expect(tooltipDiv.innerHTML).toContain("Orion Nebula");
     expect(tooltipDiv.innerHTML).toContain("nebula");
     expect(tooltipDiv.innerHTML).toContain("4.0");
+  });
+
+  // --- Click-to-card tests ---
+
+  it("clicking an object invokes onObjectClicked with the picked data + screen coords", () => {
+    const container = document.createElement("div");
+    const viewer = makeMockViewer();
+    const onObjectClicked = vi.fn();
+    createTooltip(viewer as never, container, { onObjectClicked });
+
+    const clickCallback = mockSetInputAction.mock.calls[1]![0] as (movement: {
+      position: { x: number; y: number };
+    }) => void;
+
+    mockPick.mockReturnValueOnce({
+      id: {
+        hip: 32349,
+        ra: 101.2872,
+        dec: -16.7161,
+        alt: 45.2,
+        az: 180.3,
+        mag: -1.44,
+        name: "Sirius",
+        size: 16,
+        opacity: 1,
+      },
+    });
+    clickCallback({ position: { x: 100, y: 200 } });
+
+    expect(onObjectClicked).toHaveBeenCalledOnce();
+    const call = onObjectClicked.mock.calls[0] as [{ kind: string }, number, number];
+    expect(call[0].kind).toBe("star");
+    expect(call[1]).toBe(100);
+    expect(call[2]).toBe(200);
+  });
+
+  it("clicking empty space does NOT invoke onObjectClicked", () => {
+    const container = document.createElement("div");
+    const viewer = makeMockViewer();
+    const onObjectClicked = vi.fn();
+    createTooltip(viewer as never, container, { onObjectClicked });
+
+    const clickCallback = mockSetInputAction.mock.calls[1]![0] as (movement: {
+      position: { x: number; y: number };
+    }) => void;
+    mockPick.mockReturnValueOnce(undefined);
+    clickCallback({ position: { x: 200, y: 200 } });
+    expect(onObjectClicked).not.toHaveBeenCalled();
+  });
+
+  it("clicking a constellation label invokes onObjectClicked with kind='constellation'", () => {
+    const container = document.createElement("div");
+    const viewer = makeMockViewer();
+    const onObjectClicked = vi.fn();
+    createTooltip(viewer as never, container, { onObjectClicked });
+
+    const clickCallback = mockSetInputAction.mock.calls[1]![0] as (movement: {
+      position: { x: number; y: number };
+    }) => void;
+    mockPick.mockReturnValueOnce({
+      id: {
+        id: "Ori",
+        name: "Orion",
+        lines: [],
+        centroid: { alt: 15, az: 105 },
+      },
+    });
+    clickCallback({ position: { x: 150, y: 150 } });
+    expect(onObjectClicked).toHaveBeenCalledOnce();
+    expect((onObjectClicked.mock.calls[0]![0] as { kind: string }).kind).toBe("constellation");
+  });
+
+  it("does not throw when clicked without an onObjectClicked handler", () => {
+    const container = document.createElement("div");
+    const viewer = makeMockViewer();
+    createTooltip(viewer as never, container);
+    const clickCallback = mockSetInputAction.mock.calls[1]![0] as (movement: {
+      position: { x: number; y: number };
+    }) => void;
+    mockPick.mockReturnValueOnce({
+      id: {
+        hip: 32349,
+        ra: 101,
+        dec: -16,
+        alt: 45,
+        az: 180,
+        mag: -1.44,
+        name: "Sirius",
+        size: 16,
+        opacity: 1,
+      },
+    });
+    expect(() => clickCallback({ position: { x: 10, y: 20 } })).not.toThrow();
   });
 });

--- a/src/scene/tooltip.ts
+++ b/src/scene/tooltip.ts
@@ -5,9 +5,25 @@ import type { AltAzStar } from "../astro";
 import type { CelestialBody } from "../astro";
 import type { VisibleSatellite } from "../sat";
 import type { VisibleMessier } from "../astro/messier";
+import type { VisibleConstellation } from "../astro/constellations";
 
 export type Tooltip = {
   destroy: () => void;
+};
+
+/** Structured representation of what was picked under the mouse.
+ *  Used for both hover rendering and the click-emit callback. */
+export type PickedObject =
+  | { readonly kind: "star"; readonly star: AltAzStar }
+  | { readonly kind: "body"; readonly body: CelestialBody }
+  | { readonly kind: "satellite"; readonly satellite: VisibleSatellite }
+  | { readonly kind: "messier"; readonly messier: VisibleMessier }
+  | { readonly kind: "constellation"; readonly constellation: VisibleConstellation };
+
+export type TooltipOptions = {
+  /** Invoked on left-click when an object is picked. The caller is responsible for
+   *  presenting any pinned UI (see `ui/object-cards-manager`). */
+  onObjectClicked?: (picked: PickedObject, screenX: number, screenY: number) => void;
 };
 
 function formatRa(raDeg: number): string {
@@ -97,6 +113,18 @@ function isVisibleMessier(obj: unknown): obj is VisibleMessier {
   );
 }
 
+function isVisibleConstellation(obj: unknown): obj is VisibleConstellation {
+  return (
+    typeof obj === "object" &&
+    obj !== null &&
+    "centroid" in obj &&
+    "lines" in obj &&
+    "id" in obj &&
+    "name" in obj &&
+    typeof (obj as Record<string, unknown>).id === "string"
+  );
+}
+
 function formatMessier(obj: VisibleMessier): string {
   const label = obj.name.length > 0 ? `M${String(obj.m)} \u2014 ${obj.name}` : `M${String(obj.m)}`;
   return (
@@ -116,21 +144,37 @@ function formatSatellite(sat: VisibleSatellite): string {
   );
 }
 
-function pickHtml(
+function pickObject(
   viewer: { scene: { pick: (pos: Cartesian2) => unknown } },
   position: Cartesian2,
-): string | null {
+): PickedObject | null {
   const picked: { id?: unknown } | undefined = viewer.scene.pick(position) as
     | { id?: unknown }
     | undefined;
 
   if (!defined(picked) || picked === undefined) return null;
 
-  if (isAltAzStar(picked.id)) return formatStar(picked.id);
-  if (isCelestialBody(picked.id)) return formatBody(picked.id);
-  if (isVisibleSatellite(picked.id)) return formatSatellite(picked.id);
-  if (isVisibleMessier(picked.id)) return formatMessier(picked.id);
+  if (isAltAzStar(picked.id)) return { kind: "star", star: picked.id };
+  if (isCelestialBody(picked.id)) return { kind: "body", body: picked.id };
+  if (isVisibleSatellite(picked.id)) return { kind: "satellite", satellite: picked.id };
+  if (isVisibleMessier(picked.id)) return { kind: "messier", messier: picked.id };
+  if (isVisibleConstellation(picked.id)) return { kind: "constellation", constellation: picked.id };
   return null;
+}
+
+function pickHtml(picked: PickedObject): string {
+  switch (picked.kind) {
+    case "star":
+      return formatStar(picked.star);
+    case "body":
+      return formatBody(picked.body);
+    case "satellite":
+      return formatSatellite(picked.satellite);
+    case "messier":
+      return formatMessier(picked.messier);
+    case "constellation":
+      return `<strong>${picked.constellation.name}</strong><br>(constellation)`;
+  }
 }
 
 const HOVER_STYLE =
@@ -138,47 +182,22 @@ const HOVER_STYLE =
   "color:#fff;font:12px/1.4 monospace;padding:6px 10px;border-radius:4px;" +
   "border:1px solid rgba(255,255,255,0.2);white-space:nowrap;z-index:10";
 
-const PINNED_STYLE =
-  "position:absolute;pointer-events:auto;display:none;background:rgba(10,20,40,0.95);" +
-  "color:#fff;font:12px/1.4 monospace;padding:6px 10px 6px 10px;border-radius:4px;" +
-  "border:1px solid rgba(100,160,255,0.8);white-space:nowrap;z-index:11;box-shadow:0 0 8px rgba(100,160,255,0.3)";
-
-const CLOSE_BTN_STYLE =
-  "background:none;border:none;color:rgba(255,255,255,0.6);cursor:pointer;" +
-  "font:14px/1 monospace;padding:0 0 0 8px;vertical-align:top;float:right";
-
-export function createTooltip(viewer: Viewer, container: HTMLElement): Tooltip {
-  // Hover tooltip
+export function createTooltip(
+  viewer: Viewer,
+  container: HTMLElement,
+  options: TooltipOptions = {},
+): Tooltip {
+  // Hover tooltip only — pinned / card presentation now lives in ui/object-cards-manager.
   const hoverEl = document.createElement("div");
   hoverEl.style.cssText = HOVER_STYLE;
   container.appendChild(hoverEl);
 
-  // Pinned tooltip
-  const pinnedEl = document.createElement("div");
-  pinnedEl.style.cssText = PINNED_STYLE;
-  pinnedEl.dataset.pinned = "true";
-  container.appendChild(pinnedEl);
-
-  let isPinned = false;
-
-  function dismissPinned(): void {
-    isPinned = false;
-    pinnedEl.style.display = "none";
-    pinnedEl.innerHTML = "";
-  }
-
   const handler = new ScreenSpaceEventHandler(viewer.scene.canvas);
 
-  // Hover handler
   handler.setInputAction((movement: { endPosition: Cartesian2 }) => {
-    if (isPinned) {
-      hoverEl.style.display = "none";
-      return;
-    }
-
-    const html = pickHtml(viewer, movement.endPosition);
-    if (html !== null) {
-      hoverEl.innerHTML = html;
+    const picked = pickObject(viewer, movement.endPosition);
+    if (picked !== null) {
+      hoverEl.innerHTML = pickHtml(picked);
       hoverEl.style.display = "block";
       hoverEl.style.left = `${String(movement.endPosition.x + 14)}px`;
       hoverEl.style.top = `${String(movement.endPosition.y + 14)}px`;
@@ -187,38 +206,16 @@ export function createTooltip(viewer: Viewer, container: HTMLElement): Tooltip {
     }
   }, ScreenSpaceEventType.MOUSE_MOVE);
 
-  // Click handler
   handler.setInputAction((movement: { position: Cartesian2 }) => {
-    const html = pickHtml(viewer, movement.position);
-
-    if (html === null) {
-      // Clicked empty space — dismiss pinned
-      dismissPinned();
-      return;
-    }
-
-    // Pin the tooltip
-    isPinned = true;
+    const picked = pickObject(viewer, movement.position);
+    if (picked === null) return;
     hoverEl.style.display = "none";
-
-    const closeBtn = document.createElement("button");
-    closeBtn.style.cssText = CLOSE_BTN_STYLE;
-    closeBtn.textContent = "\u00D7";
-    closeBtn.addEventListener("click", () => {
-      dismissPinned();
-    });
-
-    pinnedEl.innerHTML = html;
-    pinnedEl.appendChild(closeBtn);
-    pinnedEl.style.display = "block";
-    pinnedEl.style.left = `${String(movement.position.x + 14)}px`;
-    pinnedEl.style.top = `${String(movement.position.y + 14)}px`;
+    options.onObjectClicked?.(picked, movement.position.x, movement.position.y);
   }, ScreenSpaceEventType.LEFT_CLICK);
 
   function destroy(): void {
     handler.destroy();
     hoverEl.remove();
-    pinnedEl.remove();
   }
 
   return { destroy };

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -38,6 +38,18 @@ export type {
   PaletteSettingSource,
   PaletteObjectType,
 } from "./palette-results";
+export { createObjectCard } from "./object-card";
+export type { ObjectCard, ObjectCardData, ObjectCardProps } from "./object-card";
+export { createObjectCardsManager } from "./object-cards-manager";
+export type {
+  ObjectCardsManager,
+  CardsManagerOptions,
+  CardKey,
+  ObjectCardKind,
+  ScreenPosition,
+  ObjectPosition,
+  OpenCardRequest,
+} from "./object-cards-manager";
 
 import type { LayerVisibility, LayerOpacity } from "../state/state";
 import type { Language } from "../astro/constellation-names";
@@ -61,4 +73,11 @@ export type UIIntent =
   | { type: "open-location-picker" }
   | { type: "toggle-animation" }
   | { type: "pin-object"; id: string }
-  | { type: "copy-link" };
+  | { type: "copy-link" }
+  | {
+      type: "open-object-card";
+      objectKind: "star" | "body" | "satellite" | "messier" | "constellation";
+      id: string;
+      screenX: number;
+      screenY: number;
+    };

--- a/src/ui/object-card.test.ts
+++ b/src/ui/object-card.test.ts
@@ -1,0 +1,447 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { describe, expect, it, vi } from "vitest";
+import { createObjectCard } from "./object-card";
+import type { ObjectCardData } from "./object-card";
+import type { UIIntent } from "./index";
+
+function starData(): ObjectCardData {
+  return {
+    kind: "star",
+    star: {
+      hip: 32349,
+      ra: 101.2872,
+      dec: -16.7161,
+      alt: 45.2,
+      az: 180.3,
+      mag: -1.44,
+      name: "Sirius",
+      size: 16,
+      opacity: 1,
+    },
+  };
+}
+
+function bodyData(): ObjectCardData {
+  return {
+    kind: "body",
+    body: {
+      id: "Moon",
+      alt: 55.3,
+      az: 120.1,
+      ra: 100.5,
+      dec: -5.2,
+      mag: -12.7,
+      size: 20,
+      color: "#E8E8E0",
+      illumination: 0.75,
+      phaseAngle: 90,
+    },
+    observer: { lat: 34, lon: -118 },
+    time: new Date("2026-04-18T04:00:00Z"),
+  };
+}
+
+function satelliteData(): ObjectCardData {
+  return {
+    kind: "satellite",
+    satellite: {
+      name: "ISS (ZARYA)",
+      noradId: 25544,
+      alt: 45.2,
+      az: 200.3,
+      height: 420,
+      velocity: 7.66,
+      trail: [],
+    },
+  };
+}
+
+function messierData(): ObjectCardData {
+  return {
+    kind: "messier",
+    messier: {
+      m: 42,
+      name: "Orion Nebula",
+      type: "nebula",
+      alt: 45.2,
+      az: 180.3,
+      ra: 83.8221,
+      dec: -5.3911,
+      mag: 4.0,
+    },
+  };
+}
+
+function constellationData(): ObjectCardData {
+  return {
+    kind: "constellation",
+    constellation: {
+      id: "Ori",
+      name: "Orion",
+      lines: [
+        {
+          start: { alt: 10, az: 100 },
+          end: { alt: 20, az: 110 },
+        },
+      ],
+      centroid: { alt: 15, az: 105 },
+    },
+  };
+}
+
+describe("createObjectCard — star", () => {
+  it("renders star name, magnitude and alt/az", () => {
+    const dispatch = vi.fn();
+    const { element } = createObjectCard({
+      data: starData(),
+      screenX: 100,
+      screenY: 200,
+      viewportWidth: 800,
+      viewportHeight: 600,
+      dispatch,
+    });
+    const html = element.innerHTML;
+    expect(html).toContain("Sirius");
+    expect(html).toContain("-1.44");
+    expect(html).toContain("45.2");
+    expect(html).toContain("180.3");
+    expect(html).toMatch(/star/i);
+  });
+
+  it("shows Pin and Copy link actions but no Trail / Go to peak for a star", () => {
+    const dispatch = vi.fn();
+    const { element } = createObjectCard({
+      data: starData(),
+      screenX: 100,
+      screenY: 200,
+      viewportWidth: 800,
+      viewportHeight: 600,
+      dispatch,
+    });
+    const buttons = Array.from(element.querySelectorAll("button")).map((b) => b.textContent ?? "");
+    expect(buttons.some((t) => /pin/i.test(t))).toBe(true);
+    expect(buttons.some((t) => /copy link/i.test(t))).toBe(true);
+    expect(buttons.some((t) => /trail/i.test(t))).toBe(false);
+  });
+
+  it("Pin action dispatches pin-object intent with the star name", () => {
+    const dispatch = vi.fn<(i: UIIntent) => void>();
+    const { element } = createObjectCard({
+      data: starData(),
+      screenX: 100,
+      screenY: 200,
+      viewportWidth: 800,
+      viewportHeight: 600,
+      dispatch,
+    });
+    const pinBtn = Array.from(element.querySelectorAll("button")).find((b) =>
+      /pin/i.test(b.textContent ?? ""),
+    );
+    expect(pinBtn).toBeDefined();
+    pinBtn!.click();
+    expect(dispatch).toHaveBeenCalledWith({ type: "pin-object", id: "Sirius" });
+  });
+});
+
+describe("createObjectCard — body", () => {
+  it("renders body name, magnitude, illumination and rise/set rows", () => {
+    const { element } = createObjectCard({
+      data: bodyData(),
+      screenX: 100,
+      screenY: 200,
+      viewportWidth: 800,
+      viewportHeight: 600,
+      dispatch: vi.fn(),
+    });
+    expect(element.innerHTML).toContain("Moon");
+    expect(element.innerHTML).toContain("-12.7");
+    expect(element.innerHTML).toContain("75%");
+  });
+
+  it("body card includes Trail action", () => {
+    const { element } = createObjectCard({
+      data: bodyData(),
+      screenX: 100,
+      screenY: 200,
+      viewportWidth: 800,
+      viewportHeight: 600,
+      dispatch: vi.fn(),
+    });
+    const buttons = Array.from(element.querySelectorAll("button")).map((b) => b.textContent ?? "");
+    expect(buttons.some((t) => /trail/i.test(t))).toBe(true);
+  });
+
+  it("body Trail action dispatches show-trail intent", () => {
+    const dispatch = vi.fn<(i: UIIntent) => void>();
+    const { element } = createObjectCard({
+      data: bodyData(),
+      screenX: 100,
+      screenY: 200,
+      viewportWidth: 800,
+      viewportHeight: 600,
+      dispatch,
+    });
+    const trailBtn = Array.from(element.querySelectorAll("button")).find((b) =>
+      /trail/i.test(b.textContent ?? ""),
+    );
+    trailBtn!.click();
+    expect(dispatch).toHaveBeenCalledWith({
+      type: "show-trail",
+      objectKind: "body",
+      id: "Moon",
+    });
+  });
+});
+
+describe("createObjectCard — satellite", () => {
+  it("renders satellite name, NORAD id, altitude and velocity", () => {
+    const { element } = createObjectCard({
+      data: satelliteData(),
+      screenX: 100,
+      screenY: 200,
+      viewportWidth: 800,
+      viewportHeight: 600,
+      dispatch: vi.fn(),
+    });
+    expect(element.innerHTML).toContain("ISS");
+    expect(element.innerHTML).toContain("25544");
+    expect(element.innerHTML).toContain("420");
+    expect(element.innerHTML).toContain("7.66");
+  });
+
+  it("satellite card has Pin but no Trail action (trail deferred per #164)", () => {
+    const { element } = createObjectCard({
+      data: satelliteData(),
+      screenX: 100,
+      screenY: 200,
+      viewportWidth: 800,
+      viewportHeight: 600,
+      dispatch: vi.fn(),
+    });
+    const buttons = Array.from(element.querySelectorAll("button")).map((b) => b.textContent ?? "");
+    expect(buttons.some((t) => /pin/i.test(t))).toBe(true);
+    expect(buttons.some((t) => /trail/i.test(t))).toBe(false);
+  });
+});
+
+describe("createObjectCard — messier", () => {
+  it("renders messier designation, name, type and magnitude", () => {
+    const { element } = createObjectCard({
+      data: messierData(),
+      screenX: 100,
+      screenY: 200,
+      viewportWidth: 800,
+      viewportHeight: 600,
+      dispatch: vi.fn(),
+    });
+    expect(element.innerHTML).toContain("M42");
+    expect(element.innerHTML).toContain("Orion Nebula");
+    expect(element.innerHTML).toContain("nebula");
+    expect(element.innerHTML).toContain("4.0");
+  });
+});
+
+describe("createObjectCard — constellation", () => {
+  it("renders constellation name and centroid alt/az", () => {
+    const { element } = createObjectCard({
+      data: constellationData(),
+      screenX: 100,
+      screenY: 200,
+      viewportWidth: 800,
+      viewportHeight: 600,
+      dispatch: vi.fn(),
+    });
+    expect(element.innerHTML).toContain("Orion");
+    // Centroid alt (15) and az (105) rendered
+    expect(element.innerHTML).toContain("15");
+    expect(element.innerHTML).toContain("105");
+  });
+});
+
+describe("createObjectCard — close button", () => {
+  it("has a close button that invokes the onClose callback", () => {
+    const onClose = vi.fn();
+    const { element } = createObjectCard({
+      data: starData(),
+      screenX: 100,
+      screenY: 200,
+      viewportWidth: 800,
+      viewportHeight: 600,
+      dispatch: vi.fn(),
+      onClose,
+    });
+    const closeBtn = element.querySelector<HTMLButtonElement>("[data-testid='object-card-close']");
+    expect(closeBtn).not.toBeNull();
+    closeBtn!.click();
+    expect(onClose).toHaveBeenCalled();
+  });
+});
+
+describe("createObjectCard — Go to peak", () => {
+  it("renders Go to peak only when upcomingEvent is provided on a body card", () => {
+    const withoutEvent = createObjectCard({
+      data: bodyData(),
+      screenX: 100,
+      screenY: 200,
+      viewportWidth: 800,
+      viewportHeight: 600,
+      dispatch: vi.fn(),
+    });
+    expect(withoutEvent.element.querySelector("[data-testid='object-card-go-to-peak']")).toBeNull();
+
+    const withEvent = createObjectCard({
+      data: bodyData(),
+      screenX: 100,
+      screenY: 200,
+      viewportWidth: 800,
+      viewportHeight: 600,
+      dispatch: vi.fn(),
+      upcomingEvent: {
+        when: new Date("2026-05-01T00:00:00Z"),
+        viewAz: 180,
+        viewAlt: 30,
+      },
+    });
+    expect(
+      withEvent.element.querySelector("[data-testid='object-card-go-to-peak']"),
+    ).not.toBeNull();
+  });
+
+  it("Go to peak action dispatches set-time and set-view to the event's instant", () => {
+    const dispatch = vi.fn<(i: UIIntent) => void>();
+    const when = new Date("2026-05-01T00:00:00Z");
+    const { element } = createObjectCard({
+      data: bodyData(),
+      screenX: 100,
+      screenY: 200,
+      viewportWidth: 800,
+      viewportHeight: 600,
+      dispatch,
+      upcomingEvent: { when, viewAz: 180, viewAlt: 30 },
+    });
+    const btn = element.querySelector<HTMLButtonElement>("[data-testid='object-card-go-to-peak']");
+    btn!.click();
+    expect(dispatch).toHaveBeenCalledWith({ type: "set-time", time: when });
+    expect(dispatch).toHaveBeenCalledWith({ type: "set-view", az: 180, alt: 30 });
+  });
+});
+
+describe("createObjectCard — copy-link", () => {
+  it("Copy link dispatches copy-link intent with framing view", () => {
+    const dispatch = vi.fn<(i: UIIntent) => void>();
+    const { element } = createObjectCard({
+      data: starData(),
+      screenX: 100,
+      screenY: 200,
+      viewportWidth: 800,
+      viewportHeight: 600,
+      dispatch,
+    });
+    const copyBtn = Array.from(element.querySelectorAll("button")).find((b) =>
+      /copy link/i.test(b.textContent ?? ""),
+    );
+    expect(copyBtn).toBeDefined();
+    copyBtn!.click();
+    // Copy link frames the object (set-view) then copies. Either side of the
+    // bundle is fine so long as copy-link actually fires.
+    expect(dispatch).toHaveBeenCalled();
+    const types = dispatch.mock.calls.map((c) => c[0].type);
+    expect(types).toContain("copy-link");
+  });
+});
+
+describe("createObjectCard — smart positioning", () => {
+  it("places the card to the right of the click when room is available", () => {
+    const { element } = createObjectCard({
+      data: starData(),
+      screenX: 100,
+      screenY: 100,
+      viewportWidth: 800,
+      viewportHeight: 600,
+      dispatch: vi.fn(),
+    });
+    // Card is absolutely positioned
+    const leftPx = parseInt(element.style.left, 10);
+    expect(leftPx).toBeGreaterThan(100);
+  });
+
+  it("flips to the left when the click is near the right edge", () => {
+    const { element } = createObjectCard({
+      data: starData(),
+      screenX: 780,
+      screenY: 100,
+      viewportWidth: 800,
+      viewportHeight: 600,
+      dispatch: vi.fn(),
+    });
+    const leftPx = parseInt(element.style.left, 10);
+    // Left edge of the card should be to the left of the click when flipped
+    expect(leftPx).toBeLessThan(780);
+  });
+});
+
+describe("createObjectCard — update / destroy", () => {
+  it("update repositions the card on new screen coordinates", () => {
+    const card = createObjectCard({
+      data: starData(),
+      screenX: 100,
+      screenY: 100,
+      viewportWidth: 800,
+      viewportHeight: 600,
+      dispatch: vi.fn(),
+    });
+    const before = card.element.style.left;
+    card.update({ screenX: 500, screenY: 300, belowHorizon: false });
+    const after = card.element.style.left;
+    expect(after).not.toBe(before);
+  });
+
+  it("update shows a below-horizon indicator", () => {
+    const card = createObjectCard({
+      data: starData(),
+      screenX: 100,
+      screenY: 100,
+      viewportWidth: 800,
+      viewportHeight: 600,
+      dispatch: vi.fn(),
+    });
+    expect(
+      card.element.querySelector<HTMLElement>("[data-testid='object-card-below-horizon']"),
+    ).toBeNull();
+    card.update({ screenX: 500, screenY: 300, belowHorizon: true });
+    expect(
+      card.element.querySelector<HTMLElement>("[data-testid='object-card-below-horizon']"),
+    ).not.toBeNull();
+  });
+
+  it("setActive applies dimmed style when false and normal style when true", () => {
+    const card = createObjectCard({
+      data: starData(),
+      screenX: 100,
+      screenY: 100,
+      viewportWidth: 800,
+      viewportHeight: 600,
+      dispatch: vi.fn(),
+    });
+    card.setActive(false);
+    expect(parseFloat(card.element.style.opacity)).toBeLessThan(1);
+    card.setActive(true);
+    expect(parseFloat(card.element.style.opacity)).toBeCloseTo(1, 2);
+  });
+
+  it("destroy removes the element from its parent", () => {
+    const card = createObjectCard({
+      data: starData(),
+      screenX: 100,
+      screenY: 100,
+      viewportWidth: 800,
+      viewportHeight: 600,
+      dispatch: vi.fn(),
+    });
+    const container = document.createElement("div");
+    container.appendChild(card.element);
+    expect(container.children.length).toBe(1);
+    card.destroy();
+    expect(container.children.length).toBe(0);
+  });
+});

--- a/src/ui/object-card.ts
+++ b/src/ui/object-card.ts
@@ -1,0 +1,405 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import type { AltAzStar, CelestialBody, VisibleMessier, VisibleConstellation } from "../astro";
+import type { VisibleSatellite } from "../sat";
+import type { UIIntent } from "./index";
+import { computeRiseSet } from "../astro/rise-set";
+
+export type ObjectCardData =
+  | { readonly kind: "star"; readonly star: AltAzStar }
+  | {
+      readonly kind: "body";
+      readonly body: CelestialBody;
+      readonly observer?: { readonly lat: number; readonly lon: number };
+      readonly time?: Date;
+    }
+  | { readonly kind: "satellite"; readonly satellite: VisibleSatellite }
+  | { readonly kind: "messier"; readonly messier: VisibleMessier }
+  | { readonly kind: "constellation"; readonly constellation: VisibleConstellation };
+
+/** Upcoming event usable by the "Go to peak" action. Passed in from the caller so
+ *  the card doesn't have to know how to query the events subsystem. */
+export type UpcomingEvent = {
+  readonly when: Date;
+  readonly viewAz: number;
+  readonly viewAlt: number;
+};
+
+export type ObjectCardProps = {
+  readonly data: ObjectCardData;
+  readonly screenX: number;
+  readonly screenY: number;
+  readonly viewportWidth: number;
+  readonly viewportHeight: number;
+  readonly dispatch: (intent: UIIntent) => void;
+  readonly onClose?: () => void;
+  /** Optional — when provided, the card shows a "Go to peak" action that jumps
+   *  time + view to the event instant. */
+  readonly upcomingEvent?: UpcomingEvent;
+};
+
+export type ObjectCardUpdate = {
+  readonly screenX: number;
+  readonly screenY: number;
+  readonly belowHorizon: boolean;
+};
+
+export type ObjectCard = {
+  readonly element: HTMLElement;
+  update(u: ObjectCardUpdate): void;
+  setActive(active: boolean): void;
+  destroy(): void;
+};
+
+const CARD_WIDTH_PX = 240;
+const CARD_OFFSET_PX = 16;
+const ESTIMATED_HEIGHT_PX = 150;
+
+const CARD_STYLE =
+  "position:absolute;width:240px;background:rgba(10,20,40,0.96);color:#fff;" +
+  "font:12px/1.45 sans-serif;padding:10px 12px 10px 12px;border-radius:6px;" +
+  "border:1px solid rgba(100,160,255,0.8);z-index:1200;pointer-events:auto;" +
+  "box-shadow:0 4px 16px rgba(0,0,0,0.5);transition:opacity 150ms ease;" +
+  "box-sizing:border-box";
+
+const CLOSE_BTN_STYLE =
+  "background:none;border:none;color:rgba(255,255,255,0.7);cursor:pointer;" +
+  "font:16px/1 sans-serif;padding:0;margin:0 0 0 8px;line-height:1";
+
+const ACTION_BTN_STYLE =
+  "background:rgba(255,255,255,0.08);border:1px solid rgba(255,255,255,0.2);" +
+  "border-radius:3px;color:#fff;cursor:pointer;font:11px/1.3 sans-serif;" +
+  "padding:3px 8px;margin:0";
+
+function formatRa(raDeg: number): string {
+  const hours = raDeg / 15;
+  const h = Math.floor(hours);
+  const m = Math.round((hours - h) * 60);
+  return `${String(h)}h ${String(m)}m`;
+}
+
+function formatDec(dec: number): string {
+  const sign = dec >= 0 ? "+" : "-";
+  const abs = Math.abs(dec);
+  const d = Math.floor(abs);
+  const m = Math.round((abs - d) * 60);
+  return `${sign}${String(d)}\u00B0 ${String(m)}\u2032`;
+}
+
+function formatHHMM(d: Date | null): string {
+  if (d === null) return "--";
+  const h = String(d.getHours()).padStart(2, "0");
+  const m = String(d.getMinutes()).padStart(2, "0");
+  return `${h}:${m}`;
+}
+
+/** Compute card left/top so the card stays fully on-screen. Prefers right-of-click,
+ *  flips left if it would overflow; same for top-vs-bottom. */
+function smartPosition(
+  screenX: number,
+  screenY: number,
+  viewportWidth: number,
+  viewportHeight: number,
+): { left: number; top: number } {
+  let left = screenX + CARD_OFFSET_PX;
+  if (left + CARD_WIDTH_PX > viewportWidth) {
+    left = screenX - CARD_OFFSET_PX - CARD_WIDTH_PX;
+  }
+  if (left < 4) left = 4;
+
+  let top = screenY + CARD_OFFSET_PX;
+  if (top + ESTIMATED_HEIGHT_PX > viewportHeight) {
+    top = screenY - CARD_OFFSET_PX - ESTIMATED_HEIGHT_PX;
+  }
+  if (top < 4) top = 4;
+
+  return { left, top };
+}
+
+function cardTitleForData(data: ObjectCardData): { title: string; subtitle: string } {
+  switch (data.kind) {
+    case "star": {
+      const name = data.star.name ?? `HIP ${String(data.star.hip)}`;
+      return { title: name, subtitle: "Star" };
+    }
+    case "body":
+      return { title: data.body.id, subtitle: "Solar system body" };
+    case "satellite":
+      return {
+        title: data.satellite.name,
+        subtitle: `Satellite · NORAD ${String(data.satellite.noradId)}`,
+      };
+    case "messier": {
+      const mLabel =
+        data.messier.name.length > 0
+          ? `M${String(data.messier.m)} \u2014 ${data.messier.name}`
+          : `M${String(data.messier.m)}`;
+      return { title: mLabel, subtitle: `Deep-sky (${data.messier.type})` };
+    }
+    case "constellation":
+      return { title: data.constellation.name, subtitle: "Constellation" };
+  }
+}
+
+function objectIdForData(data: ObjectCardData): string {
+  switch (data.kind) {
+    case "star":
+      return data.star.name ?? `HIP ${String(data.star.hip)}`;
+    case "body":
+      return data.body.id;
+    case "satellite":
+      return data.satellite.name;
+    case "messier":
+      return `M${String(data.messier.m)}`;
+    case "constellation":
+      return data.constellation.id;
+  }
+}
+
+function appendAttrRow(container: HTMLElement, label: string, value: string): void {
+  const row = document.createElement("div");
+  row.style.display = "flex";
+  row.style.justifyContent = "space-between";
+  row.style.color = "rgba(255,255,255,0.85)";
+  row.style.marginTop = "2px";
+  const l = document.createElement("span");
+  l.textContent = label;
+  l.style.color = "rgba(255,255,255,0.55)";
+  const v = document.createElement("span");
+  v.textContent = value;
+  row.appendChild(l);
+  row.appendChild(v);
+  container.appendChild(row);
+}
+
+function buildAttributes(data: ObjectCardData): HTMLElement {
+  const wrap = document.createElement("div");
+  wrap.dataset.testid = "object-card-attrs";
+  wrap.style.marginTop = "6px";
+  wrap.style.fontFamily = "monospace";
+  wrap.style.fontSize = "11px";
+
+  switch (data.kind) {
+    case "star": {
+      const s = data.star;
+      appendAttrRow(wrap, "Alt / Az", `${s.alt.toFixed(1)}\u00B0 / ${s.az.toFixed(1)}\u00B0`);
+      appendAttrRow(wrap, "RA / Dec", `${formatRa(s.ra)} ${formatDec(s.dec)}`);
+      appendAttrRow(wrap, "Magnitude", s.mag.toFixed(2));
+      break;
+    }
+    case "body": {
+      const b = data.body;
+      appendAttrRow(wrap, "Alt / Az", `${b.alt.toFixed(1)}\u00B0 / ${b.az.toFixed(1)}\u00B0`);
+      appendAttrRow(wrap, "RA / Dec", `${formatRa(b.ra)} ${formatDec(b.dec)}`);
+      appendAttrRow(wrap, "Magnitude", b.mag.toFixed(2));
+      if (b.illumination !== undefined) {
+        appendAttrRow(wrap, "Illuminated", `${Math.round(b.illumination * 100)}%`);
+      }
+      if (data.observer && data.time) {
+        const rs = computeRiseSet(b.id, data.observer.lat, data.observer.lon, data.time);
+        appendAttrRow(wrap, "Rise / Set", `${formatHHMM(rs.rise)} / ${formatHHMM(rs.set)}`);
+      }
+      break;
+    }
+    case "satellite": {
+      const sat = data.satellite;
+      appendAttrRow(wrap, "Alt / Az", `${sat.alt.toFixed(1)}\u00B0 / ${sat.az.toFixed(1)}\u00B0`);
+      appendAttrRow(wrap, "Height", `${String(Math.round(sat.height))} km`);
+      appendAttrRow(wrap, "Velocity", `${sat.velocity.toFixed(2)} km/s`);
+      appendAttrRow(wrap, "NORAD ID", String(sat.noradId));
+      break;
+    }
+    case "messier": {
+      const m = data.messier;
+      appendAttrRow(wrap, "Alt / Az", `${m.alt.toFixed(1)}\u00B0 / ${m.az.toFixed(1)}\u00B0`);
+      appendAttrRow(wrap, "RA / Dec", `${formatRa(m.ra)} ${formatDec(m.dec)}`);
+      appendAttrRow(wrap, "Magnitude", m.mag.toFixed(1));
+      break;
+    }
+    case "constellation": {
+      const c = data.constellation;
+      appendAttrRow(
+        wrap,
+        "Centroid Alt / Az",
+        `${c.centroid.alt.toFixed(1)}\u00B0 / ${c.centroid.az.toFixed(1)}\u00B0`,
+      );
+      appendAttrRow(wrap, "Visible lines", String(c.lines.length));
+      break;
+    }
+  }
+
+  return wrap;
+}
+
+function buildActions(
+  data: ObjectCardData,
+  dispatch: (i: UIIntent) => void,
+  upcomingEvent: UpcomingEvent | undefined,
+): HTMLElement {
+  const row = document.createElement("div");
+  row.dataset.testid = "object-card-actions";
+  row.style.display = "flex";
+  row.style.flexWrap = "wrap";
+  row.style.gap = "4px";
+  row.style.marginTop = "8px";
+
+  const id = objectIdForData(data);
+
+  const pinBtn = document.createElement("button");
+  pinBtn.dataset.testid = "object-card-pin";
+  pinBtn.textContent = "Pin";
+  pinBtn.style.cssText = ACTION_BTN_STYLE;
+  pinBtn.addEventListener("click", () => {
+    dispatch({ type: "pin-object", id });
+  });
+  row.appendChild(pinBtn);
+
+  if (data.kind === "body") {
+    const trailBtn = document.createElement("button");
+    trailBtn.dataset.testid = "object-card-trail";
+    trailBtn.textContent = "Trail";
+    trailBtn.style.cssText = ACTION_BTN_STYLE;
+    trailBtn.addEventListener("click", () => {
+      dispatch({ type: "show-trail", objectKind: "body", id: data.body.id });
+    });
+    row.appendChild(trailBtn);
+  }
+
+  if (upcomingEvent !== undefined && (data.kind === "body" || data.kind === "satellite")) {
+    const peakBtn = document.createElement("button");
+    peakBtn.dataset.testid = "object-card-go-to-peak";
+    peakBtn.textContent = "Go to peak";
+    peakBtn.style.cssText = ACTION_BTN_STYLE;
+    peakBtn.addEventListener("click", () => {
+      dispatch({ type: "set-time", time: upcomingEvent.when });
+      dispatch({ type: "set-view", az: upcomingEvent.viewAz, alt: upcomingEvent.viewAlt });
+    });
+    row.appendChild(peakBtn);
+  }
+
+  const copyBtn = document.createElement("button");
+  copyBtn.dataset.testid = "object-card-copy-link";
+  copyBtn.textContent = "Copy link";
+  copyBtn.style.cssText = ACTION_BTN_STYLE;
+  copyBtn.addEventListener("click", () => {
+    // The app frames the object in URL state via vaz/valt on set-view, then copy-link
+    // serializes current state. Dispatch set-view first when we have a position, then copy.
+    const pos = dataPosition(data);
+    if (pos) {
+      dispatch({ type: "set-view", az: pos.az, alt: pos.alt });
+    }
+    dispatch({ type: "copy-link" });
+  });
+  row.appendChild(copyBtn);
+
+  return row;
+}
+
+function dataPosition(data: ObjectCardData): { alt: number; az: number } | null {
+  switch (data.kind) {
+    case "star":
+      return { alt: data.star.alt, az: data.star.az };
+    case "body":
+      return { alt: data.body.alt, az: data.body.az };
+    case "satellite":
+      return { alt: data.satellite.alt, az: data.satellite.az };
+    case "messier":
+      return { alt: data.messier.alt, az: data.messier.az };
+    case "constellation":
+      return { alt: data.constellation.centroid.alt, az: data.constellation.centroid.az };
+  }
+}
+
+export function createObjectCard(props: ObjectCardProps): ObjectCard {
+  const root = document.createElement("div");
+  root.dataset.testid = "object-card";
+  root.style.cssText = CARD_STYLE;
+
+  const applyPosition = (x: number, y: number): void => {
+    const pos = smartPosition(x, y, props.viewportWidth, props.viewportHeight);
+    root.style.left = `${String(pos.left)}px`;
+    root.style.top = `${String(pos.top)}px`;
+  };
+  applyPosition(props.screenX, props.screenY);
+
+  // Header: title + close button
+  const header = document.createElement("div");
+  header.style.display = "flex";
+  header.style.justifyContent = "space-between";
+  header.style.alignItems = "flex-start";
+
+  const { title, subtitle } = cardTitleForData(props.data);
+  const headerText = document.createElement("div");
+  headerText.style.flex = "1 1 auto";
+  headerText.style.minWidth = "0";
+  const titleEl = document.createElement("div");
+  titleEl.dataset.testid = "object-card-title";
+  titleEl.textContent = title;
+  titleEl.style.fontWeight = "bold";
+  titleEl.style.fontSize = "13px";
+  titleEl.style.overflow = "hidden";
+  titleEl.style.textOverflow = "ellipsis";
+  titleEl.style.whiteSpace = "nowrap";
+  headerText.appendChild(titleEl);
+
+  const subtitleEl = document.createElement("div");
+  subtitleEl.dataset.testid = "object-card-subtitle";
+  subtitleEl.textContent = subtitle;
+  subtitleEl.style.fontSize = "10px";
+  subtitleEl.style.color = "rgba(255,255,255,0.55)";
+  subtitleEl.style.marginTop = "1px";
+  headerText.appendChild(subtitleEl);
+
+  header.appendChild(headerText);
+
+  const closeBtn = document.createElement("button");
+  closeBtn.dataset.testid = "object-card-close";
+  closeBtn.type = "button";
+  closeBtn.textContent = "\u00D7";
+  closeBtn.title = "Close";
+  closeBtn.style.cssText = CLOSE_BTN_STYLE;
+  if (props.onClose) {
+    const fn = props.onClose;
+    closeBtn.addEventListener("click", () => {
+      fn();
+    });
+  }
+  header.appendChild(closeBtn);
+
+  root.appendChild(header);
+
+  const attrs = buildAttributes(props.data);
+  root.appendChild(attrs);
+
+  const actions = buildActions(props.data, props.dispatch, props.upcomingEvent);
+  root.appendChild(actions);
+
+  let belowEl: HTMLElement | null = null;
+
+  return {
+    element: root,
+    update(u: ObjectCardUpdate): void {
+      applyPosition(u.screenX, u.screenY);
+      if (u.belowHorizon) {
+        if (belowEl === null) {
+          const el = document.createElement("div");
+          el.dataset.testid = "object-card-below-horizon";
+          el.textContent = "\u2193 Below horizon";
+          el.style.marginTop = "4px";
+          el.style.color = "rgba(255,180,100,0.9)";
+          el.style.fontSize = "10px";
+          root.appendChild(el);
+          belowEl = el;
+        }
+      } else if (belowEl !== null) {
+        belowEl.remove();
+        belowEl = null;
+      }
+    },
+    setActive(active: boolean): void {
+      root.style.opacity = active ? "1" : "0.65";
+    },
+    destroy(): void {
+      root.remove();
+    },
+  };
+}

--- a/src/ui/object-cards-manager.test.ts
+++ b/src/ui/object-cards-manager.test.ts
@@ -1,0 +1,230 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createObjectCardsManager } from "./object-cards-manager";
+import type { ObjectCardData } from "./object-card";
+
+function starData(name = "Sirius", alt = 45, az = 180): ObjectCardData {
+  return {
+    kind: "star",
+    star: {
+      hip: 32349,
+      ra: 101.2872,
+      dec: -16.7161,
+      alt,
+      az,
+      mag: -1.44,
+      name,
+      size: 16,
+      opacity: 1,
+    },
+  };
+}
+
+function bodyData(id = "Mars", alt = 30, az = 100): ObjectCardData {
+  return {
+    kind: "body",
+    body: {
+      id,
+      alt,
+      az,
+      ra: 50,
+      dec: 20,
+      mag: 1,
+      size: 10,
+      color: "#CC4422",
+    },
+  };
+}
+
+describe("createObjectCardsManager", () => {
+  let container: HTMLElement;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container);
+  });
+
+  it("open creates a card element inside the container", () => {
+    const mgr = createObjectCardsManager({
+      container,
+      dispatch: vi.fn(),
+      projector: () => ({ x: 100, y: 100, onScreen: true }),
+      resolver: () => ({ alt: 45, az: 180, belowHorizon: false }),
+      getViewport: () => ({ width: 800, height: 600 }),
+    });
+    mgr.open({ data: starData("Sirius"), screenX: 200, screenY: 200 });
+    expect(container.querySelectorAll("[data-testid='object-card']").length).toBe(1);
+  });
+
+  it("opening twice with the same id/kind moves the existing card instead of duplicating", () => {
+    const mgr = createObjectCardsManager({
+      container,
+      dispatch: vi.fn(),
+      projector: () => ({ x: 100, y: 100, onScreen: true }),
+      resolver: () => ({ alt: 45, az: 180, belowHorizon: false }),
+      getViewport: () => ({ width: 800, height: 600 }),
+    });
+    mgr.open({ data: starData("Sirius"), screenX: 100, screenY: 100 });
+    mgr.open({ data: starData("Sirius"), screenX: 300, screenY: 300 });
+    expect(container.querySelectorAll("[data-testid='object-card']").length).toBe(1);
+  });
+
+  it("open adds multiple cards when ids differ", () => {
+    const mgr = createObjectCardsManager({
+      container,
+      dispatch: vi.fn(),
+      projector: () => ({ x: 100, y: 100, onScreen: true }),
+      resolver: () => ({ alt: 45, az: 180, belowHorizon: false }),
+      getViewport: () => ({ width: 800, height: 600 }),
+    });
+    mgr.open({ data: starData("Sirius"), screenX: 100, screenY: 100 });
+    mgr.open({ data: starData("Vega"), screenX: 200, screenY: 200 });
+    mgr.open({ data: bodyData("Mars"), screenX: 300, screenY: 300 });
+    expect(container.querySelectorAll("[data-testid='object-card']").length).toBe(3);
+  });
+
+  it("closeActive removes the most recent card", () => {
+    const mgr = createObjectCardsManager({
+      container,
+      dispatch: vi.fn(),
+      projector: () => ({ x: 100, y: 100, onScreen: true }),
+      resolver: () => ({ alt: 45, az: 180, belowHorizon: false }),
+      getViewport: () => ({ width: 800, height: 600 }),
+    });
+    mgr.open({ data: starData("Sirius"), screenX: 100, screenY: 100 });
+    mgr.open({ data: starData("Vega"), screenX: 200, screenY: 200 });
+    expect(container.querySelectorAll("[data-testid='object-card']").length).toBe(2);
+    mgr.closeActive();
+    expect(container.querySelectorAll("[data-testid='object-card']").length).toBe(1);
+  });
+
+  it("close-by-id removes the specified card", () => {
+    const mgr = createObjectCardsManager({
+      container,
+      dispatch: vi.fn(),
+      projector: () => ({ x: 100, y: 100, onScreen: true }),
+      resolver: () => ({ alt: 45, az: 180, belowHorizon: false }),
+      getViewport: () => ({ width: 800, height: 600 }),
+    });
+    mgr.open({ data: starData("Sirius"), screenX: 100, screenY: 100 });
+    mgr.open({ data: starData("Vega"), screenX: 200, screenY: 200 });
+    mgr.close({ objectKind: "star", id: "Sirius" });
+    const remaining = Array.from(
+      container.querySelectorAll<HTMLElement>("[data-testid='object-card-title']"),
+    ).map((el) => el.textContent);
+    expect(remaining).toContain("Vega");
+    expect(remaining).not.toContain("Sirius");
+  });
+
+  it("escape key closes the active card", () => {
+    const mgr = createObjectCardsManager({
+      container,
+      dispatch: vi.fn(),
+      projector: () => ({ x: 100, y: 100, onScreen: true }),
+      resolver: () => ({ alt: 45, az: 180, belowHorizon: false }),
+      getViewport: () => ({ width: 800, height: 600 }),
+    });
+    mgr.open({ data: starData("Sirius"), screenX: 100, screenY: 100 });
+    mgr.open({ data: starData("Vega"), screenX: 200, screenY: 200 });
+    const event = new KeyboardEvent("keydown", { key: "Escape" });
+    document.dispatchEvent(event);
+    expect(container.querySelectorAll("[data-testid='object-card']").length).toBe(1);
+    mgr.destroy();
+  });
+
+  it("most recently interacted card is marked active; previous cards are dimmed", () => {
+    const mgr = createObjectCardsManager({
+      container,
+      dispatch: vi.fn(),
+      projector: () => ({ x: 100, y: 100, onScreen: true }),
+      resolver: () => ({ alt: 45, az: 180, belowHorizon: false }),
+      getViewport: () => ({ width: 800, height: 600 }),
+    });
+    mgr.open({ data: starData("Sirius"), screenX: 100, screenY: 100 });
+    mgr.open({ data: starData("Vega"), screenX: 200, screenY: 200 });
+    const cards = container.querySelectorAll<HTMLElement>("[data-testid='object-card']");
+    // Sirius (first) should be dimmed; Vega (second, active) should be bright
+    const opacitiesByTitle = new Map<string, number>();
+    for (const c of cards) {
+      const title = c.querySelector<HTMLElement>("[data-testid='object-card-title']");
+      opacitiesByTitle.set(title?.textContent ?? "", parseFloat(c.style.opacity));
+    }
+    expect(opacitiesByTitle.get("Sirius")).toBeLessThan(1);
+    expect(opacitiesByTitle.get("Vega") ?? 0).toBeCloseTo(1, 2);
+  });
+
+  it("update() reprojects positions using the resolver and projector", () => {
+    let projCall = 0;
+    const mgr = createObjectCardsManager({
+      container,
+      dispatch: vi.fn(),
+      projector: () => {
+        projCall++;
+        return { x: 400 + projCall, y: 400, onScreen: true };
+      },
+      resolver: () => ({ alt: 45, az: 180, belowHorizon: false }),
+      getViewport: () => ({ width: 800, height: 600 }),
+    });
+    mgr.open({ data: starData("Sirius"), screenX: 100, screenY: 100 });
+    const first = container.querySelector<HTMLElement>("[data-testid='object-card']")!;
+    const leftBefore = first.style.left;
+    mgr.update();
+    const leftAfter = first.style.left;
+    expect(leftAfter).not.toBe(leftBefore);
+  });
+
+  it("update() marks a card below horizon when the resolver reports so", () => {
+    const mgr = createObjectCardsManager({
+      container,
+      dispatch: vi.fn(),
+      projector: () => ({ x: 200, y: 200, onScreen: true }),
+      resolver: () => ({ alt: -5, az: 180, belowHorizon: true }),
+      getViewport: () => ({ width: 800, height: 600 }),
+    });
+    mgr.open({ data: starData("Sirius"), screenX: 100, screenY: 100 });
+    mgr.update();
+    expect(
+      container.querySelector<HTMLElement>("[data-testid='object-card-below-horizon']"),
+    ).not.toBeNull();
+  });
+
+  it("update() removes a card when the resolver reports the object has gone away", () => {
+    // Simulate the case where the pinned object is no longer in the scene
+    // (e.g. a satellite that left the visible set). The card should stay open
+    // showing a below-horizon / unavailable state rather than throwing.
+    const mgr = createObjectCardsManager({
+      container,
+      dispatch: vi.fn(),
+      projector: () => ({ x: 200, y: 200, onScreen: true }),
+      resolver: () => null,
+      getViewport: () => ({ width: 800, height: 600 }),
+    });
+    mgr.open({ data: starData("Sirius"), screenX: 100, screenY: 100 });
+    expect(() => {
+      mgr.update();
+    }).not.toThrow();
+    expect(
+      container.querySelector<HTMLElement>("[data-testid='object-card-below-horizon']"),
+    ).not.toBeNull();
+  });
+
+  it("destroy removes all cards and unbinds listeners", () => {
+    const mgr = createObjectCardsManager({
+      container,
+      dispatch: vi.fn(),
+      projector: () => ({ x: 100, y: 100, onScreen: true }),
+      resolver: () => ({ alt: 45, az: 180, belowHorizon: false }),
+      getViewport: () => ({ width: 800, height: 600 }),
+    });
+    mgr.open({ data: starData("Sirius"), screenX: 100, screenY: 100 });
+    mgr.destroy();
+    expect(container.querySelectorAll("[data-testid='object-card']").length).toBe(0);
+    // After destroy, Escape should NOT close anything (no active card exists)
+    const event = new KeyboardEvent("keydown", { key: "Escape" });
+    expect(() => document.dispatchEvent(event)).not.toThrow();
+  });
+});

--- a/src/ui/object-cards-manager.ts
+++ b/src/ui/object-cards-manager.ts
@@ -1,0 +1,178 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { createObjectCard } from "./object-card";
+import type { ObjectCard, ObjectCardData, UpcomingEvent } from "./object-card";
+import type { UIIntent } from "./index";
+
+export type ObjectCardKind = ObjectCardData["kind"];
+
+/** Stable identifier per card: kind + id within kind. */
+export type CardKey = { readonly objectKind: ObjectCardKind; readonly id: string };
+
+export type ScreenPosition = {
+  readonly x: number;
+  readonly y: number;
+  /** False if the object projects off the viewport (or behind the camera). */
+  readonly onScreen: boolean;
+};
+
+export type ObjectPosition = {
+  readonly alt: number;
+  readonly az: number;
+  readonly belowHorizon: boolean;
+};
+
+export type CardsManagerOptions = {
+  /** DOM node that owns the cards (typically the Cesium container). */
+  readonly container: HTMLElement;
+  readonly dispatch: (intent: UIIntent) => void;
+  /** Project an alt/az pair to viewport coordinates. Returns `null` if projection fails. */
+  readonly projector: (alt: number, az: number) => ScreenPosition | null;
+  /** Resolve the latest alt/az for a given object. Returns `null` if the object is no
+   *  longer present (e.g. a satellite that left the visible set). */
+  readonly resolver: (key: CardKey) => ObjectPosition | null;
+  readonly getViewport: () => { readonly width: number; readonly height: number };
+  /** Optional — lookup an upcoming event for this object, if one is in the feed. */
+  readonly findUpcomingEvent?: (key: CardKey) => UpcomingEvent | undefined;
+};
+
+export type OpenCardRequest = {
+  readonly data: ObjectCardData;
+  readonly screenX: number;
+  readonly screenY: number;
+};
+
+export type ObjectCardsManager = {
+  open(req: OpenCardRequest): void;
+  close(key: CardKey): void;
+  closeActive(): void;
+  update(): void;
+  destroy(): void;
+};
+
+function keyForData(data: ObjectCardData): CardKey {
+  switch (data.kind) {
+    case "star":
+      return { objectKind: "star", id: data.star.name ?? `HIP ${String(data.star.hip)}` };
+    case "body":
+      return { objectKind: "body", id: data.body.id };
+    case "satellite":
+      return { objectKind: "satellite", id: data.satellite.name };
+    case "messier":
+      return { objectKind: "messier", id: `M${String(data.messier.m)}` };
+    case "constellation":
+      return { objectKind: "constellation", id: data.constellation.id };
+  }
+}
+
+function keyEquals(a: CardKey, b: CardKey): boolean {
+  return a.objectKind === b.objectKind && a.id === b.id;
+}
+
+type Entry = {
+  readonly key: CardKey;
+  readonly card: ObjectCard;
+};
+
+export function createObjectCardsManager(opts: CardsManagerOptions): ObjectCardsManager {
+  // Ordered by recency: entries[entries.length - 1] is the most recent (active).
+  const entries: Entry[] = [];
+
+  function setActiveState(): void {
+    for (let i = 0; i < entries.length; i++) {
+      const entry = entries[i];
+      if (entry === undefined) continue;
+      entry.card.setActive(i === entries.length - 1);
+    }
+  }
+
+  function removeAt(index: number): void {
+    const entry = entries[index];
+    if (entry === undefined) return;
+    entry.card.destroy();
+    entries.splice(index, 1);
+    setActiveState();
+  }
+
+  function findIndex(key: CardKey): number {
+    return entries.findIndex((e) => keyEquals(e.key, key));
+  }
+
+  function open(req: OpenCardRequest): void {
+    const key = keyForData(req.data);
+    const existingIdx = findIndex(key);
+    if (existingIdx !== -1) {
+      // Move existing card to the end (most recent) and reposition it.
+      const existing = entries[existingIdx]!;
+      entries.splice(existingIdx, 1);
+      existing.card.update({
+        screenX: req.screenX,
+        screenY: req.screenY,
+        belowHorizon: false,
+      });
+      entries.push(existing);
+      setActiveState();
+      return;
+    }
+    const viewport = opts.getViewport();
+    const upcomingEvent = opts.findUpcomingEvent?.(key);
+    const card = createObjectCard({
+      data: req.data,
+      screenX: req.screenX,
+      screenY: req.screenY,
+      viewportWidth: viewport.width,
+      viewportHeight: viewport.height,
+      dispatch: opts.dispatch,
+      onClose: () => {
+        close(key);
+      },
+      ...(upcomingEvent !== undefined ? { upcomingEvent } : {}),
+    });
+    opts.container.appendChild(card.element);
+    entries.push({ key, card });
+    setActiveState();
+  }
+
+  function close(key: CardKey): void {
+    const idx = findIndex(key);
+    if (idx === -1) return;
+    removeAt(idx);
+  }
+
+  function closeActive(): void {
+    if (entries.length === 0) return;
+    removeAt(entries.length - 1);
+  }
+
+  function update(): void {
+    for (const entry of entries) {
+      const pos = opts.resolver(entry.key);
+      if (pos === null) {
+        // Object has left the scene — keep the card visible with a below-horizon flag.
+        entry.card.update({ screenX: -9999, screenY: -9999, belowHorizon: true });
+        continue;
+      }
+      const screen = opts.projector(pos.alt, pos.az);
+      if (screen === null || !screen.onScreen) {
+        entry.card.update({ screenX: -9999, screenY: -9999, belowHorizon: pos.belowHorizon });
+        continue;
+      }
+      entry.card.update({ screenX: screen.x, screenY: screen.y, belowHorizon: pos.belowHorizon });
+    }
+  }
+
+  function onKeyDown(e: KeyboardEvent): void {
+    if (e.key !== "Escape") return;
+    if (entries.length === 0) return;
+    closeActive();
+  }
+
+  document.addEventListener("keydown", onKeyDown);
+
+  function destroy(): void {
+    for (const entry of entries) entry.card.destroy();
+    entries.length = 0;
+    document.removeEventListener("keydown", onKeyDown);
+  }
+
+  return { open, close, closeActive, update, destroy };
+}


### PR DESCRIPTION
## Summary

Milestone 1C of Plan 07 (Sky-First HUD). Replaces the scene's single pinned-tooltip pattern with rich floating cards that can coexist (one per pinned object) and follow their objects as time advances.

- **`src/scene/tooltip.ts`** — pinned-DOM / dismissal logic removed. Hover tooltip preserved; left-click now invokes a `options.onObjectClicked(picked, x, y)` callback with a typed `PickedObject` discriminated union (`star | body | satellite | messier | constellation`).
- **`src/ui/object-card.ts`** (new) — card builder. Pin, Trail (bodies only per #164), "Go to peak" when an upcoming event is supplied, and Copy link (which first dispatches `set-view` to frame the object, then `copy-link`). Smart positioning flips horizontally + vertically when the click is near a viewport edge. Below-horizon indicator added on update.
- **`src/ui/object-cards-manager.ts`** (new) — manages the set of open cards. Most-recent is active (full opacity); earlier cards dim slightly. Esc closes the active card. Repositions all cards on each rerender using a caller-supplied alt/az resolver + scene projector. Handles "object left the scene" gracefully (keeps the card with below-horizon indicator).
- **`src/scene/project.ts`** (new) — scene-only `projectAltAzToScreen` wrapping `SceneTransforms.worldToWindowCoordinates` so Cesium stays inside `scene/`.
- **`src/scene/constellations.ts`** — add `id: constellation` to the centroid label so clicks on a constellation label resolve to a structured `VisibleConstellation`.
- **`src/ui/index.ts`** — export the new types and extend `UIIntent` with the new intent shape (see below).
- **`src/app.ts`** — wire the tooltip's click callback to dispatch `open-object-card`, bootstrap the cards manager, and maintain a `LatestPositions` map updated on every rerender so the manager can follow objects as time advances. Surface upcoming conjunctions / lunar eclipses / ISS passes to cards via `findUpcomingEventForKey`.

### New intent shape

```ts
{
  type: "open-object-card";
  objectKind: "star" | "body" | "satellite" | "messier" | "constellation";
  id: string;
  screenX: number;
  screenY: number;
}
```

The scene click emits a full `ObjectCardData` into a `pendingCardData` map keyed by `objectKind|id`, then dispatches the intent. The handler pops that map and calls `cardsManager.open(...)`.

### Tooltip refactor

The single-pinned-tooltip DOM + state has been removed. The hover tooltip is unchanged. Callers now own the pinned UI surface — this PR introduces `ui/object-cards-manager` as the canonical consumer of the new `onObjectClicked` callback.

### TDD

Tests were written red-first:

- `src/ui/object-card.test.ts` — 20 tests covering rendering per kind, actions dispatching correct intents, smart positioning, close button, below-horizon indicator, setActive.
- `src/ui/object-cards-manager.test.ts` — 11 tests covering open/close, deduping by id, multi-card coexistence, Esc closes active, update repositions via projector + resolver, "object disappeared" fallback.
- `src/scene/project.test.ts` — 4 tests covering the projection helper.
- `src/scene/tooltip.test.ts` — rewritten to drop pinned-tooltip tests and add `onObjectClicked` assertions (including constellation-label click).
- `src/app.test.ts` — new intent wiring test.

### Coverage

All thresholds (ui ≥80% lines, scene ≥80% lines, app.ts ≥80% lines) met. Total tests 884 pass.

### Bundle

+~1KB gzipped (782.88 → 783.81 kB).

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm test` — 884 tests pass
- [x] `pnpm test:cov` — thresholds met
- [x] `pnpm build` — 637ms clean build
- [ ] Manual: click a star → card appears, time scrub → card moves with the star, click Pin → URL reflects object, click × → card closes, click a second star → first dims, Esc → active closes first

## Heads-up for wave-2 rebasers

`src/app.ts`, `src/ui/index.ts`, and `src/scene/tooltip.ts` are the shared hot spots with #196 / #197. This PR:
- appends a new case to the `UIIntent` union and new exports from `ui/index`,
- adds `options` parameter to `createTooltip` with `onObjectClicked` callback,
- adds a new `open-object-card` case to `handleIntent` in app.ts.

The other PRs should keep both sets of changes; conflicts should be mechanical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)