### PR TITLE
feat(2a.1): feature gate primitive + email allowlist (closes #224)

### DIFF
--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -239,12 +239,21 @@ let capturedPanelOptions: {
   onOpenSettings?: () => void;
   onOpenHelp?: () => void;
   onOpenTonight?: () => void;
+  onProRequired?: () => void;
   mode?: "planetarium" | "notebook";
 } | null = null;
 let notebookWorkspaceMock: {
   element: HTMLElement;
   setVisible: ReturnType<typeof vi.fn>;
   destroy: ReturnType<typeof vi.fn>;
+  onProRequired: (() => void) | null;
+} | null = null;
+let emailGateModalMock: {
+  element: HTMLElement;
+  open: ReturnType<typeof vi.fn>;
+  close: ReturnType<typeof vi.fn>;
+  isOpen: ReturnType<typeof vi.fn>;
+  onGranted: () => void;
 } | null = null;
 let panelSetModeMock: ReturnType<typeof vi.fn> | null = null;
 let settingsDrawerMock: {
@@ -286,6 +295,7 @@ vi.mock("./ui", () => ({
         onOpenSettings?: () => void;
         onOpenHelp?: () => void;
         onOpenTonight?: () => void;
+        onProRequired?: () => void;
         mode?: "planetarium" | "notebook";
       },
     ) => {
@@ -429,18 +439,34 @@ vi.mock("./ui", () => ({
         isOpen: vi.fn().mockReturnValue(false),
       };
     }),
-  createNotebookWorkspace: vi.fn().mockImplementation(() => {
-    const element = document.createElement("aside");
-    element.dataset.testid = "notebook-workspace";
+  createNotebookWorkspace: vi
+    .fn()
+    .mockImplementation((opts?: { getCurrentView?: unknown; onProRequired?: () => void }) => {
+      const element = document.createElement("aside");
+      element.dataset.testid = "notebook-workspace";
+      const mock = {
+        element,
+        setVisible: vi.fn(),
+        destroy: vi.fn(),
+        onProRequired: opts?.onProRequired ?? null,
+      };
+      notebookWorkspaceMock = mock;
+      return mock;
+    }),
+  NOTEBOOK_SCRATCH_STORAGE_KEY: "planisphere.notebook.scratch.v1",
+  createEmailGateModal: vi.fn().mockImplementation((opts: { onGranted: () => void }) => {
+    const element = document.createElement("div");
+    element.dataset.testid = "email-gate-modal";
     const mock = {
       element,
-      setVisible: vi.fn(),
-      destroy: vi.fn(),
+      open: vi.fn(),
+      close: vi.fn(),
+      isOpen: vi.fn().mockReturnValue(false),
+      onGranted: opts.onGranted,
     };
-    notebookWorkspaceMock = mock;
+    emailGateModalMock = mock;
     return mock;
   }),
-  NOTEBOOK_SCRATCH_STORAGE_KEY: "planisphere.notebook.scratch.v1",
   createOnboardingOverlay: vi.fn().mockImplementation(() => {
     const element = document.createElement("div");
     element.dataset.testid = "onboarding-overlay";
@@ -1685,9 +1711,12 @@ describe("handleIntent routing", () => {
       .forEach((el) => el.parentNode?.removeChild(el));
   });
 
-  it("set-mode intent toggles the notebook workspace visibility", async () => {
+  it("set-mode intent toggles the notebook workspace visibility (Pro user)", async () => {
     capturedDispatch = null;
     notebookWorkspaceMock = null;
+    // Notebook is a Pro feature (issue #224); establish Pro identity first.
+    const { setUser } = await import("./features");
+    setUser("rob.sartin@gmail.com");
     const { root, panelRoot } = makeRoot();
     await bootstrap(root);
     expect(notebookWorkspaceMock).not.toBeNull();
@@ -1696,6 +1725,7 @@ describe("handleIntent routing", () => {
     expect(notebookWorkspaceMock!.setVisible).toHaveBeenCalledWith(true);
     capturedDispatch!({ type: "set-mode", mode: "planetarium" });
     expect(notebookWorkspaceMock!.setVisible).toHaveBeenCalledWith(false);
+    globalThis.localStorage?.clear();
     document.body.removeChild(root);
     document.body.removeChild(panelRoot);
     document
@@ -1703,9 +1733,11 @@ describe("handleIntent routing", () => {
       .forEach((el) => el.parentNode?.removeChild(el));
   });
 
-  it("set-mode intent updates URL with mode param when notebook, removes it when planetarium", async () => {
+  it("set-mode intent updates URL with mode param when notebook, removes it when planetarium (Pro user)", async () => {
     capturedDispatch = null;
     notebookWorkspaceMock = null;
+    const { setUser } = await import("./features");
+    setUser("rob.sartin@gmail.com");
     const { root, panelRoot } = makeRoot();
     const spy = vi.spyOn(globalThis.history, "replaceState");
     await bootstrap(root);
@@ -1720,6 +1752,7 @@ describe("handleIntent routing", () => {
     expect(String(lastCall[2])).not.toContain("mode=");
 
     spy.mockRestore();
+    globalThis.localStorage?.clear();
     document.body.removeChild(root);
     document.body.removeChild(panelRoot);
     document
@@ -1727,9 +1760,11 @@ describe("handleIntent routing", () => {
       .forEach((el) => el.parentNode?.removeChild(el));
   });
 
-  it("set-mode intent updates the panel's mode-toggle icon via setMode", async () => {
+  it("set-mode intent updates the panel's mode-toggle icon via setMode (Pro user)", async () => {
     capturedDispatch = null;
     panelSetModeMock = null;
+    const { setUser } = await import("./features");
+    setUser("rob.sartin@gmail.com");
     const { root, panelRoot } = makeRoot();
     await bootstrap(root);
     expect(panelSetModeMock).not.toBeNull();
@@ -1738,10 +1773,108 @@ describe("handleIntent routing", () => {
     expect(panelSetModeMock).toHaveBeenCalledWith("notebook");
     capturedDispatch!({ type: "set-mode", mode: "planetarium" });
     expect(panelSetModeMock).toHaveBeenCalledWith("planetarium");
+    globalThis.localStorage?.clear();
     document.body.removeChild(root);
     document.body.removeChild(panelRoot);
     document
       .querySelectorAll("[data-testid='notebook-workspace']")
+      .forEach((el) => el.parentNode?.removeChild(el));
+  });
+
+  it("set-mode notebook while NOT Pro opens the email-gate modal and does NOT flip", async () => {
+    capturedDispatch = null;
+    notebookWorkspaceMock = null;
+    emailGateModalMock = null;
+    globalThis.localStorage?.clear();
+    const { root, panelRoot } = makeRoot();
+    await bootstrap(root);
+    expect(emailGateModalMock).not.toBeNull();
+    expect(notebookWorkspaceMock).not.toBeNull();
+    notebookWorkspaceMock!.setVisible.mockClear();
+    emailGateModalMock!.open.mockClear();
+
+    capturedDispatch!({ type: "set-mode", mode: "notebook" });
+    expect(emailGateModalMock!.open).toHaveBeenCalledTimes(1);
+    expect(notebookWorkspaceMock!.setVisible).not.toHaveBeenCalledWith(true);
+
+    document.body.removeChild(root);
+    document.body.removeChild(panelRoot);
+    document
+      .querySelectorAll("[data-testid='notebook-workspace']")
+      .forEach((el) => el.parentNode?.removeChild(el));
+    document
+      .querySelectorAll("[data-testid='email-gate-modal']")
+      .forEach((el) => el.parentNode?.removeChild(el));
+  });
+
+  it("email-gate onGranted callback re-dispatches set-mode and flips to notebook", async () => {
+    capturedDispatch = null;
+    notebookWorkspaceMock = null;
+    emailGateModalMock = null;
+    globalThis.localStorage?.clear();
+    const { root, panelRoot } = makeRoot();
+    await bootstrap(root);
+    expect(emailGateModalMock).not.toBeNull();
+    notebookWorkspaceMock!.setVisible.mockClear();
+    // Simulate the modal's successful path: user is now Pro and onGranted fires.
+    const { setUser } = await import("./features");
+    setUser("rob.sartin@gmail.com");
+    emailGateModalMock!.onGranted();
+    expect(notebookWorkspaceMock!.setVisible).toHaveBeenCalledWith(true);
+    globalThis.localStorage?.clear();
+    document.body.removeChild(root);
+    document.body.removeChild(panelRoot);
+    document
+      .querySelectorAll("[data-testid='notebook-workspace']")
+      .forEach((el) => el.parentNode?.removeChild(el));
+    document
+      .querySelectorAll("[data-testid='email-gate-modal']")
+      .forEach((el) => el.parentNode?.removeChild(el));
+  });
+
+  it("panel option onProRequired opens the email-gate modal", async () => {
+    capturedDispatch = null;
+    capturedPanelOptions = null;
+    emailGateModalMock = null;
+    globalThis.localStorage?.clear();
+    const { root, panelRoot } = makeRoot();
+    await bootstrap(root);
+    expect(capturedPanelOptions).not.toBeNull();
+    expect(capturedPanelOptions!.onProRequired).toBeDefined();
+    expect(emailGateModalMock).not.toBeNull();
+    emailGateModalMock!.open.mockClear();
+    capturedPanelOptions!.onProRequired!();
+    expect(emailGateModalMock!.open).toHaveBeenCalledTimes(1);
+    document.body.removeChild(root);
+    document.body.removeChild(panelRoot);
+    document
+      .querySelectorAll("[data-testid='notebook-workspace']")
+      .forEach((el) => el.parentNode?.removeChild(el));
+    document
+      .querySelectorAll("[data-testid='email-gate-modal']")
+      .forEach((el) => el.parentNode?.removeChild(el));
+  });
+
+  it("notebook workspace's onProRequired opens the email-gate modal", async () => {
+    capturedDispatch = null;
+    notebookWorkspaceMock = null;
+    emailGateModalMock = null;
+    globalThis.localStorage?.clear();
+    const { root, panelRoot } = makeRoot();
+    await bootstrap(root);
+    expect(notebookWorkspaceMock).not.toBeNull();
+    expect(notebookWorkspaceMock!.onProRequired).not.toBeNull();
+    expect(emailGateModalMock).not.toBeNull();
+    emailGateModalMock!.open.mockClear();
+    notebookWorkspaceMock!.onProRequired!();
+    expect(emailGateModalMock!.open).toHaveBeenCalledTimes(1);
+    document.body.removeChild(root);
+    document.body.removeChild(panelRoot);
+    document
+      .querySelectorAll("[data-testid='notebook-workspace']")
+      .forEach((el) => el.parentNode?.removeChild(el));
+    document
+      .querySelectorAll("[data-testid='email-gate-modal']")
       .forEach((el) => el.parentNode?.removeChild(el));
   });
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -86,8 +86,10 @@ import {
   createEmptySkyPopover,
   createOnboardingOverlay,
   createNotebookWorkspace,
+  createEmailGateModal,
   ONBOARDING_STORAGE_KEY,
 } from "./ui";
+import { isPro } from "./features";
 import type { OnboardingStep } from "./ui";
 import type {
   BottomHud,
@@ -1065,6 +1067,7 @@ export async function bootstrap(
   let bottomHud: BottomHud | null = null;
   let locationPicker: ReturnType<typeof createLocationPickerOverlay> | null = null;
   let notebookWorkspace: ReturnType<typeof createNotebookWorkspace> | null = null;
+  let emailGateModal: ReturnType<typeof createEmailGateModal> | null = null;
 
   // Intent handler
   function handleIntent(intent: UIIntent): void {
@@ -1167,6 +1170,13 @@ export async function bootstrap(
         break;
       }
       case "set-mode": {
+        // Notebook is a Pro feature (issue #224). Non-Pro users attempting to
+        // enter it are shown the email-gate modal instead of flipping mode.
+        // Exiting back to planetarium is always free.
+        if (intent.mode === "notebook" && !isPro()) {
+          emailGateModal?.open();
+          break;
+        }
         state = { ...state, mode: intent.mode };
         notebookWorkspace?.setVisible(intent.mode === "notebook");
         nightVisionPanel?.setMode(intent.mode);
@@ -1366,6 +1376,18 @@ export async function bootstrap(
   });
   document.body.appendChild(locationPicker.element);
 
+  // Email-gate modal (issue #224) — surfaced whenever a non-Pro user hits a
+  // Pro-gated action. Built before the panel/notebook so they can reference
+  // it via an onProRequired callback. On-grant behaviour is to re-dispatch a
+  // set-mode intent; by the time it fires, isPro() is true so the gate falls
+  // open.
+  emailGateModal = createEmailGateModal({
+    onGranted: () => {
+      handleIntent({ type: "set-mode", mode: "notebook" });
+    },
+  });
+  document.body.appendChild(emailGateModal.element);
+
   // Notebook workspace (milestone 2A of Plan 07, issue #216). Right-side shell
   // shown only when state.mode === "notebook". Content is a placeholder +
   // localStorage-backed scratch textarea; the real editor arrives in #219.
@@ -1374,6 +1396,9 @@ export async function bootstrap(
       href: globalThis.location.href,
       timeUtc: state.timeUtc,
     }),
+    onProRequired: () => {
+      emailGateModal?.open();
+    },
   });
   document.body.appendChild(notebookWorkspace.element);
   notebookWorkspace.setVisible(state.mode === "notebook");
@@ -1428,6 +1453,9 @@ export async function bootstrap(
         if (eventsDrawer?.isOpen()) eventsDrawer.close();
         if (settingsDrawer.isOpen()) settingsDrawer.close();
         tonightDrawer?.open();
+      },
+      onProRequired: () => {
+        emailGateModal?.open();
       },
       mode: state.mode,
     });

--- a/src/features.test.ts
+++ b/src/features.test.ts
@@ -1,0 +1,172 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  PRO_EMAIL_ALLOWLIST,
+  USER_STORAGE_KEY,
+  clearUser,
+  getUser,
+  isPro,
+  setUser,
+} from "./features";
+
+describe("features — constants", () => {
+  it("exposes the PRO_EMAIL_ALLOWLIST seeded with Rob's email (lowercase)", () => {
+    expect(PRO_EMAIL_ALLOWLIST.has("rob.sartin@gmail.com")).toBe(true);
+  });
+
+  it("uses the canonical user storage key", () => {
+    expect(USER_STORAGE_KEY).toBe("planisphere.user.v1");
+  });
+});
+
+describe("features — getUser / setUser / clearUser", () => {
+  beforeEach(() => {
+    globalThis.localStorage?.clear();
+  });
+
+  afterEach(() => {
+    globalThis.localStorage?.clear();
+  });
+
+  it("getUser returns { email: null } when no user is stored", () => {
+    expect(getUser()).toEqual({ email: null });
+  });
+
+  it("setUser persists an email and getUser reads it back", () => {
+    setUser("rob.sartin@gmail.com");
+    expect(getUser()).toEqual({ email: "rob.sartin@gmail.com" });
+  });
+
+  it("setUser normalises email to lowercase", () => {
+    setUser("Rob.Sartin@Gmail.COM");
+    expect(getUser().email).toBe("rob.sartin@gmail.com");
+  });
+
+  it("setUser trims surrounding whitespace", () => {
+    setUser("   rob.sartin@gmail.com  ");
+    expect(getUser().email).toBe("rob.sartin@gmail.com");
+  });
+
+  it("clearUser removes the stored email", () => {
+    setUser("someone@example.com");
+    clearUser();
+    expect(getUser()).toEqual({ email: null });
+  });
+
+  it("getUser returns { email: null } when the stored JSON is malformed", () => {
+    globalThis.localStorage.setItem(USER_STORAGE_KEY, "not-json");
+    expect(getUser()).toEqual({ email: null });
+  });
+
+  it("getUser returns { email: null } when the stored payload lacks an email string", () => {
+    globalThis.localStorage.setItem(USER_STORAGE_KEY, JSON.stringify({ unrelated: 1 }));
+    expect(getUser()).toEqual({ email: null });
+  });
+
+  it("getUser returns { email: null } when the stored payload is not an object", () => {
+    globalThis.localStorage.setItem(USER_STORAGE_KEY, JSON.stringify("just-a-string"));
+    expect(getUser()).toEqual({ email: null });
+  });
+
+  it("getUser returns { email: null } when the stored payload is null", () => {
+    globalThis.localStorage.setItem(USER_STORAGE_KEY, JSON.stringify(null));
+    expect(getUser()).toEqual({ email: null });
+  });
+
+  it("getUser returns { email: null } when localStorage throws on read", () => {
+    const orig = globalThis.localStorage;
+    const broken = {
+      getItem: () => {
+        throw new Error("storage denied");
+      },
+      setItem: () => {},
+      removeItem: () => {},
+      clear: () => {},
+      key: () => null,
+      length: 0,
+    } satisfies Storage;
+    Object.defineProperty(globalThis, "localStorage", { value: broken, configurable: true });
+    try {
+      expect(getUser()).toEqual({ email: null });
+    } finally {
+      Object.defineProperty(globalThis, "localStorage", { value: orig, configurable: true });
+    }
+  });
+
+  it("setUser does not throw when localStorage throws on write", () => {
+    const orig = globalThis.localStorage;
+    const broken = {
+      getItem: () => null,
+      setItem: () => {
+        throw new Error("quota");
+      },
+      removeItem: () => {},
+      clear: () => {},
+      key: () => null,
+      length: 0,
+    } satisfies Storage;
+    Object.defineProperty(globalThis, "localStorage", { value: broken, configurable: true });
+    try {
+      expect(() => setUser("x@y.com")).not.toThrow();
+    } finally {
+      Object.defineProperty(globalThis, "localStorage", { value: orig, configurable: true });
+    }
+  });
+
+  it("clearUser does not throw when localStorage throws on remove", () => {
+    const orig = globalThis.localStorage;
+    const broken = {
+      getItem: () => null,
+      setItem: () => {},
+      removeItem: () => {
+        throw new Error("denied");
+      },
+      clear: () => {},
+      key: () => null,
+      length: 0,
+    } satisfies Storage;
+    Object.defineProperty(globalThis, "localStorage", { value: broken, configurable: true });
+    try {
+      expect(() => {
+        clearUser();
+      }).not.toThrow();
+    } finally {
+      Object.defineProperty(globalThis, "localStorage", { value: orig, configurable: true });
+    }
+  });
+});
+
+describe("features — isPro", () => {
+  beforeEach(() => {
+    globalThis.localStorage?.clear();
+  });
+
+  afterEach(() => {
+    globalThis.localStorage?.clear();
+  });
+
+  it("returns false when no user is set", () => {
+    expect(isPro()).toBe(false);
+  });
+
+  it("returns true when the stored email matches the allowlist", () => {
+    setUser("rob.sartin@gmail.com");
+    expect(isPro()).toBe(true);
+  });
+
+  it("returns true regardless of case/whitespace in the provided email (normalisation)", () => {
+    setUser("  ROB.SARTIN@gmail.com  ");
+    expect(isPro()).toBe(true);
+  });
+
+  it("returns false when the stored email is not on the allowlist", () => {
+    setUser("stranger@example.com");
+    expect(isPro()).toBe(false);
+  });
+
+  it("returns false after clearUser", () => {
+    setUser("rob.sartin@gmail.com");
+    clearUser();
+    expect(isPro()).toBe(false);
+  });
+});

--- a/src/features.ts
+++ b/src/features.ts
@@ -1,0 +1,78 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/**
+ * Feature-gate primitives (Rung 1 of the entitlement ladder, issue #224).
+ *
+ * Intentionally trivial: a bundle-time email allowlist plus a localStorage-persisted
+ * identity. This is bypassable in ~10 seconds by anyone who reads the source, and
+ * that's fine — it exists to gate paid surfaces during a private beta without
+ * standing up auth infrastructure yet. Proper enforcement arrives in Rungs 2/3
+ * (signed JWT / Cloudflare Access) once the business model firms up.
+ */
+
+/** Lowercased emails that currently have "Pro" entitlements. */
+export const PRO_EMAIL_ALLOWLIST: ReadonlySet<string> = new Set(["rob.sartin@gmail.com"]);
+
+/** localStorage key used for the persisted user identity. Bump the suffix
+ *  (`.v2`) when the shape changes so old blobs never deserialise into a
+ *  schema-aware reader. */
+export const USER_STORAGE_KEY = "planisphere.user.v1";
+
+export type User = { email: string | null };
+
+function normaliseEmail(raw: string): string {
+  return raw.trim().toLowerCase();
+}
+
+/**
+ * Read the persisted user identity. Returns `{ email: null }` on every
+ * failure path — missing key, malformed JSON, unexpected shape, or
+ * localStorage unavailable — so callers don't need to handle errors.
+ */
+export function getUser(): User {
+  let raw: string | null;
+  try {
+    raw = globalThis.localStorage?.getItem(USER_STORAGE_KEY) ?? null;
+  } catch {
+    return { email: null };
+  }
+  if (raw === null) return { email: null };
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return { email: null };
+  }
+  if (parsed === null || typeof parsed !== "object") return { email: null };
+  const rec = parsed as Record<string, unknown>;
+  if (typeof rec.email !== "string") return { email: null };
+  return { email: rec.email };
+}
+
+/** Persist an email as the current user. Normalised to trimmed-lowercase. */
+export function setUser(email: string): void {
+  const normalised = normaliseEmail(email);
+  const payload = JSON.stringify({ email: normalised });
+  try {
+    globalThis.localStorage?.setItem(USER_STORAGE_KEY, payload);
+  } catch {
+    // Quota exceeded / storage disabled — Rung 1 is best-effort persistence.
+  }
+}
+
+/** Remove the persisted user identity. */
+export function clearUser(): void {
+  try {
+    globalThis.localStorage?.removeItem(USER_STORAGE_KEY);
+  } catch {
+    // Ignore — nothing to do if storage is unavailable.
+  }
+}
+
+/** True iff the currently persisted email is on the Pro allowlist. */
+export function isPro(): boolean {
+  const { email } = getUser();
+  if (email === null) return false;
+  return PRO_EMAIL_ALLOWLIST.has(normaliseEmail(email));
+}

--- a/src/ui/email-gate-modal.test.ts
+++ b/src/ui/email-gate-modal.test.ts
@@ -1,0 +1,191 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createEmailGateModal } from "./email-gate-modal";
+import { PRO_EMAIL_ALLOWLIST, USER_STORAGE_KEY, getUser } from "../features";
+
+describe("createEmailGateModal", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    document.body.style.overflow = "";
+    globalThis.localStorage?.clear();
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+    document.body.style.overflow = "";
+    globalThis.localStorage?.clear();
+  });
+
+  it("exposes element, open, close, isOpen", () => {
+    const modal = createEmailGateModal({ onGranted: vi.fn() });
+    expect(modal).toHaveProperty("element");
+    expect(typeof modal.open).toBe("function");
+    expect(typeof modal.close).toBe("function");
+    expect(typeof modal.isOpen).toBe("function");
+  });
+
+  it("is hidden initially", () => {
+    const modal = createEmailGateModal({ onGranted: vi.fn() });
+    document.body.appendChild(modal.element);
+    expect(modal.isOpen()).toBe(false);
+    expect(modal.element.style.display).toBe("none");
+  });
+
+  it("open() makes it visible, close() hides it", () => {
+    const modal = createEmailGateModal({ onGranted: vi.fn() });
+    document.body.appendChild(modal.element);
+    modal.open();
+    expect(modal.isOpen()).toBe(true);
+    expect(modal.element.style.display).not.toBe("none");
+    modal.close();
+    expect(modal.isOpen()).toBe(false);
+    expect(modal.element.style.display).toBe("none");
+  });
+
+  it("clicking the backdrop closes the modal", () => {
+    const modal = createEmailGateModal({ onGranted: vi.fn() });
+    document.body.appendChild(modal.element);
+    modal.open();
+    const backdrop = modal.element.querySelector<HTMLElement>(
+      "[data-testid='email-gate-backdrop']",
+    )!;
+    backdrop.click();
+    expect(modal.isOpen()).toBe(false);
+  });
+
+  it("pressing Escape closes the modal", () => {
+    const modal = createEmailGateModal({ onGranted: vi.fn() });
+    document.body.appendChild(modal.element);
+    modal.open();
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    expect(modal.isOpen()).toBe(false);
+  });
+
+  it("Escape is a no-op when the modal is closed", () => {
+    const modal = createEmailGateModal({ onGranted: vi.fn() });
+    document.body.appendChild(modal.element);
+    // Never opened.
+    expect(() =>
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" })),
+    ).not.toThrow();
+    expect(modal.isOpen()).toBe(false);
+  });
+
+  it("cancel button closes the modal", () => {
+    const modal = createEmailGateModal({ onGranted: vi.fn() });
+    document.body.appendChild(modal.element);
+    modal.open();
+    const cancel = modal.element.querySelector<HTMLButtonElement>(
+      "[data-testid='email-gate-cancel']",
+    )!;
+    cancel.click();
+    expect(modal.isOpen()).toBe(false);
+  });
+
+  it("Continue with an allowlisted email invokes onGranted and closes the modal", () => {
+    const onGranted = vi.fn();
+    const modal = createEmailGateModal({ onGranted });
+    document.body.appendChild(modal.element);
+    modal.open();
+    // Grab the allowlisted email from the shared set so the test doesn't hardcode it.
+    const proEmail = [...PRO_EMAIL_ALLOWLIST][0];
+    expect(proEmail).toBeDefined();
+    const input = modal.element.querySelector<HTMLInputElement>(
+      "[data-testid='email-gate-input']",
+    )!;
+    input.value = proEmail!;
+    const continueBtn = modal.element.querySelector<HTMLButtonElement>(
+      "[data-testid='email-gate-continue']",
+    )!;
+    continueBtn.click();
+    expect(onGranted).toHaveBeenCalledTimes(1);
+    expect(modal.isOpen()).toBe(false);
+    // Side effect: the email is persisted through setUser.
+    expect(getUser().email).toBe(proEmail);
+  });
+
+  it("Continue normalises the email (trims + lowercases) before matching the allowlist", () => {
+    const onGranted = vi.fn();
+    const modal = createEmailGateModal({ onGranted });
+    document.body.appendChild(modal.element);
+    modal.open();
+    const input = modal.element.querySelector<HTMLInputElement>(
+      "[data-testid='email-gate-input']",
+    )!;
+    input.value = "  ROB.SARTIN@Gmail.COM  ";
+    const continueBtn = modal.element.querySelector<HTMLButtonElement>(
+      "[data-testid='email-gate-continue']",
+    )!;
+    continueBtn.click();
+    expect(onGranted).toHaveBeenCalledTimes(1);
+  });
+
+  it("Continue with a non-allowlisted email swaps to the request-access state", () => {
+    const onGranted = vi.fn();
+    const modal = createEmailGateModal({ onGranted });
+    document.body.appendChild(modal.element);
+    modal.open();
+    const input = modal.element.querySelector<HTMLInputElement>(
+      "[data-testid='email-gate-input']",
+    )!;
+    input.value = "stranger@example.com";
+    const continueBtn = modal.element.querySelector<HTMLButtonElement>(
+      "[data-testid='email-gate-continue']",
+    )!;
+    continueBtn.click();
+    expect(onGranted).not.toHaveBeenCalled();
+    expect(modal.isOpen()).toBe(true); // stays open so the user can read the CTA
+    // Request-access state visible.
+    expect(modal.element.querySelector("[data-testid='email-gate-request-state']")).not.toBeNull();
+    // Initial form state hidden.
+    expect(modal.element.querySelector("[data-testid='email-gate-form']")).toBeNull();
+  });
+
+  it("the request-access state includes a mailto button pointing at rob.sartin@gmail.com", () => {
+    const modal = createEmailGateModal({ onGranted: vi.fn() });
+    document.body.appendChild(modal.element);
+    modal.open();
+    const input = modal.element.querySelector<HTMLInputElement>(
+      "[data-testid='email-gate-input']",
+    )!;
+    input.value = "stranger@example.com";
+    modal.element.querySelector<HTMLButtonElement>("[data-testid='email-gate-continue']")!.click();
+    const mailto = modal.element.querySelector<HTMLAnchorElement>(
+      "[data-testid='email-gate-mailto']",
+    );
+    expect(mailto).not.toBeNull();
+    expect(mailto!.href.startsWith("mailto:rob.sartin@gmail.com")).toBe(true);
+  });
+
+  it("Continue with a blank email does not call onGranted and does not persist", () => {
+    const onGranted = vi.fn();
+    const modal = createEmailGateModal({ onGranted });
+    document.body.appendChild(modal.element);
+    modal.open();
+    const continueBtn = modal.element.querySelector<HTMLButtonElement>(
+      "[data-testid='email-gate-continue']",
+    )!;
+    continueBtn.click();
+    expect(onGranted).not.toHaveBeenCalled();
+    expect(globalThis.localStorage.getItem(USER_STORAGE_KEY)).toBeNull();
+    expect(modal.isOpen()).toBe(true);
+  });
+
+  it("reopening after a miss resets the modal back to the form state", () => {
+    const modal = createEmailGateModal({ onGranted: vi.fn() });
+    document.body.appendChild(modal.element);
+    modal.open();
+    const input = modal.element.querySelector<HTMLInputElement>(
+      "[data-testid='email-gate-input']",
+    )!;
+    input.value = "stranger@example.com";
+    modal.element.querySelector<HTMLButtonElement>("[data-testid='email-gate-continue']")!.click();
+    // In request-access state now.
+    expect(modal.element.querySelector("[data-testid='email-gate-request-state']")).not.toBeNull();
+    modal.close();
+    modal.open();
+    // Back to the form state.
+    expect(modal.element.querySelector("[data-testid='email-gate-form']")).not.toBeNull();
+    expect(modal.element.querySelector("[data-testid='email-gate-request-state']")).toBeNull();
+  });
+});

--- a/src/ui/email-gate-modal.ts
+++ b/src/ui/email-gate-modal.ts
@@ -1,0 +1,246 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { isPro, setUser } from "../features";
+import { PANEL_BG, PANEL_BORDER, TEXT_COLOR, FONT_FAMILY, applyButton } from "./styles";
+
+export type EmailGateModal = {
+  element: HTMLElement;
+  open(): void;
+  close(): void;
+  isOpen(): boolean;
+};
+
+export type EmailGateModalOptions = {
+  /** Invoked after a successful (allowlisted) email is entered. The modal
+   *  closes itself before this fires. */
+  readonly onGranted: () => void;
+};
+
+const PRO_CONTACT_EMAIL = "rob.sartin@gmail.com";
+
+/**
+ * Centered modal that collects an email, normalises it, and grants access iff
+ * the email is on the Pro allowlist. Non-allowlisted emails swap the modal
+ * body to a "request access" call-to-action with a mailto link. No loading
+ * states — everything is synchronous by design (Rung 1 of the entitlement
+ * ladder; see `src/features.ts`).
+ */
+export function createEmailGateModal(options: EmailGateModalOptions): EmailGateModal {
+  const root = document.createElement("div");
+  root.dataset.testid = "email-gate-modal";
+  root.style.display = "none";
+  root.style.position = "fixed";
+  root.style.inset = "0";
+  root.style.zIndex = "2100";
+
+  const backdrop = document.createElement("div");
+  backdrop.dataset.testid = "email-gate-backdrop";
+  backdrop.style.position = "absolute";
+  backdrop.style.inset = "0";
+  backdrop.style.background = "rgba(0,0,0,0.6)";
+
+  const panel = document.createElement("div");
+  panel.style.position = "absolute";
+  panel.style.top = "50%";
+  panel.style.left = "50%";
+  panel.style.transform = "translate(-50%, -50%)";
+  panel.style.width = "min(90vw, 420px)";
+  panel.style.background = PANEL_BG;
+  panel.style.border = PANEL_BORDER;
+  panel.style.borderRadius = "8px";
+  panel.style.padding = "22px 24px";
+  panel.style.color = TEXT_COLOR;
+  panel.style.fontFamily = FONT_FAMILY;
+  panel.style.boxSizing = "border-box";
+  panel.style.display = "flex";
+  panel.style.flexDirection = "column";
+  panel.style.gap = "14px";
+
+  const body = document.createElement("div");
+  body.style.display = "flex";
+  body.style.flexDirection = "column";
+  body.style.gap = "14px";
+
+  panel.appendChild(body);
+  root.appendChild(backdrop);
+  root.appendChild(panel);
+
+  let open = false;
+
+  function setOpen(value: boolean): void {
+    open = value;
+    root.style.display = value ? "block" : "none";
+  }
+
+  function doClose(): void {
+    setOpen(false);
+  }
+
+  function renderForm(): void {
+    body.replaceChildren();
+
+    const heading = document.createElement("h2");
+    heading.textContent = "Notebook is a Pro feature";
+    heading.style.margin = "0";
+    heading.style.fontSize = "18px";
+    heading.style.fontWeight = "600";
+
+    const blurb = document.createElement("p");
+    blurb.textContent =
+      "Enter the email associated with your Pro access to continue. We'll remember it on this device.";
+    blurb.style.margin = "0";
+    blurb.style.fontSize = "13px";
+    blurb.style.lineHeight = "1.5";
+    blurb.style.color = "rgba(255,255,255,0.78)";
+
+    const form = document.createElement("form");
+    form.dataset.testid = "email-gate-form";
+    form.style.display = "flex";
+    form.style.flexDirection = "column";
+    form.style.gap = "10px";
+
+    const input = document.createElement("input");
+    input.dataset.testid = "email-gate-input";
+    input.type = "email";
+    input.placeholder = "you@example.com";
+    input.autocomplete = "email";
+    input.style.background = "rgba(255,255,255,0.06)";
+    input.style.border = "1px solid rgba(255,255,255,0.25)";
+    input.style.borderRadius = "6px";
+    input.style.color = TEXT_COLOR;
+    input.style.fontFamily = FONT_FAMILY;
+    input.style.fontSize = "14px";
+    input.style.padding = "10px 12px";
+    input.style.boxSizing = "border-box";
+
+    const btnRow = document.createElement("div");
+    btnRow.style.display = "flex";
+    btnRow.style.justifyContent = "flex-end";
+    btnRow.style.gap = "8px";
+
+    const cancelBtn = document.createElement("button");
+    cancelBtn.dataset.testid = "email-gate-cancel";
+    cancelBtn.type = "button";
+    cancelBtn.textContent = "Cancel";
+    applyButton(cancelBtn);
+    cancelBtn.style.padding = "6px 14px";
+
+    const continueBtn = document.createElement("button");
+    continueBtn.dataset.testid = "email-gate-continue";
+    continueBtn.type = "submit";
+    continueBtn.textContent = "Continue";
+    applyButton(continueBtn);
+    continueBtn.style.padding = "6px 14px";
+    continueBtn.style.background = "rgba(0,255,136,0.15)";
+    continueBtn.style.borderColor = "rgba(0,255,136,0.45)";
+
+    btnRow.appendChild(cancelBtn);
+    btnRow.appendChild(continueBtn);
+
+    form.appendChild(input);
+    form.appendChild(btnRow);
+
+    body.appendChild(heading);
+    body.appendChild(blurb);
+    body.appendChild(form);
+
+    cancelBtn.addEventListener("click", doClose);
+    form.addEventListener("submit", (e) => {
+      e.preventDefault();
+      handleSubmit(input.value);
+    });
+  }
+
+  function renderRequestAccessState(): void {
+    body.replaceChildren();
+
+    const wrap = document.createElement("div");
+    wrap.dataset.testid = "email-gate-request-state";
+    wrap.style.display = "flex";
+    wrap.style.flexDirection = "column";
+    wrap.style.gap = "14px";
+
+    const heading = document.createElement("h2");
+    heading.textContent = "Pro access required";
+    heading.style.margin = "0";
+    heading.style.fontSize = "18px";
+    heading.style.fontWeight = "600";
+
+    const blurb = document.createElement("p");
+    blurb.textContent = `That email isn't on the Pro allowlist yet. Request access by emailing ${PRO_CONTACT_EMAIL}, and we'll add you.`;
+    blurb.style.margin = "0";
+    blurb.style.fontSize = "13px";
+    blurb.style.lineHeight = "1.5";
+    blurb.style.color = "rgba(255,255,255,0.78)";
+
+    const btnRow = document.createElement("div");
+    btnRow.style.display = "flex";
+    btnRow.style.justifyContent = "flex-end";
+    btnRow.style.gap = "8px";
+
+    const closeBtn = document.createElement("button");
+    closeBtn.dataset.testid = "email-gate-close-request";
+    closeBtn.type = "button";
+    closeBtn.textContent = "Close";
+    applyButton(closeBtn);
+    closeBtn.style.padding = "6px 14px";
+
+    const mailto = document.createElement("a");
+    mailto.dataset.testid = "email-gate-mailto";
+    mailto.href = `mailto:${PRO_CONTACT_EMAIL}?subject=${encodeURIComponent(
+      "Planisphere Pro access request",
+    )}`;
+    mailto.textContent = `Email ${PRO_CONTACT_EMAIL}`;
+    mailto.style.display = "inline-block";
+    mailto.style.background = "rgba(0,255,136,0.15)";
+    mailto.style.border = "1px solid rgba(0,255,136,0.45)";
+    mailto.style.borderRadius = "4px";
+    mailto.style.color = TEXT_COLOR;
+    mailto.style.fontFamily = FONT_FAMILY;
+    mailto.style.fontSize = "12px";
+    mailto.style.padding = "6px 14px";
+    mailto.style.textDecoration = "none";
+
+    btnRow.appendChild(closeBtn);
+    btnRow.appendChild(mailto);
+
+    wrap.appendChild(heading);
+    wrap.appendChild(blurb);
+    wrap.appendChild(btnRow);
+    body.appendChild(wrap);
+
+    closeBtn.addEventListener("click", doClose);
+  }
+
+  function handleSubmit(raw: string): void {
+    const trimmed = raw.trim();
+    if (trimmed === "") return;
+    setUser(trimmed);
+    if (isPro()) {
+      doClose();
+      options.onGranted();
+      return;
+    }
+    renderRequestAccessState();
+  }
+
+  function doOpen(): void {
+    // Always re-render the form on open so the user returns to the entry
+    // state after a miss + close + reopen.
+    renderForm();
+    setOpen(true);
+  }
+
+  backdrop.addEventListener("click", doClose);
+  document.addEventListener("keydown", (e) => {
+    if (e.key === "Escape" && open) {
+      doClose();
+    }
+  });
+
+  return {
+    element: root,
+    open: doOpen,
+    close: doClose,
+    isOpen: () => open,
+  };
+}

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -44,6 +44,8 @@ export { createCommandPalette } from "./command-palette";
 export type { CommandPalette, CommandPaletteOptions } from "./command-palette";
 export { createNotebookWorkspace, NOTEBOOK_SCRATCH_STORAGE_KEY } from "./notebook-workspace";
 export type { NotebookWorkspace, NotebookWorkspaceOptions } from "./notebook-workspace";
+export { createEmailGateModal } from "./email-gate-modal";
+export type { EmailGateModal, EmailGateModalOptions } from "./email-gate-modal";
 export { buildPaletteResults, fuzzyScore } from "./palette-results";
 export type {
   PaletteResult,

--- a/src/ui/notebook-workspace.test.ts
+++ b/src/ui/notebook-workspace.test.ts
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createNotebookWorkspace, NOTEBOOK_SCRATCH_STORAGE_KEY } from "./notebook-workspace";
+import { setUser } from "../features";
 
 describe("createNotebookWorkspace", () => {
   beforeEach(() => {
@@ -111,6 +112,12 @@ describe("createNotebookWorkspace", () => {
     const TEST_HREF = "http://localhost:5173/?lat=40.7&lon=-74&t=2026-08-12T04:30:00.000Z";
     const TEST_TIME = new Date("2026-08-12T04:30:00.000Z");
 
+    beforeEach(() => {
+      // Insert-link is a Pro feature; establish a Pro identity so the existing
+      // insertion-behavior assertions hit the Pro branch.
+      setUser("rob.sartin@gmail.com");
+    });
+
     function pad(n: number): string {
       return String(n).padStart(2, "0");
     }
@@ -176,6 +183,73 @@ describe("createNotebookWorkspace", () => {
       const { element } = createNotebookWorkspace({});
       const btn = element.querySelector<HTMLButtonElement>("[data-testid='notebook-insert-link']");
       expect(btn).toBeNull();
+    });
+  });
+
+  describe("insert link — Pro gating", () => {
+    const TEST_HREF = "http://localhost:5173/?lat=40.7&lon=-74&t=2026-08-12T04:30:00.000Z";
+    const TEST_TIME = new Date("2026-08-12T04:30:00.000Z");
+
+    it("shows a 'Pro' pill next to the Insert-link button when the user is not Pro", () => {
+      const { element } = createNotebookWorkspace({
+        getCurrentView: () => ({ href: TEST_HREF, timeUtc: TEST_TIME }),
+      });
+      const pill = element.querySelector<HTMLElement>("[data-testid='notebook-insert-link-pro']");
+      expect(pill).not.toBeNull();
+    });
+
+    it("does not show the 'Pro' pill when the user is Pro", () => {
+      setUser("rob.sartin@gmail.com");
+      const { element } = createNotebookWorkspace({
+        getCurrentView: () => ({ href: TEST_HREF, timeUtc: TEST_TIME }),
+      });
+      const pill = element.querySelector<HTMLElement>("[data-testid='notebook-insert-link-pro']");
+      expect(pill).toBeNull();
+    });
+
+    it("non-Pro click invokes onProRequired and does NOT modify the textarea", () => {
+      const onProRequired = vi.fn();
+      const { element } = createNotebookWorkspace({
+        getCurrentView: () => ({ href: TEST_HREF, timeUtc: TEST_TIME }),
+        onProRequired,
+      });
+      const textarea = element.querySelector<HTMLTextAreaElement>(
+        "[data-testid='notebook-scratch']",
+      )!;
+      const btn = element.querySelector<HTMLButtonElement>("[data-testid='notebook-insert-link']")!;
+      textarea.value = "";
+      btn.click();
+      expect(onProRequired).toHaveBeenCalledTimes(1);
+      expect(textarea.value).toBe("");
+    });
+
+    it("Pro click inserts the link even when onProRequired is wired", () => {
+      setUser("rob.sartin@gmail.com");
+      const onProRequired = vi.fn();
+      const { element } = createNotebookWorkspace({
+        getCurrentView: () => ({ href: TEST_HREF, timeUtc: TEST_TIME }),
+        onProRequired,
+      });
+      const textarea = element.querySelector<HTMLTextAreaElement>(
+        "[data-testid='notebook-scratch']",
+      )!;
+      const btn = element.querySelector<HTMLButtonElement>("[data-testid='notebook-insert-link']")!;
+      btn.click();
+      expect(onProRequired).not.toHaveBeenCalled();
+      expect(textarea.value).toContain(TEST_HREF);
+    });
+
+    it("non-Pro click with no onProRequired callback is a safe no-op", () => {
+      const { element } = createNotebookWorkspace({
+        getCurrentView: () => ({ href: TEST_HREF, timeUtc: TEST_TIME }),
+      });
+      const textarea = element.querySelector<HTMLTextAreaElement>(
+        "[data-testid='notebook-scratch']",
+      )!;
+      const btn = element.querySelector<HTMLButtonElement>("[data-testid='notebook-insert-link']")!;
+      textarea.value = "before";
+      expect(() => btn.click()).not.toThrow();
+      expect(textarea.value).toBe("before");
     });
   });
 

--- a/src/ui/notebook-workspace.ts
+++ b/src/ui/notebook-workspace.ts
@@ -1,4 +1,5 @@
 /* SPDX-License-Identifier: Apache-2.0 */
+import { isPro } from "../features";
 import { PANEL_BG, PANEL_BORDER, TEXT_COLOR, FONT_FAMILY } from "./styles";
 
 /**
@@ -18,6 +19,12 @@ export type NotebookWorkspaceOptions = {
    * the cursor. Omitted in tests that don't care about the button.
    */
   getCurrentView?: () => { readonly href: string; readonly timeUtc: Date };
+  /**
+   * Invoked when a non-Pro user clicks a Pro-gated surface (currently just the
+   * Insert-link button). app.ts passes in a function that opens the email-gate
+   * modal. When omitted, Pro-gated clicks are a no-op — safe for tests.
+   */
+  onProRequired?: () => void;
 };
 
 export type NotebookWorkspace = {
@@ -132,13 +139,15 @@ export function createNotebookWorkspace(options: NotebookWorkspaceOptions = {}):
   // getCurrentView callback is supplied so the notebook-alone test paths stay
   // dependency-free. Format: Markdown link `- [YYYY-MM-DD HH:MM](href)\n` so
   // a future slideshow parser can extract views as ordered list items.
+  // Gated behind isPro() — non-Pro users see a small "Pro" pill and an
+  // onProRequired callback fires on click (defense in depth; the mode-toggle
+  // is also gated upstream so non-Pro users rarely reach the notebook).
   let insertLinkBtn: HTMLButtonElement | null = null;
   if (options.getCurrentView !== undefined) {
     const getCurrentView = options.getCurrentView;
     insertLinkBtn = document.createElement("button");
     insertLinkBtn.type = "button";
     insertLinkBtn.dataset.testid = "notebook-insert-link";
-    insertLinkBtn.textContent = "\u2192 Insert link to this view";
     insertLinkBtn.style.background = "rgba(255,255,255,0.08)";
     insertLinkBtn.style.border = "1px solid rgba(255,255,255,0.2)";
     insertLinkBtn.style.borderRadius = "4px";
@@ -148,8 +157,35 @@ export function createNotebookWorkspace(options: NotebookWorkspaceOptions = {}):
     insertLinkBtn.style.fontSize = "12px";
     insertLinkBtn.style.padding = "6px 10px";
     insertLinkBtn.style.alignSelf = "flex-start";
+    insertLinkBtn.style.display = "inline-flex";
+    insertLinkBtn.style.alignItems = "center";
+    insertLinkBtn.style.gap = "6px";
+
+    const label = document.createElement("span");
+    label.textContent = "\u2192 Insert link to this view";
+    insertLinkBtn.appendChild(label);
+
+    if (!isPro()) {
+      const pill = document.createElement("span");
+      pill.dataset.testid = "notebook-insert-link-pro";
+      pill.textContent = "Pro";
+      pill.style.background = "rgba(0,255,136,0.18)";
+      pill.style.border = "1px solid rgba(0,255,136,0.5)";
+      pill.style.borderRadius = "10px";
+      pill.style.color = "#00ff88";
+      pill.style.fontSize = "10px";
+      pill.style.fontWeight = "600";
+      pill.style.letterSpacing = "0.05em";
+      pill.style.padding = "1px 7px";
+      pill.style.textTransform = "uppercase";
+      insertLinkBtn.appendChild(pill);
+    }
 
     insertLinkBtn.addEventListener("click", () => {
+      if (!isPro()) {
+        options.onProRequired?.();
+        return;
+      }
       const view = getCurrentView();
       const pad = (n: number): string => String(n).padStart(2, "0");
       const d = view.timeUtc;

--- a/src/ui/panel.test.ts
+++ b/src/ui/panel.test.ts
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createPanel } from "./panel";
+import { setUser } from "../features";
 import type { UIIntent } from "./index";
 
 describe("createPanel", () => {
@@ -8,6 +9,11 @@ describe("createPanel", () => {
 
   beforeEach(() => {
     container = document.createElement("div");
+    globalThis.localStorage?.clear();
+  });
+
+  afterEach(() => {
+    globalThis.localStorage?.clear();
   });
 
   it("returns an object with element, setContent, and setCollapsed", () => {
@@ -209,23 +215,24 @@ describe("createPanel", () => {
 
     it("renders the 🌃 icon while in planetarium mode", () => {
       const { element } = createPanel(container, vi.fn(), { mode: "planetarium" });
-      const btn = element.querySelector<HTMLButtonElement>("[data-testid='panel-mode']")!;
-      expect(btn.textContent).toBe("\u{1F303}");
+      const icon = element.querySelector<HTMLElement>("[data-testid='panel-mode-icon']")!;
+      expect(icon.textContent).toBe("\u{1F303}");
     });
 
     it("renders the 📓 icon while in notebook mode", () => {
       const { element } = createPanel(container, vi.fn(), { mode: "notebook" });
-      const btn = element.querySelector<HTMLButtonElement>("[data-testid='panel-mode']")!;
-      expect(btn.textContent).toBe("\u{1F4D3}");
+      const icon = element.querySelector<HTMLElement>("[data-testid='panel-mode-icon']")!;
+      expect(icon.textContent).toBe("\u{1F4D3}");
     });
 
     it("defaults the icon to 🌃 when no mode is provided (planetarium default)", () => {
       const { element } = createPanel(container, vi.fn());
-      const btn = element.querySelector<HTMLButtonElement>("[data-testid='panel-mode']")!;
-      expect(btn.textContent).toBe("\u{1F303}");
+      const icon = element.querySelector<HTMLElement>("[data-testid='panel-mode-icon']")!;
+      expect(icon.textContent).toBe("\u{1F303}");
     });
 
-    it("clicking in planetarium mode dispatches set-mode notebook", () => {
+    it("clicking in planetarium mode dispatches set-mode notebook (Pro user)", () => {
+      setUser("rob.sartin@gmail.com");
       const dispatch = vi.fn();
       const { element } = createPanel(container, dispatch, { mode: "planetarium" });
       const btn = element.querySelector<HTMLButtonElement>("[data-testid='panel-mode']")!;
@@ -233,6 +240,39 @@ describe("createPanel", () => {
       expect(dispatch).toHaveBeenCalledWith({
         type: "set-mode",
         mode: "notebook",
+      } satisfies UIIntent);
+    });
+
+    it("clicking in planetarium mode invokes onProRequired instead of dispatching when non-Pro", () => {
+      const dispatch = vi.fn();
+      const onProRequired = vi.fn();
+      const { element } = createPanel(container, dispatch, {
+        mode: "planetarium",
+        onProRequired,
+      });
+      const btn = element.querySelector<HTMLButtonElement>("[data-testid='panel-mode']")!;
+      btn.click();
+      expect(onProRequired).toHaveBeenCalledTimes(1);
+      expect(dispatch).not.toHaveBeenCalledWith(
+        expect.objectContaining({ type: "set-mode" }) as unknown as UIIntent,
+      );
+    });
+
+    it("clicking in notebook mode ALWAYS dispatches set-mode planetarium (exit is free)", () => {
+      // Even a non-Pro user (e.g. edge case where they're somehow in notebook
+      // mode via stale URL) can always exit back to planetarium.
+      const dispatch = vi.fn();
+      const onProRequired = vi.fn();
+      const { element } = createPanel(container, dispatch, {
+        mode: "notebook",
+        onProRequired,
+      });
+      const btn = element.querySelector<HTMLButtonElement>("[data-testid='panel-mode']")!;
+      btn.click();
+      expect(onProRequired).not.toHaveBeenCalled();
+      expect(dispatch).toHaveBeenCalledWith({
+        type: "set-mode",
+        mode: "planetarium",
       } satisfies UIIntent);
     });
 
@@ -249,12 +289,36 @@ describe("createPanel", () => {
 
     it("setMode updates the button icon", () => {
       const { element, setMode } = createPanel(container, vi.fn(), { mode: "planetarium" });
-      const btn = element.querySelector<HTMLButtonElement>("[data-testid='panel-mode']")!;
-      expect(btn.textContent).toBe("\u{1F303}");
+      const icon = element.querySelector<HTMLElement>("[data-testid='panel-mode-icon']")!;
+      expect(icon.textContent).toBe("\u{1F303}");
       setMode("notebook");
-      expect(btn.textContent).toBe("\u{1F4D3}");
+      expect(icon.textContent).toBe("\u{1F4D3}");
       setMode("planetarium");
-      expect(btn.textContent).toBe("\u{1F303}");
+      expect(icon.textContent).toBe("\u{1F303}");
+    });
+  });
+
+  describe("mode-toggle Pro pill", () => {
+    beforeEach(() => {
+      globalThis.localStorage?.clear();
+    });
+
+    afterEach(() => {
+      globalThis.localStorage?.clear();
+    });
+
+    it("renders a 'Pro' pill inside the mode-toggle button when the user is not Pro", () => {
+      const { element } = createPanel(container, vi.fn());
+      const pill = element.querySelector<HTMLElement>("[data-testid='panel-mode-pro']");
+      expect(pill).not.toBeNull();
+      expect(pill!.textContent).toMatch(/pro/i);
+    });
+
+    it("does not render the 'Pro' pill when the user is Pro", () => {
+      setUser("rob.sartin@gmail.com");
+      const { element } = createPanel(container, vi.fn());
+      const pill = element.querySelector<HTMLElement>("[data-testid='panel-mode-pro']");
+      expect(pill).toBeNull();
     });
   });
 

--- a/src/ui/panel.ts
+++ b/src/ui/panel.ts
@@ -1,4 +1,5 @@
 /* SPDX-License-Identifier: Apache-2.0 */
+import { isPro } from "../features";
 import {
   PANEL_BG,
   PANEL_BORDER,
@@ -27,6 +28,13 @@ export type PanelOptions = {
   onOpenEvents?: () => void;
   onOpenSettings?: () => void;
   onOpenTonight?: () => void;
+  /**
+   * Invoked when a non-Pro user clicks the mode-toggle while planetarium is
+   * the active mode (i.e. they're trying to enter Notebook). When supplied,
+   * the panel calls this instead of dispatching `set-mode` so the caller can
+   * open the email-gate modal. No-op fallback is safe.
+   */
+  onProRequired?: () => void;
   /** Current app mode — controls the 🌃/📓 toggle icon. Defaults to "planetarium". */
   mode?: AppMode;
 };
@@ -109,9 +117,35 @@ export function createPanel(
   let currentMode: AppMode = options.mode ?? "planetarium";
   const modeBtn = document.createElement("button");
   modeBtn.dataset.testid = "panel-mode";
-  modeBtn.textContent = currentMode === "notebook" ? MODE_ICON_NOTEBOOK : MODE_ICON_PLANETARIUM;
   modeBtn.title = "Toggle Planetarium / Notebook";
   applyButton(modeBtn);
+  modeBtn.style.display = "inline-flex";
+  modeBtn.style.alignItems = "center";
+  modeBtn.style.gap = "4px";
+
+  const modeIcon = document.createElement("span");
+  modeIcon.dataset.testid = "panel-mode-icon";
+  modeIcon.textContent = currentMode === "notebook" ? MODE_ICON_NOTEBOOK : MODE_ICON_PLANETARIUM;
+  modeBtn.appendChild(modeIcon);
+
+  // Pro pill: shown only when the current user isn't on the Pro allowlist.
+  // Discoverable but quiet — signals that Notebook mode is a paid feature
+  // without hiding the toggle (the CTA itself is a conversion surface).
+  if (!isPro()) {
+    const pill = document.createElement("span");
+    pill.dataset.testid = "panel-mode-pro";
+    pill.textContent = "Pro";
+    pill.style.background = "rgba(0,255,136,0.18)";
+    pill.style.border = "1px solid rgba(0,255,136,0.5)";
+    pill.style.borderRadius = "8px";
+    pill.style.color = "#00ff88";
+    pill.style.fontSize = "9px";
+    pill.style.fontWeight = "600";
+    pill.style.letterSpacing = "0.05em";
+    pill.style.padding = "0 5px";
+    pill.style.textTransform = "uppercase";
+    modeBtn.appendChild(pill);
+  }
 
   const toggleBtn = document.createElement("button");
   toggleBtn.dataset.testid = "panel-toggle";
@@ -164,6 +198,12 @@ export function createPanel(
 
   modeBtn.addEventListener("click", () => {
     const next: AppMode = currentMode === "planetarium" ? "notebook" : "planetarium";
+    // Gate entry into notebook mode for non-Pro users. Exit back to
+    // planetarium is always free.
+    if (next === "notebook" && !isPro()) {
+      options.onProRequired?.();
+      return;
+    }
     dispatch({ type: "set-mode", mode: next });
   });
 
@@ -219,7 +259,7 @@ export function createPanel(
 
   function setMode(mode: AppMode): void {
     currentMode = mode;
-    modeBtn.textContent = mode === "notebook" ? MODE_ICON_NOTEBOOK : MODE_ICON_PLANETARIUM;
+    modeIcon.textContent = mode === "notebook" ? MODE_ICON_NOTEBOOK : MODE_ICON_PLANETARIUM;
   }
 
   return { element: panel, setContent, setCollapsed, setNightVision, setMode };


### PR DESCRIPTION
## Summary
- Introduces `src/features.ts` — a tiny bundle-time email allowlist + localStorage-persisted identity. Exports `PRO_EMAIL_ALLOWLIST`, `getUser` / `setUser` / `clearUser`, `isPro`. Rob's email is the only allowlisted address today.
- Adds `src/ui/email-gate-modal.ts` — centered dark-theme modal (Esc + backdrop closes) with an email input, Continue, and Cancel. On a successful (allowlisted) email the modal closes and fires `onGranted`; on a miss it swaps to a "request access" state with a `mailto:rob.sartin@gmail.com` button.
- Gates Notebook mode behind `isPro()` at two layers:
  - `src/app.ts` `set-mode` intent handler: non-Pro attempts to enter `notebook` open the gate modal instead of flipping. `onGranted` re-dispatches the intent so the flip lands once the user is on the allowlist.
  - `src/ui/panel.ts` mode-toggle button: non-Pro clicks call `onProRequired` directly (defense in depth + cleaner UX — the modal appears without a no-op mode flip).
- Gates the Insert-link button in `src/ui/notebook-workspace.ts` via a new optional `onProRequired` callback — non-Pro clicks open the gate modal; Pro users insert as today.
- Renders a small "Pro" pill next to the mode-toggle icon and next to the Insert-link label whenever the viewer isn't on the allowlist. The buttons themselves stay visible — they're the conversion surface.

**Why this shape.** Rung 1 of the entitlement ladder is trivially bypassable (view source), and that's fine for a private beta. Rung 2 (signed JWT) and Rung 3 (Cloudflare Access) land in follow-ups (#217+).

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm format:check`
- [x] `pnpm test:cov` — 1138 passed, `src/features.ts` at 100% line/branch, `src/app.ts` at 90.52% line / 73.91% branch (both comfortably above their thresholds)
- [x] `pnpm build`
- [ ] Manual: in a fresh browser, click the mode-toggle while non-Pro — gate modal appears, entering a non-allowlisted email shows the mailto CTA, entering `rob.sartin@gmail.com` flips into Notebook and persists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)