### PR TITLE
feat(ux): tonight's sky drawer replaces always-on planet-info (closes #198)

### DIFF
--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -214,6 +214,7 @@ let capturedPanelOptions: {
   onOpenEvents?: () => void;
   onOpenSettings?: () => void;
   onOpenHelp?: () => void;
+  onOpenTonight?: () => void;
 } | null = null;
 let settingsDrawerMock: {
   open: ReturnType<typeof vi.fn>;
@@ -226,6 +227,11 @@ let settingsDrawerMock: {
 const eventsDrawerSetEvents = vi.fn();
 const eventsDrawerOpen = vi.fn();
 
+// Captured tonight-drawer spies — same shape as events drawer. Tests assert
+// setBodies fires on observer/time changes and open() fires on panel click.
+const tonightDrawerSetBodies = vi.fn();
+const tonightDrawerOpen = vi.fn();
+
 // Mock UI modules — they exercise DOM which is fully covered in their own tests
 vi.mock("./ui", () => ({
   createPanel: vi.fn().mockImplementation(
@@ -236,6 +242,7 @@ vi.mock("./ui", () => ({
         onOpenEvents?: () => void;
         onOpenSettings?: () => void;
         onOpenHelp?: () => void;
+        onOpenTonight?: () => void;
       },
     ) => {
       capturedPanelOptions = options ?? null;
@@ -268,6 +275,23 @@ vi.mock("./ui", () => ({
       }),
       isOpen: vi.fn().mockImplementation(() => open),
       setEvents: eventsDrawerSetEvents,
+    };
+  }),
+  createTonightDrawer: vi.fn().mockImplementation(() => {
+    const element = document.createElement("div");
+    element.dataset.testid = "tonight-drawer";
+    let open = false;
+    return {
+      element,
+      open: vi.fn().mockImplementation(() => {
+        open = true;
+        tonightDrawerOpen();
+      }),
+      close: vi.fn().mockImplementation(() => {
+        open = false;
+      }),
+      isOpen: vi.fn().mockImplementation(() => open),
+      setBodies: tonightDrawerSetBodies,
     };
   }),
   createHelpModal: vi.fn().mockReturnValue({
@@ -1078,6 +1102,131 @@ describe("handleIntent routing", () => {
       .forEach((el) => el.parentNode?.removeChild(el));
   });
 
+  it("mounts the tonight drawer on the document body", async () => {
+    capturedDispatch = null;
+    capturedPanelOptions = null;
+    tonightDrawerSetBodies.mockClear();
+    tonightDrawerOpen.mockClear();
+    const { root, panelRoot } = makeRoot();
+    await bootstrap(root);
+
+    expect(document.querySelector("[data-testid='tonight-drawer']")).not.toBeNull();
+    document.body.removeChild(root);
+    document.body.removeChild(panelRoot);
+    document
+      .querySelectorAll("[data-testid='tonight-drawer']")
+      .forEach((el) => el.parentNode?.removeChild(el));
+  });
+
+  it("tonight drawer is refreshed on set-time intent", async () => {
+    vi.useFakeTimers();
+    capturedDispatch = null;
+    tonightDrawerSetBodies.mockClear();
+    const { root, panelRoot } = makeRoot();
+    await bootstrap(root);
+
+    const beforeCount = tonightDrawerSetBodies.mock.calls.length;
+    capturedDispatch!({ type: "set-time", time: new Date("2026-05-01T00:00:00Z") });
+    expect(tonightDrawerSetBodies.mock.calls.length).toBeGreaterThan(beforeCount);
+
+    vi.advanceTimersByTime(100);
+    document.body.removeChild(root);
+    document.body.removeChild(panelRoot);
+    document
+      .querySelectorAll("[data-testid='tonight-drawer']")
+      .forEach((el) => el.parentNode?.removeChild(el));
+    vi.useRealTimers();
+  });
+
+  it("tonight drawer is refreshed on set-observer intent", async () => {
+    vi.useFakeTimers();
+    capturedDispatch = null;
+    tonightDrawerSetBodies.mockClear();
+    const { root, panelRoot } = makeRoot();
+    await bootstrap(root);
+
+    const beforeCount = tonightDrawerSetBodies.mock.calls.length;
+    capturedDispatch!({ type: "set-observer", lat: 48.8, lon: 2.35 });
+    expect(tonightDrawerSetBodies.mock.calls.length).toBeGreaterThan(beforeCount);
+
+    vi.advanceTimersByTime(100);
+    document.body.removeChild(root);
+    document.body.removeChild(panelRoot);
+    document
+      .querySelectorAll("[data-testid='tonight-drawer']")
+      .forEach((el) => el.parentNode?.removeChild(el));
+    vi.useRealTimers();
+  });
+
+  it("tonight drawer is refreshed on now intent", async () => {
+    vi.useFakeTimers();
+    capturedDispatch = null;
+    tonightDrawerSetBodies.mockClear();
+    Object.defineProperty(navigator, "geolocation", { value: undefined, configurable: true });
+    const { root, panelRoot } = makeRoot();
+    await bootstrap(root);
+
+    const beforeCount = tonightDrawerSetBodies.mock.calls.length;
+    capturedDispatch!({ type: "now" });
+    expect(tonightDrawerSetBodies.mock.calls.length).toBeGreaterThan(beforeCount);
+
+    vi.advanceTimersByTime(100);
+    document.body.removeChild(root);
+    document.body.removeChild(panelRoot);
+    document
+      .querySelectorAll("[data-testid='tonight-drawer']")
+      .forEach((el) => el.parentNode?.removeChild(el));
+    vi.useRealTimers();
+  });
+
+  it("tonight drawer is refreshed on show-trail intent", async () => {
+    capturedDispatch = null;
+    tonightDrawerSetBodies.mockClear();
+    const { root, panelRoot } = makeRoot();
+    await bootstrap(root);
+
+    const beforeCount = tonightDrawerSetBodies.mock.calls.length;
+    capturedDispatch!({ type: "show-trail", objectKind: "body", id: "Mars" });
+    expect(tonightDrawerSetBodies.mock.calls.length).toBeGreaterThan(beforeCount);
+
+    document.body.removeChild(root);
+    document.body.removeChild(panelRoot);
+  });
+
+  it("tonight drawer is refreshed on hide-trail intent", async () => {
+    capturedDispatch = null;
+    tonightDrawerSetBodies.mockClear();
+    const { root, panelRoot } = makeRoot();
+    await bootstrap(root);
+
+    capturedDispatch!({ type: "show-trail", objectKind: "body", id: "Mars" });
+    const beforeCount = tonightDrawerSetBodies.mock.calls.length;
+    capturedDispatch!({ type: "hide-trail" });
+    expect(tonightDrawerSetBodies.mock.calls.length).toBeGreaterThan(beforeCount);
+
+    document.body.removeChild(root);
+    document.body.removeChild(panelRoot);
+  });
+
+  it("panel's onOpenTonight callback opens the tonight drawer", async () => {
+    capturedDispatch = null;
+    capturedPanelOptions = null;
+    tonightDrawerOpen.mockClear();
+    const { root, panelRoot } = makeRoot();
+    await bootstrap(root);
+
+    expect(capturedPanelOptions).not.toBeNull();
+    expect(typeof capturedPanelOptions!.onOpenTonight).toBe("function");
+    capturedPanelOptions!.onOpenTonight!();
+    expect(tonightDrawerOpen).toHaveBeenCalled();
+
+    document.body.removeChild(root);
+    document.body.removeChild(panelRoot);
+    document
+      .querySelectorAll("[data-testid='tonight-drawer']")
+      .forEach((el) => el.parentNode?.removeChild(el));
+  });
+
   it("side panel setContent is called without a layer-controls child (moved to drawer)", async () => {
     const ui = await import("./ui");
     const panelMock = ui.createPanel as unknown as ReturnType<typeof vi.fn>;
@@ -1099,6 +1248,8 @@ describe("handleIntent routing", () => {
     expect(uiContainer.querySelector("select[data-skyculture]")).toBeNull();
     expect(uiContainer.querySelector("input[data-mag='limit']")).toBeNull();
     expect(uiContainer.querySelector("input[data-opacity]")).toBeNull();
+    // Planet Info likewise now lives in the tonight drawer (milestone 1G).
+    expect(uiContainer.querySelector("[data-testid='planet-info-heading']")).toBeNull();
     document.body.removeChild(root);
     document.body.removeChild(panelRoot);
   });

--- a/src/app.ts
+++ b/src/app.ts
@@ -72,7 +72,6 @@ import {
   createPanel,
   createLocationControls,
   createViewControls,
-  createPlanetInfo,
   createSearch,
   createFovControls,
   createEventsDrawer,
@@ -80,6 +79,7 @@ import {
   createBottomHud,
   createCommandPalette,
   createSettingsDrawer,
+  createTonightDrawer,
   createObjectCardsManager,
 } from "./ui";
 import type {
@@ -89,6 +89,7 @@ import type {
   ObjectCardData,
   ObjectPosition,
   CardKey,
+  TonightDrawer,
 } from "./ui";
 import type {
   CommandPalette,
@@ -979,14 +980,15 @@ export async function bootstrap(
     onZoom: () => layers.reticle?.render(),
   });
 
-  // Planet info wrapper — holds the current planet-info section, refreshed on time/observer changes
-  const planetInfoWrapper = document.createElement("div");
-
   // Events drawer — celestial event alerts (conjunctions / lunar eclipses / meteor showers / ISS).
   // Drawer is created at bootstrap (lives on <body>) and refreshed on any observer/time change
   // regardless of whether it's currently open, so it's always fresh when the user taps 📅.
   let cachedEvents: readonly CelestialEvent[] = [];
   let eventsDrawer: EventsDrawer | null = null;
+  // Tonight drawer (milestone 1G) — slide-in surface holding the Planet Info list (replaces
+  // the always-on side-panel section). Refreshed on observer/time/trail changes so it's
+  // always current when the user taps ♀.
+  let tonightDrawer: TonightDrawer | null = null;
 
   function refreshEvents(s: AppState): void {
     const result = computeUpcomingEvents(
@@ -998,27 +1000,10 @@ export async function bootstrap(
     eventsDrawer?.setEvents(cachedEvents);
   }
 
-  function refreshPlanetInfo(s: AppState): void {
+  function refreshTonight(s: AppState): void {
+    if (tonightDrawer === null) return;
     const bodies = computeBodyPositions(s.observer.lat, s.observer.lon, s.timeUtc, false);
-    planetInfoWrapper.replaceChildren(
-      createPlanetInfo(
-        bodies,
-        s.observer.lat,
-        s.observer.lon,
-        s.timeUtc,
-        (az, alt) => {
-          handleIntent({ type: "set-view", az, alt });
-        },
-        (id) => {
-          if (trailBodyId === id) {
-            handleIntent({ type: "hide-trail" });
-          } else {
-            handleIntent({ type: "show-trail", objectKind: "body", id });
-          }
-        },
-        trailBodyId,
-      ),
-    );
+    tonightDrawer.setBodies(bodies, s.observer.lat, s.observer.lon, s.timeUtc, trailBodyId);
   }
 
   function rebuildSearchIndex(s: AppState): void {
@@ -1041,7 +1026,7 @@ export async function bootstrap(
       case "set-time": {
         state = { ...state, timeUtc: intent.time };
         scheduleRerender(state);
-        refreshPlanetInfo(state);
+        refreshTonight(state);
         refreshEvents(state);
         rebuildSearchIndex(state);
         rerenderTrail(state);
@@ -1053,7 +1038,7 @@ export async function bootstrap(
         state = { ...state, observer: { lat: intent.lat, lon: intent.lon } };
         initCamera(viewer.camera, intent.lat, intent.lon);
         scheduleRerender(state);
-        refreshPlanetInfo(state);
+        refreshTonight(state);
         refreshEvents(state);
         rebuildSearchIndex(state);
         rerenderTrail(state);
@@ -1102,13 +1087,13 @@ export async function bootstrap(
       case "show-trail": {
         trailBodyId = intent.id;
         rerenderTrail(state);
-        refreshPlanetInfo(state);
+        refreshTonight(state);
         break;
       }
       case "hide-trail": {
         trailBodyId = null;
         layers.trail.hide();
-        refreshPlanetInfo(state);
+        refreshTonight(state);
         break;
       }
       case "set-language": {
@@ -1168,7 +1153,7 @@ export async function bootstrap(
         const now = new Date();
         state = { ...state, timeUtc: now };
         scheduleRerender(state);
-        refreshPlanetInfo(state);
+        refreshTonight(state);
         refreshEvents(state);
         rebuildSearchIndex(state);
         rerenderTrail(state);
@@ -1181,7 +1166,7 @@ export async function bootstrap(
               state = { ...state, observer: { lat, lon } };
               initCamera(viewer.camera, lat, lon);
               scheduleRerender(state);
-              refreshPlanetInfo(state);
+              refreshTonight(state);
               refreshEvents(state);
               rebuildSearchIndex(state);
               rerenderTrail(state);
@@ -1251,6 +1236,13 @@ export async function bootstrap(
   });
   document.body.appendChild(settingsDrawer.element);
 
+  // Tonight drawer (Plan 07 1G) — slide-in ♀ drawer that replaces the always-on
+  // Planet Info side-panel section. Created at bootstrap (so tests / headless
+  // environments still mount it) and populated with the initial body list.
+  tonightDrawer = createTonightDrawer({ dispatch: handleIntent });
+  document.body.appendChild(tonightDrawer.element);
+  refreshTonight(state);
+
   // Bottom HUD — ambient bar with time, location chip, and compass. Replaces the
   // side-panel Time section (milestone 1A of Plan 07). Appended to <body> so it
   // sits above the cesium canvas independently of the side panel.
@@ -1301,12 +1293,20 @@ export async function bootstrap(
         // Mutual exclusion: close other open surfaces before opening the drawer.
         if (helpModal.isOpen()) helpModal.close();
         if (settingsDrawer.isOpen()) settingsDrawer.close();
+        if (tonightDrawer?.isOpen()) tonightDrawer.close();
         eventsDrawer?.open();
       },
       onOpenSettings: () => {
         if (helpModal.isOpen()) helpModal.close();
         if (eventsDrawer?.isOpen()) eventsDrawer.close();
+        if (tonightDrawer?.isOpen()) tonightDrawer.close();
         settingsDrawer.open();
+      },
+      onOpenTonight: () => {
+        if (helpModal.isOpen()) helpModal.close();
+        if (eventsDrawer?.isOpen()) eventsDrawer.close();
+        if (settingsDrawer.isOpen()) settingsDrawer.close();
+        tonightDrawer?.open();
       },
     });
     nightVisionPanel = panel;
@@ -1328,9 +1328,6 @@ export async function bootstrap(
 
     const fovEl = createFovControls(state.fov, handleIntent);
     uiContainer.appendChild(fovEl);
-
-    refreshPlanetInfo(state);
-    uiContainer.appendChild(planetInfoWrapper);
 
     panel.setContent(uiContainer);
   }

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -22,6 +22,8 @@ export { createFovControls } from "./fov-controls";
 export { createEventsPanel } from "./events-panel";
 export { createEventsDrawer } from "./events-drawer";
 export type { EventsDrawer, EventsDrawerOptions } from "./events-drawer";
+export { createTonightDrawer } from "./tonight-drawer";
+export type { TonightDrawer, TonightDrawerOptions } from "./tonight-drawer";
 export type { HelpModal } from "./help-modal";
 export { createHelpModal } from "./help-modal";
 export { createBottomHud } from "./bottom-hud";

--- a/src/ui/panel.test.ts
+++ b/src/ui/panel.test.ts
@@ -144,6 +144,34 @@ describe("createPanel", () => {
     });
   });
 
+  describe("tonight button", () => {
+    it("renders a tonight (♀) button in the header", () => {
+      const { element } = createPanel(container);
+      const btn = element.querySelector("[data-testid='panel-tonight']");
+      expect(btn).not.toBeNull();
+    });
+
+    it("displays the ♀ icon", () => {
+      const { element } = createPanel(container);
+      const btn = element.querySelector<HTMLButtonElement>("[data-testid='panel-tonight']")!;
+      expect(btn.textContent).toBe("\u2640");
+    });
+
+    it("clicking the tonight button invokes the provided onOpenTonight callback", () => {
+      const onOpenTonight = vi.fn();
+      const { element } = createPanel(container, vi.fn(), { onOpenTonight });
+      const btn = element.querySelector<HTMLButtonElement>("[data-testid='panel-tonight']")!;
+      btn.click();
+      expect(onOpenTonight).toHaveBeenCalledTimes(1);
+    });
+
+    it("clicking the tonight button is a no-op when no callback is provided", () => {
+      const { element } = createPanel(container);
+      const btn = element.querySelector<HTMLButtonElement>("[data-testid='panel-tonight']")!;
+      expect(() => btn.click()).not.toThrow();
+    });
+  });
+
   describe("settings button", () => {
     it("renders a settings button in the header", () => {
       const { element } = createPanel(container);

--- a/src/ui/panel.ts
+++ b/src/ui/panel.ts
@@ -21,6 +21,7 @@ export type PanelOptions = {
   onOpenHelp?: () => void;
   onOpenEvents?: () => void;
   onOpenSettings?: () => void;
+  onOpenTonight?: () => void;
 };
 
 export function createPanel(
@@ -80,6 +81,12 @@ export function createPanel(
   eventsBtn.title = "Upcoming events";
   applyButton(eventsBtn);
 
+  const tonightBtn = document.createElement("button");
+  tonightBtn.dataset.testid = "panel-tonight";
+  tonightBtn.textContent = "\u2640";
+  tonightBtn.title = "Tonight's sky";
+  applyButton(tonightBtn);
+
   const helpBtn = document.createElement("button");
   helpBtn.dataset.testid = "panel-help";
   helpBtn.textContent = "?";
@@ -101,6 +108,7 @@ export function createPanel(
   btnGroup.appendChild(nightVisionBtn);
   btnGroup.appendChild(copyLinkBtn);
   btnGroup.appendChild(eventsBtn);
+  btnGroup.appendChild(tonightBtn);
   btnGroup.appendChild(helpBtn);
   btnGroup.appendChild(settingsBtn);
   btnGroup.appendChild(toggleBtn);
@@ -129,6 +137,10 @@ export function createPanel(
 
   eventsBtn.addEventListener("click", () => {
     options.onOpenEvents?.();
+  });
+
+  tonightBtn.addEventListener("click", () => {
+    options.onOpenTonight?.();
   });
 
   settingsBtn.addEventListener("click", () => {

--- a/src/ui/tonight-drawer.test.ts
+++ b/src/ui/tonight-drawer.test.ts
@@ -1,0 +1,174 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createTonightDrawer } from "./tonight-drawer";
+import type { CelestialBody } from "../astro/bodies";
+
+function makeBody(overrides: Partial<CelestialBody> & { id: string }): CelestialBody {
+  return {
+    id: overrides.id,
+    alt: overrides.alt ?? 45,
+    az: overrides.az ?? 90,
+    ra: overrides.ra ?? 180,
+    dec: overrides.dec ?? 0,
+    mag: overrides.mag ?? 0,
+    size: overrides.size ?? 8,
+    color: overrides.color ?? "#ffffff",
+  };
+}
+
+const BODIES_ABOVE: CelestialBody[] = [
+  makeBody({ id: "Sun", alt: 55, az: 180 }),
+  makeBody({ id: "Moon", alt: 30, az: 90 }),
+  makeBody({ id: "Mars", alt: 10, az: 120 }),
+];
+
+const BODIES_MIXED: CelestialBody[] = [
+  makeBody({ id: "Sun", alt: 55, az: 180 }),
+  makeBody({ id: "Venus", alt: -5, az: 270 }),
+  makeBody({ id: "Jupiter", alt: 20, az: 60 }),
+];
+
+const LAT = 34;
+const LON = -118;
+const TIME = new Date("2026-06-15T18:00:00Z");
+
+describe("createTonightDrawer", () => {
+  afterEach(() => {
+    document.querySelectorAll("[data-testid='tonight-drawer']").forEach((el) => el.remove());
+  });
+
+  it("returns an object with element, open, close, isOpen, setBodies", () => {
+    const drawer = createTonightDrawer({ dispatch: vi.fn() });
+    expect(drawer).toHaveProperty("element");
+    expect(typeof drawer.open).toBe("function");
+    expect(typeof drawer.close).toBe("function");
+    expect(typeof drawer.isOpen).toBe("function");
+    expect(typeof drawer.setBodies).toBe("function");
+  });
+
+  it("is closed by default (element hidden)", () => {
+    const drawer = createTonightDrawer({ dispatch: vi.fn() });
+    expect(drawer.isOpen()).toBe(false);
+    expect(drawer.element.style.display).toBe("none");
+  });
+
+  it("open() shows the drawer and isOpen() returns true", () => {
+    const drawer = createTonightDrawer({ dispatch: vi.fn() });
+    drawer.open();
+    expect(drawer.isOpen()).toBe(true);
+    expect(drawer.element.style.display).not.toBe("none");
+  });
+
+  it("close() hides the drawer and isOpen() returns false", () => {
+    const drawer = createTonightDrawer({ dispatch: vi.fn() });
+    drawer.open();
+    drawer.close();
+    expect(drawer.isOpen()).toBe(false);
+    expect(drawer.element.style.display).toBe("none");
+  });
+
+  it("renders a 'Tonight's sky' title in the drawer header", () => {
+    const drawer = createTonightDrawer({ dispatch: vi.fn() });
+    const title = drawer.element.querySelector("[data-testid='tonight-drawer-title']");
+    expect(title).not.toBeNull();
+    expect(title!.textContent).toMatch(/tonight/i);
+  });
+
+  it("setBodies renders a planet-info row per body", () => {
+    const drawer = createTonightDrawer({ dispatch: vi.fn() });
+    drawer.setBodies(BODIES_ABOVE, LAT, LON, TIME, null);
+    const rows = drawer.element.querySelectorAll("[data-testid='planet-info-row']");
+    expect(rows.length).toBe(BODIES_ABOVE.length);
+  });
+
+  it("setBodies re-renders when called with a new body list", () => {
+    const drawer = createTonightDrawer({ dispatch: vi.fn() });
+    drawer.setBodies(BODIES_ABOVE, LAT, LON, TIME, null);
+    expect(drawer.element.querySelectorAll("[data-testid='planet-info-row']").length).toBe(
+      BODIES_ABOVE.length,
+    );
+    drawer.setBodies(BODIES_MIXED, LAT, LON, TIME, null);
+    expect(drawer.element.querySelectorAll("[data-testid='planet-info-row']").length).toBe(
+      BODIES_MIXED.length,
+    );
+  });
+
+  it("close button (×) closes the drawer", () => {
+    const drawer = createTonightDrawer({ dispatch: vi.fn() });
+    drawer.open();
+    const closeBtn = drawer.element.querySelector<HTMLButtonElement>(
+      "[data-testid='tonight-drawer-close']",
+    );
+    expect(closeBtn).not.toBeNull();
+    closeBtn!.click();
+    expect(drawer.isOpen()).toBe(false);
+  });
+
+  it("pressing Escape while open closes the drawer", () => {
+    const drawer = createTonightDrawer({ dispatch: vi.fn() });
+    document.body.appendChild(drawer.element);
+    drawer.open();
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    expect(drawer.isOpen()).toBe(false);
+  });
+
+  it("pressing Escape while closed is a no-op", () => {
+    const drawer = createTonightDrawer({ dispatch: vi.fn() });
+    document.body.appendChild(drawer.element);
+    expect(() =>
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" })),
+    ).not.toThrow();
+    expect(drawer.isOpen()).toBe(false);
+  });
+
+  it("clicking the backdrop closes the drawer", () => {
+    const drawer = createTonightDrawer({ dispatch: vi.fn() });
+    drawer.open();
+    const backdrop = drawer.element.querySelector<HTMLElement>(
+      "[data-testid='tonight-drawer-backdrop']",
+    );
+    expect(backdrop).not.toBeNull();
+    backdrop!.click();
+    expect(drawer.isOpen()).toBe(false);
+  });
+
+  it("clicking an above-horizon body name dispatches set-view", () => {
+    const dispatch = vi.fn();
+    const drawer = createTonightDrawer({ dispatch });
+    drawer.setBodies(BODIES_ABOVE, LAT, LON, TIME, null);
+    const rows = drawer.element.querySelectorAll("[data-testid='planet-info-row']");
+    const sunRow = [...rows].find(
+      (r) => r.querySelector("[data-testid='planet-name']")?.textContent === "Sun",
+    )!;
+    const nameEl = sunRow.querySelector<HTMLElement>("[data-testid='planet-name']")!;
+    nameEl.click();
+    expect(dispatch).toHaveBeenCalledWith({ type: "set-view", az: 180, alt: 55 });
+  });
+
+  it("clicking 'Show path' dispatches show-trail with the body id", () => {
+    const dispatch = vi.fn();
+    const drawer = createTonightDrawer({ dispatch });
+    drawer.setBodies(BODIES_ABOVE, LAT, LON, TIME, null);
+    const rows = drawer.element.querySelectorAll("[data-testid='planet-info-row']");
+    const marsRow = [...rows].find(
+      (r) => r.querySelector("[data-testid='planet-name']")?.textContent === "Mars",
+    )!;
+    const btn = marsRow.querySelector<HTMLButtonElement>("[data-testid='planet-show-trail']")!;
+    btn.click();
+    expect(dispatch).toHaveBeenCalledWith({ type: "show-trail", objectKind: "body", id: "Mars" });
+  });
+
+  it("clicking 'Hide path' when trailBodyId matches dispatches hide-trail", () => {
+    const dispatch = vi.fn();
+    const drawer = createTonightDrawer({ dispatch });
+    drawer.setBodies(BODIES_ABOVE, LAT, LON, TIME, "Mars");
+    const rows = drawer.element.querySelectorAll("[data-testid='planet-info-row']");
+    const marsRow = [...rows].find(
+      (r) => r.querySelector("[data-testid='planet-name']")?.textContent === "Mars",
+    )!;
+    const btn = marsRow.querySelector<HTMLButtonElement>("[data-testid='planet-show-trail']")!;
+    expect(btn.textContent?.toLowerCase()).toContain("hide");
+    btn.click();
+    expect(dispatch).toHaveBeenCalledWith({ type: "hide-trail" });
+  });
+});

--- a/src/ui/tonight-drawer.ts
+++ b/src/ui/tonight-drawer.ts
@@ -1,0 +1,112 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { createDrawer } from "./drawer";
+import { createPlanetInfo } from "./planet-info";
+import { TEXT_COLOR } from "./styles";
+import type { CelestialBody } from "../astro/bodies";
+import type { UIIntent } from "./index";
+
+export type TonightDrawer = {
+  element: HTMLElement;
+  open(): void;
+  close(): void;
+  isOpen(): boolean;
+  setBodies(
+    bodies: CelestialBody[],
+    lat: number,
+    lon: number,
+    time: Date,
+    trailBodyId: string | null,
+  ): void;
+};
+
+export type TonightDrawerOptions = {
+  dispatch: (intent: UIIntent) => void;
+};
+
+/**
+ * Slide-in drawer holding the Planet Info list.
+ *
+ * Replaces the always-on side-panel Planet Info section (milestone 1G). Thin
+ * wrapper around `createPlanetInfo` hosted inside the shared `createDrawer`
+ * primitive. Content is refreshed via `setBodies(...)` — callers (app.ts)
+ * should call this on every `set-time` / `set-observer` / `show-trail` /
+ * `hide-trail` / `now` intent so the list is current whenever the user opens
+ * the drawer.
+ */
+export function createTonightDrawer(options: TonightDrawerOptions): TonightDrawer {
+  const { dispatch } = options;
+
+  // Stable content host. Children are rebuilt when setBodies is called so
+  // updates propagate whether the drawer is open or closed.
+  const content = document.createElement("div");
+  content.dataset.testid = "tonight-drawer-content";
+
+  const title = document.createElement("div");
+  title.dataset.testid = "tonight-drawer-title";
+  title.textContent = "Tonight's sky";
+  title.style.color = TEXT_COLOR;
+  title.style.fontSize = "14px";
+  title.style.fontWeight = "bold";
+  title.style.fontFamily = "sans-serif";
+  title.style.marginBottom = "8px";
+  content.appendChild(title);
+
+  const panelHost = document.createElement("div");
+  panelHost.dataset.testid = "tonight-drawer-panel-host";
+  content.appendChild(panelHost);
+
+  type Snapshot = {
+    bodies: CelestialBody[];
+    lat: number;
+    lon: number;
+    time: Date;
+    trailBodyId: string | null;
+  };
+  let current: Snapshot | null = null;
+
+  function render(): void {
+    if (current === null) {
+      panelHost.replaceChildren();
+      return;
+    }
+    panelHost.replaceChildren(
+      createPlanetInfo(
+        current.bodies,
+        current.lat,
+        current.lon,
+        current.time,
+        (az, alt) => {
+          dispatch({ type: "set-view", az, alt });
+        },
+        (id) => {
+          if (current !== null && current.trailBodyId === id) {
+            dispatch({ type: "hide-trail" });
+          } else {
+            dispatch({ type: "show-trail", objectKind: "body", id });
+          }
+        },
+        current.trailBodyId,
+      ),
+    );
+  }
+
+  const drawer = createDrawer({ side: "right", width: 360, initialContent: content });
+  drawer.element.dataset.testid = "tonight-drawer";
+  // Prefix the inner drawer-* test ids so the tonight-drawer-{close,backdrop,body,header,panel}
+  // selectors are unique (events + settings drawers have the same pattern on the page).
+  drawer.element.querySelectorAll<HTMLElement>("[data-testid^='drawer']").forEach((el) => {
+    const prev = el.dataset.testid!;
+    el.dataset.testid = `tonight-${prev}`;
+  });
+
+  return {
+    element: drawer.element,
+    open: () => drawer.open(content),
+    close: () => drawer.close(),
+    isOpen: () => drawer.isOpen(),
+    setBodies(bodies, lat, lon, time, trailBodyId) {
+      current = { bodies, lat, lon, time, trailBodyId };
+      render();
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- Move the Planet Info block out of the always-on side panel into a slide-in ♀ drawer (Plan 07 milestone 1G).
- New `src/ui/tonight-drawer.ts` wraps `createPlanetInfo` in the shared `createDrawer` primitive; exposes `open()` / `close()` / `isOpen()` / `setBodies(bodies, lat, lon, time, trailBodyId)`. Mirrors the events-drawer structure exactly, including test-id prefixing.
- `src/ui/panel.ts` gains a ♀ (U+2640) button next to 📅 / ? / ⚙; new `onOpenTonight` option in `PanelOptions`.
- `src/app.ts`:
  - Removes `planetInfoWrapper` from the side-panel UI container.
  - Replaces `refreshPlanetInfo` with `refreshTonight`, which calls `tonightDrawer.setBodies(...)` on every `set-time` / `set-observer` / `now` / `show-trail` / `hide-trail` intent.
  - Creates the tonight drawer at bootstrap (on `<body>`) with an initial body list.
  - Wires `onOpenTonight` with mutual exclusion against help modal, events drawer, and settings drawer — and reciprocal closes in the other open callbacks.

## Test plan
- [x] `src/ui/tonight-drawer.test.ts` (14 tests): open/close/Esc/backdrop/×, `setBodies` re-renders, clicking a body name dispatches `set-view`, "Show path" dispatches `show-trail`, "Hide path" dispatches `hide-trail`.
- [x] `src/ui/panel.test.ts` extended (+4 tests): ♀ button renders, shows U+2640, invokes `onOpenTonight`, no-op without callback.
- [x] `src/app.test.ts` extended (+7 tests): drawer mounted on body, `setBodies` fires on `set-time` / `set-observer` / `now` / `show-trail` / `hide-trail`, `onOpenTonight` opens the drawer, planet-info no longer in the side-panel UI container.
- [x] `pnpm typecheck && pnpm lint && pnpm format:check && pnpm test:cov && pnpm build` all green locally (975 tests passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)