### PR TITLE
feat(2c): magic-link auth — Worker + D1 + client hooks (closes #218)

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -3,7 +3,7 @@ module.exports = {
   root: true,
   parser: "@typescript-eslint/parser",
   parserOptions: {
-    project: ["./tsconfig.json", "./tsconfig.node.json"],
+    project: ["./tsconfig.json", "./tsconfig.node.json", "./tsconfig.worker.json"],
     tsconfigRootDir: __dirname,
     sourceType: "module",
     ecmaVersion: 2022,

--- a/NOTICE
+++ b/NOTICE
@@ -39,6 +39,26 @@ Copyright (c) 2024 Mario Heiderich (https://cure53.de/)
 License: Apache-2.0 OR MPL-2.0 (consumed under Apache-2.0)
 https://github.com/cure53/DOMPurify
 
+@cloudflare/vitest-pool-workers (dev dependency)
+Copyright (c) Cloudflare, Inc.
+License: MIT
+https://github.com/cloudflare/workers-sdk
+
+@cloudflare/workers-types (dev dependency)
+Copyright (c) Cloudflare, Inc.
+License: MIT OR Apache-2.0 (consumed under Apache-2.0)
+https://github.com/cloudflare/workerd
+
+concurrently (dev dependency)
+Copyright (c) 2015 Kimmo Brunfeldt
+License: MIT
+https://github.com/open-cli-tools/concurrently
+
+wrangler (dev dependency)
+Copyright (c) Cloudflare, Inc.
+License: MIT OR Apache-2.0 (consumed under Apache-2.0)
+https://github.com/cloudflare/workers-sdk
+
 TLE data from CelesTrak (https://celestrak.org)
 Dr. T.S. Kelso. Used with attribution.
 

--- a/README.md
+++ b/README.md
@@ -59,15 +59,30 @@ See [`docs/architecture.md`](docs/architecture.md) for Mermaid diagrams covering
 ## Commands
 
     pnpm install       # install deps
-    pnpm dev           # local dev server on http://localhost:5173
-    pnpm typecheck     # tsc --noEmit
+    pnpm dev           # local dev: vite + wrangler dev in parallel
+    pnpm dev:client    # just the SPA (Vite) on http://localhost:5173
+    pnpm dev:worker    # just the Worker (wrangler dev)
+    pnpm typecheck     # tsc --noEmit for SPA + Worker
     pnpm lint          # ESLint + SPDX header check
     pnpm format:check  # Prettier check
-    pnpm test          # Vitest
+    pnpm test          # Vitest (SPA tests under jsdom)
     pnpm test:cov      # Vitest with coverage (enforces thresholds)
+    pnpm test:worker   # Vitest for worker/ under the Cloudflare Workers pool
     pnpm build         # typecheck + production build to dist/
 
 A change is not "done" until `pnpm typecheck && pnpm lint && pnpm format:check && pnpm test:cov && pnpm build` all pass locally.
+
+### Worker / D1 local setup
+
+Phase 2 introduces a Worker + D1 backend. See [`worker/README.md`](worker/README.md)
+and [ADR 009](docs/adr/009-backend-selection.md). First-time setup:
+
+    wrangler d1 create planisphere-dev --local
+    wrangler d1 migrations apply planisphere-dev --local --config wrangler.worker.jsonc
+
+`pnpm dev` then runs Vite and `wrangler dev` in parallel. The magic-link
+email is stubbed to a `console.log` line on the Worker console — grep for
+`[auth] magic link for`.
 
 ## Quality gates
 

--- a/docs/adr/010-worker-deps.md
+++ b/docs/adr/010-worker-deps.md
@@ -1,0 +1,89 @@
+# ADR 010 — Worker dev deps: `@cloudflare/vitest-pool-workers` + `concurrently`
+
+**Date:** 2026-04-18
+**Status:** Accepted
+
+## Context
+
+[ADR 009](009-backend-selection.md) adopted Cloudflare Workers + D1 as the
+Phase 2 runtime. Implementing milestone 2C (#218 — magic-link auth) stands up
+the first Worker code in this repo under a new top-level `worker/` directory.
+
+Two small tooling decisions fall out of that:
+
+1. **How to test Worker code.** The Worker handlers use the Workers runtime
+   (`crypto.subtle`, D1 prepared statements, `Request`/`Response`). Vitest
+   running under `jsdom` (our existing `src/` test environment) doesn't
+   provide any of those, and mocking them by hand is both tedious and
+   unfaithful to the real runtime. Cloudflare ships an official Vitest
+   integration — `@cloudflare/vitest-pool-workers` — that runs each test
+   file inside a real `workerd` isolate, with a real D1 instance, bound
+   exactly as `wrangler dev` would bind them in development.
+2. **How to run the client SPA and the Worker together in local dev.**
+   `pnpm dev` must still launch Vite for the SPA; a new `pnpm dev:worker`
+   launches `wrangler dev`; and `pnpm dev` itself should (optionally) run
+   both in parallel so contributors don't have to juggle two terminals.
+
+## Decision
+
+Add two **dev-only** dependencies:
+
+- **`@cloudflare/vitest-pool-workers`** — official Cloudflare Vitest pool
+  that spins up a workerd isolate per test file. License: MIT. Keeps
+  Worker tests colocated with the code they exercise (`worker/*.test.ts`)
+  and gives them the real runtime, including D1 bindings via in-memory
+  SQLite. Referenced from a separate `vitest.worker.config.ts` so the
+  existing `src/**` Vitest run — under `jsdom`, with the Phase-1 coverage
+  gates — is completely untouched.
+- **`concurrently`** — runs multiple commands in parallel from one
+  `package.json` script, with interleaved, prefixed output and unified
+  Ctrl-C handling. License: MIT. ~20 KB install footprint, no runtime
+  impact. Used only to orchestrate `pnpm dev` = `vite` + `wrangler dev`.
+
+Neither dep ships in the production bundle. Both are MIT — compatible with
+our Apache 2.0 license.
+
+## Consequences
+
+- **Worker test fidelity.** Tests hit real `crypto.subtle`, real `Request`
+  semantics, and a real D1 binding. Regressions caused by jsdom polyfills
+  diverging from workerd can't happen, because jsdom is not in the path.
+- **Two Vitest configs.** `vitest.config.ts` (existing, `src/**`, jsdom)
+  stays the source of truth for Phase-1 coverage gates and is run by
+  `pnpm test` / `pnpm test:cov`. A new `vitest.worker.config.ts` runs
+  `worker/**/*.test.ts` under the Workers pool. A new
+  `pnpm test:worker` script runs the latter. `pnpm test:cov` does **not**
+  include Worker tests in its coverage numbers — per the PR scope,
+  `worker/**` doesn't count toward existing thresholds yet, and a
+  follow-up issue will decide what the Worker coverage gate looks like.
+- **Typecheck covers both.** `tsconfig.json` adds a project reference to
+  `tsconfig.worker.json`, so `pnpm typecheck` (`tsc --noEmit -b`) covers
+  `worker/` and `src/` in one command. No separate Worker typecheck
+  script.
+- **Dev loop.** `pnpm dev` runs `concurrently "vite" "wrangler dev"` so
+  both the SPA and the Worker are live. `pnpm dev:client` and
+  `pnpm dev:worker` remain available for contributors who want just one.
+- **No runtime cost.** Both deps are `devDependencies`. Production bundle
+  size and Worker deploy artifact are unaffected.
+- **Reversibility.** If the Vitest Workers pool ever misbehaves we can
+  fall back to hand-mocking `crypto.subtle` and stubbing D1, at the cost
+  of test fidelity. `concurrently` is swappable for `npm-run-all` or
+  shell `&` without friction.
+
+## Alternatives considered
+
+- **Miniflare directly.** Miniflare underlies the Vitest pool; we could
+  script it by hand. Rejected because the official pool already wires
+  vitest ↔ miniflare ↔ D1, test-scoped isolates, and bindings based on
+  `wrangler.jsonc`. Rolling it ourselves is strictly more code for no
+  new capability.
+- **jsdom + manual stubs for Worker code.** Rejected. The Worker uses
+  `crypto.subtle.importKey` / `sign`, and D1 prepared statements — both
+  sufficiently large surfaces that stubbing them faithfully is more work
+  than adopting the Cloudflare pool, and strictly less accurate.
+- **`npm-run-all` instead of `concurrently`.** Comparable; `concurrently`
+  picked for its interleaved-output format and unified Ctrl-C. Both are
+  MIT; the choice is stylistic.
+- **Shell `&` in the dev script.** Works but cross-platform-hostile
+  (Windows contributors), no prefixed output, no unified interrupt.
+  Rejected.

--- a/migrations/0001_init.sql
+++ b/migrations/0001_init.sql
@@ -1,0 +1,28 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Initial schema: users, magic-link tokens, sessions.
+-- See worker/README.md for the auth flow.
+
+CREATE TABLE users (
+  id INTEGER PRIMARY KEY,
+  email TEXT UNIQUE NOT NULL,
+  tier TEXT NOT NULL DEFAULT 'free',
+  created_at INTEGER NOT NULL
+);
+
+CREATE TABLE magic_links (
+  token TEXT PRIMARY KEY,
+  email TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  used_at INTEGER
+);
+
+CREATE TABLE sessions (
+  id TEXT PRIMARY KEY,
+  user_id INTEGER NOT NULL,
+  created_at INTEGER NOT NULL,
+  expires_at INTEGER NOT NULL,
+  FOREIGN KEY (user_id) REFERENCES users(id)
+);
+
+CREATE INDEX idx_magic_links_email ON magic_links(email);
+CREATE INDEX idx_sessions_expires ON sessions(expires_at);

--- a/package.json
+++ b/package.json
@@ -11,24 +11,30 @@
   },
   "packageManager": "pnpm@9.12.0",
   "scripts": {
-    "dev": "vite",
-    "build": "tsc --noEmit && vite build",
+    "dev": "concurrently -n spa,worker -c cyan,magenta \"pnpm dev:client\" \"pnpm dev:worker\"",
+    "dev:client": "vite",
+    "dev:worker": "wrangler dev --config wrangler.worker.jsonc",
+    "build": "tsc --noEmit && tsc --noEmit -p tsconfig.worker.json && vite build",
     "preview": "vite preview",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.worker.json",
     "lint": "eslint . --max-warnings=0 && node scripts/check-spdx.mjs",
     "lint:spdx": "node scripts/check-spdx.mjs",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:cov": "vitest run --coverage"
+    "test:cov": "vitest run --coverage",
+    "test:worker": "vitest run --config vitest.worker.config.ts"
   },
   "devDependencies": {
+    "@cloudflare/vitest-pool-workers": "^0.5.41",
+    "@cloudflare/workers-types": "^4.20260418.1",
     "@types/jsdom": "~21.1.7",
     "@types/node": "~20.14.12",
     "@typescript-eslint/eslint-plugin": "~7.18.0",
     "@typescript-eslint/parser": "~7.18.0",
     "@vitest/coverage-v8": "~2.1.2",
+    "concurrently": "^9.2.1",
     "eslint": "~8.57.0",
     "eslint-config-prettier": "~9.1.0",
     "jsdom": "~25.0.0",
@@ -36,7 +42,8 @@
     "typescript": "~5.5.4",
     "vite": "~6.4.2",
     "vite-plugin-cesium": "^1.2.23",
-    "vitest": "~2.1.2"
+    "vitest": "~2.1.2",
+    "wrangler": "^4.83.0"
   },
   "dependencies": {
     "astronomy-engine": "^2.1.19",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,12 @@ importers:
         specifier: ^7.0.0
         version: 7.0.0
     devDependencies:
+      '@cloudflare/vitest-pool-workers':
+        specifier: ^0.5.41
+        version: 0.5.41(@cloudflare/workers-types@4.20260418.1)(@vitest/runner@2.1.9)(@vitest/snapshot@2.1.9)(vitest@2.1.9(@types/node@20.14.15)(jsdom@25.0.1))
+      '@cloudflare/workers-types':
+        specifier: ^4.20260418.1
+        version: 4.20260418.1
       '@types/jsdom':
         specifier: ~21.1.7
         version: 21.1.7
@@ -39,6 +45,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: ~2.1.2
         version: 2.1.9(vitest@2.1.9(@types/node@20.14.15)(jsdom@25.0.1))
+      concurrently:
+        specifier: ^9.2.1
+        version: 9.2.1
       eslint:
         specifier: ~8.57.0
         version: 8.57.1
@@ -63,6 +72,9 @@ importers:
       vitest:
         specifier: ~2.1.2
         version: 2.1.9(@types/node@20.14.15)(jsdom@25.0.1)
+      wrangler:
+        specifier: ^4.83.0
+        version: 4.83.0(@cloudflare/workers-types@4.20260418.1)
 
 packages:
 
@@ -104,6 +116,97 @@ packages:
     resolution: {integrity: sha512-h/hKVooXyOtUQJUtrfyBFGMIXb+Q3RLwqE6FzXfzyC0JQuuThLXCz8nRzCPbyiRuAR/aAYT/jbbhQrUxfiWqhQ==}
     engines: {node: '>=20.19.0'}
 
+  '@cloudflare/kv-asset-handler@0.3.4':
+    resolution: {integrity: sha512-YLPHc8yASwjNkmcDMQMY35yiWjoKAKnhUbPRszBRS0YgH+IXtsMp61j+yTcnCE3oO2DgP0U3iejLC8FTtKDC8Q==}
+    engines: {node: '>=16.13'}
+
+  '@cloudflare/kv-asset-handler@0.4.2':
+    resolution: {integrity: sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@cloudflare/unenv-preset@2.16.0':
+    resolution: {integrity: sha512-8ovsRpwzPoEqPUzoErAYVv8l3FMZNeBVQfJTvtzP4AgLSRGZISRfuChFxHWUQd3n6cnrwkuTGxT+2cGo8EsyYg==}
+    peerDependencies:
+      unenv: 2.0.0-rc.24
+      workerd: 1.20260301.1 || ~1.20260302.1 || ~1.20260303.1 || ~1.20260304.1 || >1.20260305.0 <2.0.0-0
+    peerDependenciesMeta:
+      workerd:
+        optional: true
+
+  '@cloudflare/vitest-pool-workers@0.5.41':
+    resolution: {integrity: sha512-J0uYmOKJgyo/az5nV8QHlR6xQ+HHB6S65tOEutkvUPbuPDbFlBPRT+XHJhSTNNvZGeM1t2qZIzxp0WGmXLtNlQ==}
+    peerDependencies:
+      '@vitest/runner': 2.0.x - 2.1.x
+      '@vitest/snapshot': 2.0.x - 2.1.x
+      vitest: 2.0.x - 2.1.x
+
+  '@cloudflare/workerd-darwin-64@1.20241230.0':
+    resolution: {integrity: sha512-BZHLg4bbhNQoaY1Uan81O3FV/zcmWueC55juhnaI7NAobiQth9RppadPNpxNAmS9fK2mR5z8xrwMQSQrHmztyQ==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@cloudflare/workerd-darwin-64@1.20260415.1':
+    resolution: {integrity: sha512-dsxaKsQm3LnPGNPEdsRv09QN3Y4DqCw7kX5j6noKqbAtro2jTr95sVlYM1jUxZ5FkOl1f7SXgaKKB9t5H5Nkbg==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@cloudflare/workerd-darwin-arm64@1.20241230.0':
+    resolution: {integrity: sha512-lllxycj7EzYoJ0VOJh8M3palUgoonVrILnzGrgsworgWlIpgjfXGS7b41tEGCw6AxSxL9prmTIGtfSPUvn/rjg==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@cloudflare/workerd-darwin-arm64@1.20260415.1':
+    resolution: {integrity: sha512-+JgSgVA49KyKteHRA1SnonE4Zn5Ei5zdAp5FQMxFmXI8qulZw4Hl7safXxRyK4i9sTO8gl7TFOKO5Q64VPvSDQ==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@cloudflare/workerd-linux-64@1.20241230.0':
+    resolution: {integrity: sha512-Y3mHcW0KghOmWdNZyHYpEOG4Ba/ga8tht5vj1a+WXfagEjMO8Y98XhZUlCaYa9yB7Wh5jVcK5LM2jlO/BLgqpA==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [linux]
+
+  '@cloudflare/workerd-linux-64@1.20260415.1':
+    resolution: {integrity: sha512-tU+9pwsqCy8afOVlGtiWrWQc/fedQK4SRm4KPIAt+zOiQWDxWASm6YGBUJis5c648WN80yz47qnmdDi8DQNOcA==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [linux]
+
+  '@cloudflare/workerd-linux-arm64@1.20241230.0':
+    resolution: {integrity: sha512-IAjhsWPlHzhhkJ6I49sDG6XfMnhPvv0szKGXxTWQK/IWMrbGdHm4RSfNKBSoLQm67jGMIzbmcrX9UIkms27Y1g==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@cloudflare/workerd-linux-arm64@1.20260415.1':
+    resolution: {integrity: sha512-bR9uITnV19r5NQ14xnypi2xHXu2iQvfYV8cVgx0JouFUmWwTEEAwFVojDdssGq93VHX9hr/pi2IRUZeegbYBog==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@cloudflare/workerd-windows-64@1.20241230.0':
+    resolution: {integrity: sha512-y5SPIk9iOb2gz+yWtHxoeMnjPnkYQswiCJ480oHC6zexnJLlKTpcmBCjDH1nWCT4pQi8F25gaH8thgElf4NvXQ==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [win32]
+
+  '@cloudflare/workerd-windows-64@1.20260415.1':
+    resolution: {integrity: sha512-4NuMLlerI0Ijua3Ir8HXQ+qyNvCUDEG5gDco5Om+sAiK6rnWiz+aGoSlbB8W16yW9QAgzCstbmXLiVknUBflfQ==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [win32]
+
+  '@cloudflare/workers-types@4.20260418.1':
+    resolution: {integrity: sha512-bywXb2XmeSqrLCQYipcupLneqx015YhhNWz2v9b9iatpe8Cg551vP7ZuD5S2a6GfBka0dDnO70kIBiBvFglcrg==}
+
+  '@cspotcode/source-map-support@0.8.1':
+    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
+    engines: {node: '>=12'}
+
   '@csstools/color-helpers@5.1.0':
     resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
     engines: {node: '>=18'}
@@ -132,6 +235,19 @@ packages:
     resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
     engines: {node: '>=18'}
 
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+
+  '@esbuild-plugins/node-globals-polyfill@0.2.3':
+    resolution: {integrity: sha512-r3MIryXDeXDOZh7ih1l/yE9ZLORCd5e8vWg02azWRGj5SPTuoh69A2AIyn0Z31V/kHBfZ4HgWJ+OK3GTTwLmnw==}
+    peerDependencies:
+      esbuild: '*'
+
+  '@esbuild-plugins/node-modules-polyfill@0.2.2':
+    resolution: {integrity: sha512-LXV7QsWJxRuMYvKbiznh+U1ilIop3g2TeKRzUxOG5X3YITc8JyyTa90BmLwqqv0YnX4v32CSlG+vsziZp9dMvA==}
+    peerDependencies:
+      esbuild: '*'
+
   '@esbuild/aix-ppc64@0.21.5':
     resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
     engines: {node: '>=12'}
@@ -144,6 +260,18 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.27.3':
+    resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.17.19':
+    resolution: {integrity: sha512-KBMWvEZooR7+kzY0BtbTQn0OAYY7CsiydT63pVEaPtVYF0hXbUaOyZog37DKxK7NF3XacBJOpYT4adIJh+avxA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm64@0.21.5':
     resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
     engines: {node: '>=12'}
@@ -154,6 +282,18 @@ packages:
     resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.27.3':
+    resolution: {integrity: sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.17.19':
+    resolution: {integrity: sha512-rIKddzqhmav7MSmoFCmDIb6e2W57geRsM94gV2l38fzhXMwq7hZoClug9USI2pFRGL06f4IOPHHpFNOkWieR8A==}
+    engines: {node: '>=12'}
+    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.21.5':
@@ -168,6 +308,18 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.27.3':
+    resolution: {integrity: sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.17.19':
+    resolution: {integrity: sha512-uUTTc4xGNDT7YSArp/zbtmbhO0uEEK9/ETW29Wk1thYUJBz3IVnvgEiEwEa9IeLyvnpKrWK64Utw2bgUmDveww==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/android-x64@0.21.5':
     resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
     engines: {node: '>=12'}
@@ -180,6 +332,18 @@ packages:
     cpu: [x64]
     os: [android]
 
+  '@esbuild/android-x64@0.27.3':
+    resolution: {integrity: sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.17.19':
+    resolution: {integrity: sha512-80wEoCfF/hFKM6WE1FyBHc9SfUblloAWx6FJkFWTWiCoht9Mc0ARGEM47e67W9rI09YoUxJL68WHfDRYEAvOhg==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.21.5':
     resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
     engines: {node: '>=12'}
@@ -190,6 +354,18 @@ packages:
     resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-arm64@0.27.3':
+    resolution: {integrity: sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.17.19':
+    resolution: {integrity: sha512-IJM4JJsLhRYr9xdtLytPLSH9k/oxR3boaUIYiHkAawtwNOXKE8KoU8tMvryogdcT8AU+Bflmh81Xn6Q0vTZbQw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.21.5':
@@ -204,6 +380,18 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/darwin-x64@0.27.3':
+    resolution: {integrity: sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.17.19':
+    resolution: {integrity: sha512-pBwbc7DufluUeGdjSU5Si+P3SoMF5DQ/F/UmTSb8HXO80ZEAJmrykPyzo1IfNbAoaqw48YRpv8shwd1NoI0jcQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.21.5':
     resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
     engines: {node: '>=12'}
@@ -214,6 +402,18 @@ packages:
     resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-arm64@0.27.3':
+    resolution: {integrity: sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.17.19':
+    resolution: {integrity: sha512-4lu+n8Wk0XlajEhbEffdy2xy53dpR06SlzvhGByyg36qJw6Kpfk7cp45DR/62aPH9mtJRmIyrXAS5UWBrJT6TQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.21.5':
@@ -228,6 +428,18 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/freebsd-x64@0.27.3':
+    resolution: {integrity: sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.17.19':
+    resolution: {integrity: sha512-ct1Tg3WGwd3P+oZYqic+YZF4snNl2bsnMKRkb3ozHmnM0dGWuxcPTTntAF6bOP0Sp4x0PjSF+4uHQ1xvxfRKqg==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.21.5':
     resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
     engines: {node: '>=12'}
@@ -238,6 +450,18 @@ packages:
     resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm64@0.27.3':
+    resolution: {integrity: sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.17.19':
+    resolution: {integrity: sha512-cdmT3KxjlOQ/gZ2cjfrQOtmhG4HJs6hhvm3mWSRDPtZ/lP5oe8FWceS10JaSJC13GBd4eH/haHnqf7hhGNLerA==}
+    engines: {node: '>=12'}
+    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.21.5':
@@ -252,6 +476,18 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-arm@0.27.3':
+    resolution: {integrity: sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.17.19':
+    resolution: {integrity: sha512-w4IRhSy1VbsNxHRQpeGCHEmibqdTUx61Vc38APcsRbuVgK0OPEnQ0YD39Brymn96mOx48Y2laBQGqgZ0j9w6SQ==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.21.5':
     resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
     engines: {node: '>=12'}
@@ -262,6 +498,18 @@ packages:
     resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.3':
+    resolution: {integrity: sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.17.19':
+    resolution: {integrity: sha512-2iAngUbBPMq439a+z//gE+9WBldoMp1s5GWsUSgqHLzLJ9WoZLZhpwWuym0u0u/4XmZ3gpHmzV84PonE+9IIdQ==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.21.5':
@@ -276,6 +524,18 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-loong64@0.27.3':
+    resolution: {integrity: sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.17.19':
+    resolution: {integrity: sha512-LKJltc4LVdMKHsrFe4MGNPp0hqDFA1Wpt3jE1gEyM3nKUvOiO//9PheZZHfYRfYl6AwdTH4aTcXSqBerX0ml4A==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.21.5':
     resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
     engines: {node: '>=12'}
@@ -286,6 +546,18 @@ packages:
     resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.3':
+    resolution: {integrity: sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.17.19':
+    resolution: {integrity: sha512-/c/DGybs95WXNS8y3Ti/ytqETiW7EU44MEKuCAcpPto3YjQbyK3IQVKfF6nbghD7EcLUGl0NbiL5Rt5DMhn5tg==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.21.5':
@@ -300,6 +572,18 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-ppc64@0.27.3':
+    resolution: {integrity: sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.17.19':
+    resolution: {integrity: sha512-FC3nUAWhvFoutlhAkgHf8f5HwFWUL6bYdvLc/TTuxKlvLi3+pPzdZiFKSWz/PF30TB1K19SuCxDTI5KcqASJqA==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.21.5':
     resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
     engines: {node: '>=12'}
@@ -310,6 +594,18 @@ packages:
     resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
     engines: {node: '>=18'}
     cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.3':
+    resolution: {integrity: sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.17.19':
+    resolution: {integrity: sha512-IbFsFbxMWLuKEbH+7sTkKzL6NJmG2vRyy6K7JJo55w+8xDk7RElYn6xvXtDW8HCfoKBFK69f3pgBJSUSQPr+4Q==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-s390x@0.21.5':
@@ -324,6 +620,18 @@ packages:
     cpu: [s390x]
     os: [linux]
 
+  '@esbuild/linux-s390x@0.27.3':
+    resolution: {integrity: sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.17.19':
+    resolution: {integrity: sha512-68ngA9lg2H6zkZcyp22tsVt38mlhWde8l3eJLWkyLrp4HwMUr3c1s/M2t7+kHIhvMjglIBrFpncX1SzMckomGw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/linux-x64@0.21.5':
     resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
     engines: {node: '>=12'}
@@ -336,10 +644,28 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.27.3':
+    resolution: {integrity: sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/netbsd-arm64@0.25.12':
     resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.17.19':
+    resolution: {integrity: sha512-CwFq42rXCR8TYIjIfpXCbRX0rp1jo6cPIUPSaWwzbVI4aOfX96OXY8M6KNmtPcg7QjYeDmN+DD0Wp3LaBOLf4Q==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [netbsd]
 
   '@esbuild/netbsd-x64@0.21.5':
@@ -354,10 +680,28 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.27.3':
+    resolution: {integrity: sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/openbsd-arm64@0.25.12':
     resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.17.19':
+    resolution: {integrity: sha512-cnq5brJYrSZ2CF6c35eCmviIN3k3RczmHz8eYaVlNasVqsNY+JKohZU5MKmaOI+KkllCdzOKKdPs762VCPC20g==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.21.5':
@@ -372,11 +716,29 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.27.3':
+    resolution: {integrity: sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/openharmony-arm64@0.25.12':
     resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.27.3':
+    resolution: {integrity: sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.17.19':
+    resolution: {integrity: sha512-vCRT7yP3zX+bKWFeP/zdS6SqdWB8OIpaRq/mbXQxTGHnIxspRtigpkUcDMlSCOejlHowLqII7K2JKevwyRP2rg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
 
   '@esbuild/sunos-x64@0.21.5':
     resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
@@ -390,6 +752,18 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/sunos-x64@0.27.3':
+    resolution: {integrity: sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.17.19':
+    resolution: {integrity: sha512-yYx+8jwowUstVdorcMdNlzklLYhPxjniHWFKgRqH7IFlUEa0Umu3KuYplf1HUZZ422e3NU9F4LGb+4O0Kdcaag==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-arm64@0.21.5':
     resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
     engines: {node: '>=12'}
@@ -400,6 +774,18 @@ packages:
     resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.27.3':
+    resolution: {integrity: sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.17.19':
+    resolution: {integrity: sha512-eggDKanJszUtCdlVs0RB+h35wNlb5v4TWEkq4vZcmVt5u/HiDZrTXe2bWFQUez3RgNHwx/x4sk5++4NSSicKkw==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
     os: [win32]
 
   '@esbuild/win32-ia32@0.21.5':
@@ -414,6 +800,18 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.27.3':
+    resolution: {integrity: sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.17.19':
+    resolution: {integrity: sha512-lAhycmKnVOuRYNtRtatQR1LPQf2oYCkRGkSFnseDAKPl8lu5SOsK/e1sXe5a0Pc5kHIHe6P2I/ilntNv2xf3cA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
   '@esbuild/win32-x64@0.21.5':
     resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
     engines: {node: '>=12'}
@@ -422,6 +820,12 @@ packages:
 
   '@esbuild/win32-x64@0.25.12':
     resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.3':
+    resolution: {integrity: sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -444,6 +848,10 @@ packages:
     resolution: {integrity: sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
+  '@fastify/busboy@2.1.1':
+    resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
+    engines: {node: '>=14'}
+
   '@humanwhocodes/config-array@0.13.0':
     resolution: {integrity: sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==}
     engines: {node: '>=10.10.0'}
@@ -456,6 +864,143 @@ packages:
   '@humanwhocodes/object-schema@2.0.3':
     resolution: {integrity: sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==}
     deprecated: Use @eslint/object-schema instead
+
+  '@img/colour@1.1.0':
+    resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
+    engines: {node: '>=18'}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.34.5':
+    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
+    cpu: [arm]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-linux-arm64@0.34.5':
+    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-linux-arm@0.34.5':
+    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@img/sharp-linux-s390x@0.34.5':
+    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@img/sharp-linux-x64@0.34.5':
+    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-wasm32@0.34.5':
+    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [wasm32]
+
+  '@img/sharp-win32-arm64@0.34.5':
+    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@img/sharp-win32-ia32@0.34.5':
+    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.34.5':
+    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [win32]
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -478,6 +1023,9 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@jridgewell/trace-mapping@0.3.9':
+    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -493,6 +1041,15 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@poppinss/colors@4.1.6':
+    resolution: {integrity: sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==}
+
+  '@poppinss/dumper@0.6.5':
+    resolution: {integrity: sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==}
+
+  '@poppinss/exception@1.2.3':
+    resolution: {integrity: sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==}
 
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
@@ -653,6 +1210,13 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@sindresorhus/is@7.2.0':
+    resolution: {integrity: sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==}
+    engines: {node: '>=18'}
+
+  '@speed-highlight/core@1.2.15':
+    resolution: {integrity: sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw==}
+
   '@spz-loader/core@0.3.1':
     resolution: {integrity: sha512-8qJ1WIBXaJu8HjnJAjYniE0kYcr0kCe5Hp7kDzYiGVvvd7zyrOBwbF5imoW5mvwx1Qba0hxGEK5R9jEoaHKJFA==}
     engines: {node: '>=16', pnpm: '>=8'}
@@ -665,6 +1229,9 @@ packages:
 
   '@types/jsdom@21.1.7':
     resolution: {integrity: sha512-yOriVnggzrnQ3a9OKOCxaVuSug3w3/SbOj5i7VwXWZEyUNl3bLF9V3MfxGbZKuwqJOQyRfqXyROBB1CoZLFWzA==}
+
+  '@types/node-forge@1.3.14':
+    resolution: {integrity: sha512-mhVF2BnD4BO+jtOp7z1CdzaK4mbuK0LLQYAvdOLqHTavxFNq4zA1EmYkpnFjP8HOUzedfQkRnp0E2ulSAYSzAw==}
 
   '@types/node@20.14.15':
     resolution: {integrity: sha512-Fz1xDMCF/B00/tYSVMlmK7hVeLh7jE5f3B7X1/hmV0MJBwE27KlS7EvD/Yp+z1lm8mVhwV5w+n8jOZG8AfTlKw==}
@@ -783,6 +1350,10 @@ packages:
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
 
+  acorn-walk@8.3.5:
+    resolution: {integrity: sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==}
+    engines: {node: '>=0.4.0'}
+
   acorn@8.16.0:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
@@ -818,6 +1389,9 @@ packages:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
     engines: {node: '>=8'}
 
+  as-table@1.0.55:
+    resolution: {integrity: sha512-xvsWESUJn0JN421Xb9MQw6AsMHRCUknCe0Wjlxvjud80mU4E6hQf1A6NzQKcYNmYw62MfzEtXc+badstZP3JpQ==}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -843,8 +1417,14 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
+  birpc@0.2.14:
+    resolution: {integrity: sha512-37FHE8rqsYM5JEKCnXFyHpBCzvgHEExwVVTq+nUmloInU7l8ezD1TpOhKpS8oe1DTYFqEK27rFZVKG43oTqXRA==}
+
   bitmap-sdf@1.0.4:
     resolution: {integrity: sha512-1G3U4n5JE6RAiALMxu0p1XmeZkTeCwGKykzsLTCqVzfSDaN6S7fKnkIkfejogz+iwqBWc0UYAIKnKHNN7pSfDg==}
+
+  blake3-wasm@2.1.5:
+    resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
 
   brace-expansion@1.1.14:
     resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
@@ -872,6 +1452,9 @@ packages:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
 
+  capnp-ts@0.7.0:
+    resolution: {integrity: sha512-XKxXAC3HVPv7r674zP0VC3RTXz+/JKhfyw94ljvF80yynK6VkTnqE3jMuN8b3dUVmmc43TjyxjW4KTsmB3c86g==}
+
   cesium@1.140.0:
     resolution: {integrity: sha512-3RvW0rvZWuXiS6regtNE5u9vt0uXohgpsRBIo6Qc922IIIamkitYiEdr4fg+u4qX4EoK9xS3BosCza7iPOExEQ==}
     engines: {node: '>=20.19.0'}
@@ -887,6 +1470,17 @@ packages:
   check-error@2.1.3:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
     engines: {node: '>= 16'}
+
+  chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
+
+  cjs-module-lexer@1.4.3:
+    resolution: {integrity: sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==}
+
+  cliui@8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -905,6 +1499,22 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
+  concurrently@9.2.1:
+    resolution: {integrity: sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  confbox@0.1.8:
+    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -913,9 +1523,15 @@ packages:
     resolution: {integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==}
     engines: {node: '>=18'}
 
+  data-uri-to-buffer@2.0.2:
+    resolution: {integrity: sha512-ND9qDTLc6diwj+Xe5cdAgVTbLVdXbtxTJRXRhli8Mowuaan+0EJOtdqJ0QCHNSSPyoXGx9HX2/VMnKeC34AChA==}
+
   data-urls@5.0.0:
     resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
     engines: {node: '>=18'}
+
+  date-fns@4.1.0:
+    resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
 
   debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
@@ -944,6 +1560,9 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
+  defu@6.1.7:
+    resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
+
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
@@ -955,6 +1574,13 @@ packages:
   destroy@1.2.0:
     resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  devalue@4.3.3:
+    resolution: {integrity: sha512-UH8EL6H2ifcY8TbD2QsxwCC/pr5xSwPvv85LrLXVihmHVC3T3YqTCIwnR5ak0yO1KYqlxrPVOA/JVZJYPy2ATg==}
 
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
@@ -997,6 +1623,9 @@ packages:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
 
+  error-stack-parser-es@1.0.5:
+    resolution: {integrity: sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==}
+
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
     engines: {node: '>= 0.4'}
@@ -1016,6 +1645,11 @@ packages:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
 
+  esbuild@0.17.19:
+    resolution: {integrity: sha512-XQ0jAPFkK/u3LcVRcvVHQcTIqD6E2H1fvZMA5dQPSOWb3suUbWbfbRf94pjc0bNzRYLfIrDRQXr7X+LHIm5oHw==}
+    engines: {node: '>=12'}
+    hasBin: true
+
   esbuild@0.21.5:
     resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
     engines: {node: '>=12'}
@@ -1025,6 +1659,15 @@ packages:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
     engines: {node: '>=18'}
     hasBin: true
+
+  esbuild@0.27.3:
+    resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
 
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
@@ -1069,6 +1712,9 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-walker@0.6.1:
+    resolution: {integrity: sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==}
+
   estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
@@ -1082,6 +1728,10 @@ packages:
   etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
+
+  exit-hook@2.2.1:
+    resolution: {integrity: sha512-eNTPlAD67BmP31LDINZ3U7HSF8l57TxOY2PmBJ1shpCvpnxBF93mWCE8YHBnXs8qiUZJc9WDcWIeC3a2HIAMfw==}
+    engines: {node: '>=6'}
 
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
@@ -1158,6 +1808,10 @@ packages:
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
@@ -1166,6 +1820,9 @@ packages:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
 
+  get-source@2.0.12:
+    resolution: {integrity: sha512-X5+4+iD+HoSeEED+uwrQ07BOQr0kEDFMVqqpBuI+RaZBpBpHCuXxo70bjar6f0b0u/DQJsJ7ssurpP0V60Az+w==}
+
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
@@ -1173,6 +1830,9 @@ packages:
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
+
+  glob-to-regexp@0.4.1:
+    resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
 
   glob@10.5.0:
     resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
@@ -1262,6 +1922,10 @@ packages:
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
+  is-core-module@2.16.1:
+    resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
+    engines: {node: '>= 0.4'}
+
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -1307,6 +1971,9 @@ packages:
     resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
     engines: {node: '>=8'}
 
+  itty-time@1.0.6:
+    resolution: {integrity: sha512-+P8IZaLLBtFv8hCkIjcymZOp4UJ+xW6bSlQsXGqrkmJh7vSiMFSlNne0mCYagEE0N7HDNR5jJBRxwN0oYv61Rw==}
+
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
@@ -1344,6 +2011,10 @@ packages:
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  kleur@4.1.5:
+    resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
+    engines: {node: '>=6'}
 
   ktx-parse@1.1.0:
     resolution: {integrity: sha512-mKp3y+FaYgR7mXWAbyyzpa/r1zDWeaunH+INJO4fou3hb45XuNSwar+7llrRyvpMWafxSIi99RNFJ05MHedaJQ==}
@@ -1420,6 +2091,21 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
 
+  mime@3.0.0:
+    resolution: {integrity: sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==}
+    engines: {node: '>=10.0.0'}
+    hasBin: true
+
+  miniflare@3.20241230.0:
+    resolution: {integrity: sha512-ZtWNoNAIj5Q0Vb3B4SPEKr7DDmVG8a0Stsp/AuRkYXoJniA5hsbKjFNIGhTXGMIHVP5bvDrKJWt/POIDGfpiKg==}
+    engines: {node: '>=16.13'}
+    hasBin: true
+
+  miniflare@4.20260415.0:
+    resolution: {integrity: sha512-JoExRWN4YBI2luA5BoSMFEgi8rQWXUGzo3mtE+58VXCLV3jj/Xnk5Yeqs/IXWz8Es5GJIaq6BtsixDvAxXSIng==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
@@ -1435,11 +2121,18 @@ packages:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
 
+  mlly@1.8.2:
+    resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
+
   ms@2.0.0:
     resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  mustache@4.2.0:
+    resolution: {integrity: sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==}
+    hasBin: true
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
@@ -1449,11 +2142,18 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
+  node-forge@1.4.0:
+    resolution: {integrity: sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==}
+    engines: {node: '>= 6.13.0'}
+
   nosleep.js@0.12.0:
     resolution: {integrity: sha512-9d1HbpKLh3sdWlhXMhU6MMH+wQzKkrgfRkYV0EBdvt99YJfj0ilCJrWRDYG2130Tm4GXbEoTCx5b34JSaP+HhA==}
 
   nwsapi@2.2.23:
     resolution: {integrity: sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==}
+
+  ohash@1.1.6:
+    resolution: {integrity: sha512-TBu7PtV8YkAZn0tSxobKY2n2aAQva936lhRrj6957aDaCf9IEtqsKbgMzXE/F/sjqYOwmrukeORHNLe5glk7Cg==}
 
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
@@ -1503,9 +2203,15 @@ packages:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
 
+  path-parse@1.0.7:
+    resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
   path-scurry@1.11.1:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
+
+  path-to-regexp@6.3.0:
+    resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
 
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -1513,6 +2219,9 @@ packages:
 
   pathe@1.1.2:
     resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
   pathval@2.0.1:
     resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
@@ -1529,6 +2238,9 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
+  pkg-types@1.3.1:
+    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
   postcss@8.5.10:
     resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
     engines: {node: ^10 || ^12 || >=14}
@@ -1541,6 +2253,9 @@ packages:
     resolution: {integrity: sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==}
     engines: {node: '>=14'}
     hasBin: true
+
+  printable-characters@1.0.42:
+    resolution: {integrity: sha512-dKp+C4iXWK4vVYZmYSd0KBH5F/h1HoZRsbJ82AVKRO3PEo8L4lBS/vLwhVtpwwuYcoIsVY+1JYKR268yn480uQ==}
 
   protobufjs@8.0.1:
     resolution: {integrity: sha512-NWWCCscLjs+cOKF/s/XVNFRW7Yih0fdH+9brffR5NZCy8k42yRdl5KlWKMVXuI1vfCoy4o1z80XR/W/QUb3V3w==}
@@ -1563,9 +2278,22 @@ packages:
   rbush@4.0.1:
     resolution: {integrity: sha512-IP0UpfeWQujYC8Jg162rMNc01Rf0gWMMAb2Uxus/Q0qOFw4lCcq6ZnQEZwUoJqWyUGJ9th7JjwI4yIWo+uvoAQ==}
 
+  readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
+
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
+
+  resolve@1.22.12:
+    resolution: {integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==}
+    engines: {node: '>= 0.4'}
+    hasBin: true
 
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
@@ -1581,6 +2309,16 @@ packages:
     peerDependencies:
       rollup: ^2.25.0
 
+  rollup-plugin-inject@3.0.2:
+    resolution: {integrity: sha512-ptg9PQwzs3orn4jkgXJ74bfs5vYz1NCZlSQMBUA0wKcGp5i5pA1AO3fOUEte8enhGUC+iapTCzEWw2jEFFUO/w==}
+    deprecated: This package has been deprecated and is no longer maintained. Please use @rollup/plugin-inject.
+
+  rollup-plugin-node-polyfills@0.2.1:
+    resolution: {integrity: sha512-4kCrKPTJ6sK4/gLL/U5QzVT8cxJcofO0OU74tnB19F40cmuAKSzH5/siithxlofFEjwvw1YAhPmbvGNA6jEroA==}
+
+  rollup-pluginutils@2.8.2:
+    resolution: {integrity: sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==}
+
   rollup@4.60.1:
     resolution: {integrity: sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -1595,6 +2333,9 @@ packages:
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
+  rxjs@7.8.2:
+    resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
+
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
@@ -1604,6 +2345,10 @@ packages:
   saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
     engines: {node: '>=v12.22.7'}
+
+  selfsigned@2.4.1:
+    resolution: {integrity: sha512-th5B4L2U+eGLq1TVh7zNRGBapioSORUeymIydxgFpwww9d2qyKvtuPU2jJuHvYAwwqi2Y596QBL3eEqcPEYL8Q==}
+    engines: {node: '>=10'}
 
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
@@ -1621,6 +2366,10 @@ packages:
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
+  sharp@0.34.5:
+    resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
     engines: {node: '>=8'}
@@ -1628,6 +2377,10 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  shell-quote@1.8.3:
+    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+    engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -1644,6 +2397,10 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  source-map@0.6.1:
+    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
+    engines: {node: '>=0.10.0'}
+
   sourcemap-codec@1.4.8:
     resolution: {integrity: sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==}
     deprecated: Please use @jridgewell/sourcemap-codec instead
@@ -1651,12 +2408,19 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
+  stacktracey@2.2.0:
+    resolution: {integrity: sha512-ETyQEz+CzXiLjEbyJqpbp+/T79RQD/6wqFucRBIlVNZfYq2Ay7wbretD4cxpbymZlaPWx58aIhPEY1Cr8DlVvg==}
+
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  stoppable@1.1.0:
+    resolution: {integrity: sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==}
+    engines: {node: '>=4', npm: '>=6'}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -1678,9 +2442,21 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
+  supports-color@10.2.2:
+    resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
+    engines: {node: '>=18'}
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
+
+  supports-color@8.1.1:
+    resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
+    engines: {node: '>=10'}
+
+  supports-preserve-symlinks-flag@1.0.0:
+    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
+    engines: {node: '>= 0.4'}
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
@@ -1741,6 +2517,10 @@ packages:
     resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
     engines: {node: '>=18'}
 
+  tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
+
   ts-api-utils@1.4.3:
     resolution: {integrity: sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==}
     engines: {node: '>=16'}
@@ -1763,8 +2543,25 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  ufo@1.6.3:
+    resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
+
   undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+
+  undici@5.29.0:
+    resolution: {integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==}
+    engines: {node: '>=14.0'}
+
+  undici@7.24.8:
+    resolution: {integrity: sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==}
+    engines: {node: '>=20.18.1'}
+
+  unenv-nightly@2.0.0-20241218-183400-5d6aec3:
+    resolution: {integrity: sha512-7Xpi29CJRbOV1/IrC03DawMJ0hloklDLq/cigSe+J2jkcC+iDres2Cy0r4ltj5f0x7DqsaGaB4/dLuCPPFZnZA==}
+
+  unenv@2.0.0-rc.24:
+    resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
 
   universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
@@ -1918,6 +2715,37 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
+  workerd@1.20241230.0:
+    resolution: {integrity: sha512-EgixXP0JGXGq6J9lz17TKIZtfNDUvJNG+cl9paPMfZuYWT920fFpBx+K04YmnbQRLnglsivF1GT9pxh1yrlWhg==}
+    engines: {node: '>=16'}
+    hasBin: true
+
+  workerd@1.20260415.1:
+    resolution: {integrity: sha512-phyPjRnx+mQDfkhN9ENPioL1L0SdhYs4S0YmJK/xF9Oga+ykNfdSy1MHnsOj8yqnOV96zcVQMx32dJ0r3pq0jQ==}
+    engines: {node: '>=16'}
+    hasBin: true
+
+  wrangler@3.100.0:
+    resolution: {integrity: sha512-+nsZK374Xnp2BEQQuB/18pnObgsOey0AHVlg75pAdwNaKAmB2aa0/E5rFb7i89DiiwFYoZMz3cARY1UKcm/WQQ==}
+    engines: {node: '>=16.17.0'}
+    deprecated: Downgrade to 3.99.0
+    hasBin: true
+    peerDependencies:
+      '@cloudflare/workers-types': ^4.20241230.0
+    peerDependenciesMeta:
+      '@cloudflare/workers-types':
+        optional: true
+
+  wrangler@4.83.0:
+    resolution: {integrity: sha512-gw5g3LCiuAqVWxaoKY6+quE0HzAUEFb/FV3oAlNkE1ttd4XP3FiV91XDkkzUCcdqxS4WjhQvPhIDBNdhEi8P0A==}
+    engines: {node: '>=20.3.0'}
+    hasBin: true
+    peerDependencies:
+      '@cloudflare/workers-types': ^4.20260415.1
+    peerDependenciesMeta:
+      '@cloudflare/workers-types':
+        optional: true
+
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
@@ -1928,6 +2756,18 @@ packages:
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  ws@8.18.0:
+    resolution: {integrity: sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   ws@8.20.0:
     resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
@@ -1948,9 +2788,36 @@ packages:
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
+  xxhash-wasm@1.1.0:
+    resolution: {integrity: sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==}
+
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
+  yargs-parser@21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+
+  yargs@17.7.2:
+    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
+    engines: {node: '>=12'}
+
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  youch-core@0.3.3:
+    resolution: {integrity: sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==}
+
+  youch@3.3.4:
+    resolution: {integrity: sha512-UeVBXie8cA35DS6+nBkls68xaBBXCye0CNznrhszZjTbRVnJKQuNsyLKBTTL4ln1o1rh2PKtv35twV7irj5SEg==}
+
+  youch@4.1.0-beta.10:
+    resolution: {integrity: sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==}
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
 snapshots:
 
@@ -2013,6 +2880,73 @@ snapshots:
       '@cesium/engine': 24.0.0
       nosleep.js: 0.12.0
 
+  '@cloudflare/kv-asset-handler@0.3.4':
+    dependencies:
+      mime: 3.0.0
+
+  '@cloudflare/kv-asset-handler@0.4.2': {}
+
+  '@cloudflare/unenv-preset@2.16.0(unenv@2.0.0-rc.24)(workerd@1.20260415.1)':
+    dependencies:
+      unenv: 2.0.0-rc.24
+    optionalDependencies:
+      workerd: 1.20260415.1
+
+  '@cloudflare/vitest-pool-workers@0.5.41(@cloudflare/workers-types@4.20260418.1)(@vitest/runner@2.1.9)(@vitest/snapshot@2.1.9)(vitest@2.1.9(@types/node@20.14.15)(jsdom@25.0.1))':
+    dependencies:
+      '@vitest/runner': 2.1.9
+      '@vitest/snapshot': 2.1.9
+      birpc: 0.2.14
+      cjs-module-lexer: 1.4.3
+      devalue: 4.3.3
+      esbuild: 0.17.19
+      miniflare: 3.20241230.0
+      semver: 7.7.4
+      vitest: 2.1.9(@types/node@20.14.15)(jsdom@25.0.1)
+      wrangler: 3.100.0(@cloudflare/workers-types@4.20260418.1)
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - '@cloudflare/workers-types'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  '@cloudflare/workerd-darwin-64@1.20241230.0':
+    optional: true
+
+  '@cloudflare/workerd-darwin-64@1.20260415.1':
+    optional: true
+
+  '@cloudflare/workerd-darwin-arm64@1.20241230.0':
+    optional: true
+
+  '@cloudflare/workerd-darwin-arm64@1.20260415.1':
+    optional: true
+
+  '@cloudflare/workerd-linux-64@1.20241230.0':
+    optional: true
+
+  '@cloudflare/workerd-linux-64@1.20260415.1':
+    optional: true
+
+  '@cloudflare/workerd-linux-arm64@1.20241230.0':
+    optional: true
+
+  '@cloudflare/workerd-linux-arm64@1.20260415.1':
+    optional: true
+
+  '@cloudflare/workerd-windows-64@1.20241230.0':
+    optional: true
+
+  '@cloudflare/workerd-windows-64@1.20260415.1':
+    optional: true
+
+  '@cloudflare/workers-types@4.20260418.1': {}
+
+  '@cspotcode/source-map-support@0.8.1':
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.9
+
   '@csstools/color-helpers@5.1.0': {}
 
   '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
@@ -2033,10 +2967,31 @@ snapshots:
 
   '@csstools/css-tokenizer@3.0.4': {}
 
+  '@emnapi/runtime@1.10.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@esbuild-plugins/node-globals-polyfill@0.2.3(esbuild@0.17.19)':
+    dependencies:
+      esbuild: 0.17.19
+
+  '@esbuild-plugins/node-modules-polyfill@0.2.2(esbuild@0.17.19)':
+    dependencies:
+      esbuild: 0.17.19
+      escape-string-regexp: 4.0.0
+      rollup-plugin-node-polyfills: 0.2.1
+
   '@esbuild/aix-ppc64@0.21.5':
     optional: true
 
   '@esbuild/aix-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/aix-ppc64@0.27.3':
+    optional: true
+
+  '@esbuild/android-arm64@0.17.19':
     optional: true
 
   '@esbuild/android-arm64@0.21.5':
@@ -2045,10 +3000,22 @@ snapshots:
   '@esbuild/android-arm64@0.25.12':
     optional: true
 
+  '@esbuild/android-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/android-arm@0.17.19':
+    optional: true
+
   '@esbuild/android-arm@0.21.5':
     optional: true
 
   '@esbuild/android-arm@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm@0.27.3':
+    optional: true
+
+  '@esbuild/android-x64@0.17.19':
     optional: true
 
   '@esbuild/android-x64@0.21.5':
@@ -2057,10 +3024,22 @@ snapshots:
   '@esbuild/android-x64@0.25.12':
     optional: true
 
+  '@esbuild/android-x64@0.27.3':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.17.19':
+    optional: true
+
   '@esbuild/darwin-arm64@0.21.5':
     optional: true
 
   '@esbuild/darwin-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/darwin-x64@0.17.19':
     optional: true
 
   '@esbuild/darwin-x64@0.21.5':
@@ -2069,10 +3048,22 @@ snapshots:
   '@esbuild/darwin-x64@0.25.12':
     optional: true
 
+  '@esbuild/darwin-x64@0.27.3':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.17.19':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.21.5':
     optional: true
 
   '@esbuild/freebsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.17.19':
     optional: true
 
   '@esbuild/freebsd-x64@0.21.5':
@@ -2081,10 +3072,22 @@ snapshots:
   '@esbuild/freebsd-x64@0.25.12':
     optional: true
 
+  '@esbuild/freebsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-arm64@0.17.19':
+    optional: true
+
   '@esbuild/linux-arm64@0.21.5':
     optional: true
 
   '@esbuild/linux-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-arm@0.17.19':
     optional: true
 
   '@esbuild/linux-arm@0.21.5':
@@ -2093,10 +3096,22 @@ snapshots:
   '@esbuild/linux-arm@0.25.12':
     optional: true
 
+  '@esbuild/linux-arm@0.27.3':
+    optional: true
+
+  '@esbuild/linux-ia32@0.17.19':
+    optional: true
+
   '@esbuild/linux-ia32@0.21.5':
     optional: true
 
   '@esbuild/linux-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.3':
+    optional: true
+
+  '@esbuild/linux-loong64@0.17.19':
     optional: true
 
   '@esbuild/linux-loong64@0.21.5':
@@ -2105,10 +3120,22 @@ snapshots:
   '@esbuild/linux-loong64@0.25.12':
     optional: true
 
+  '@esbuild/linux-loong64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.17.19':
+    optional: true
+
   '@esbuild/linux-mips64el@0.21.5':
     optional: true
 
   '@esbuild/linux-mips64el@0.25.12':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.3':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.17.19':
     optional: true
 
   '@esbuild/linux-ppc64@0.21.5':
@@ -2117,10 +3144,22 @@ snapshots:
   '@esbuild/linux-ppc64@0.25.12':
     optional: true
 
+  '@esbuild/linux-ppc64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.17.19':
+    optional: true
+
   '@esbuild/linux-riscv64@0.21.5':
     optional: true
 
   '@esbuild/linux-riscv64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-s390x@0.17.19':
     optional: true
 
   '@esbuild/linux-s390x@0.21.5':
@@ -2129,13 +3168,28 @@ snapshots:
   '@esbuild/linux-s390x@0.25.12':
     optional: true
 
+  '@esbuild/linux-s390x@0.27.3':
+    optional: true
+
+  '@esbuild/linux-x64@0.17.19':
+    optional: true
+
   '@esbuild/linux-x64@0.21.5':
     optional: true
 
   '@esbuild/linux-x64@0.25.12':
     optional: true
 
+  '@esbuild/linux-x64@0.27.3':
+    optional: true
+
   '@esbuild/netbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.17.19':
     optional: true
 
   '@esbuild/netbsd-x64@0.21.5':
@@ -2144,7 +3198,16 @@ snapshots:
   '@esbuild/netbsd-x64@0.25.12':
     optional: true
 
+  '@esbuild/netbsd-x64@0.27.3':
+    optional: true
+
   '@esbuild/openbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.17.19':
     optional: true
 
   '@esbuild/openbsd-x64@0.21.5':
@@ -2153,7 +3216,16 @@ snapshots:
   '@esbuild/openbsd-x64@0.25.12':
     optional: true
 
+  '@esbuild/openbsd-x64@0.27.3':
+    optional: true
+
   '@esbuild/openharmony-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/sunos-x64@0.17.19':
     optional: true
 
   '@esbuild/sunos-x64@0.21.5':
@@ -2162,10 +3234,22 @@ snapshots:
   '@esbuild/sunos-x64@0.25.12':
     optional: true
 
+  '@esbuild/sunos-x64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-arm64@0.17.19':
+    optional: true
+
   '@esbuild/win32-arm64@0.21.5':
     optional: true
 
   '@esbuild/win32-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-ia32@0.17.19':
     optional: true
 
   '@esbuild/win32-ia32@0.21.5':
@@ -2174,10 +3258,19 @@ snapshots:
   '@esbuild/win32-ia32@0.25.12':
     optional: true
 
+  '@esbuild/win32-ia32@0.27.3':
+    optional: true
+
+  '@esbuild/win32-x64@0.17.19':
+    optional: true
+
   '@esbuild/win32-x64@0.21.5':
     optional: true
 
   '@esbuild/win32-x64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.3':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.1(eslint@8.57.1)':
@@ -2203,6 +3296,8 @@ snapshots:
 
   '@eslint/js@8.57.1': {}
 
+  '@fastify/busboy@2.1.1': {}
+
   '@humanwhocodes/config-array@0.13.0':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
@@ -2214,6 +3309,102 @@ snapshots:
   '@humanwhocodes/module-importer@1.0.1': {}
 
   '@humanwhocodes/object-schema@2.0.3': {}
+
+  '@img/colour@1.1.0': {}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-darwin-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-arm@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-s390x@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-wasm32@0.34.5':
+    dependencies:
+      '@emnapi/runtime': 1.10.0
+    optional: true
+
+  '@img/sharp-win32-arm64@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-ia32@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-x64@0.34.5':
+    optional: true
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -2240,6 +3431,11 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@jridgewell/trace-mapping@0.3.9':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -2254,6 +3450,18 @@ snapshots:
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
+
+  '@poppinss/colors@4.1.6':
+    dependencies:
+      kleur: 4.1.5
+
+  '@poppinss/dumper@0.6.5':
+    dependencies:
+      '@poppinss/colors': 4.1.6
+      '@sindresorhus/is': 7.2.0
+      supports-color: 10.2.2
+
+  '@poppinss/exception@1.2.3': {}
 
   '@protobufjs/aspromise@1.1.2': {}
 
@@ -2358,6 +3566,10 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.60.1':
     optional: true
 
+  '@sindresorhus/is@7.2.0': {}
+
+  '@speed-highlight/core@1.2.15': {}
+
   '@spz-loader/core@0.3.1': {}
 
   '@tweenjs/tween.js@25.0.0': {}
@@ -2369,6 +3581,10 @@ snapshots:
       '@types/node': 20.14.15
       '@types/tough-cookie': 4.0.5
       parse5: 7.3.0
+
+  '@types/node-forge@1.3.14':
+    dependencies:
+      '@types/node': 20.14.15
 
   '@types/node@20.14.15':
     dependencies:
@@ -2526,6 +3742,10 @@ snapshots:
     dependencies:
       acorn: 8.16.0
 
+  acorn-walk@8.3.5:
+    dependencies:
+      acorn: 8.16.0
+
   acorn@8.16.0: {}
 
   agent-base@7.1.4: {}
@@ -2551,6 +3771,10 @@ snapshots:
 
   array-union@2.1.0: {}
 
+  as-table@1.0.55:
+    dependencies:
+      printable-characters: 1.0.42
+
   assertion-error@2.0.1: {}
 
   astronomy-engine@2.1.19: {}
@@ -2567,7 +3791,11 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
+  birpc@0.2.14: {}
+
   bitmap-sdf@1.0.4: {}
+
+  blake3-wasm@2.1.5: {}
 
   brace-expansion@1.1.14:
     dependencies:
@@ -2595,6 +3823,13 @@ snapshots:
 
   callsites@3.1.0: {}
 
+  capnp-ts@0.7.0:
+    dependencies:
+      debug: 4.4.3
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
   cesium@1.140.0:
     dependencies:
       '@cesium/engine': 24.0.0
@@ -2615,6 +3850,18 @@ snapshots:
 
   check-error@2.1.3: {}
 
+  chokidar@4.0.3:
+    dependencies:
+      readdirp: 4.1.2
+
+  cjs-module-lexer@1.4.3: {}
+
+  cliui@8.0.1:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -2629,6 +3876,21 @@ snapshots:
 
   concat-map@0.0.1: {}
 
+  concurrently@9.2.1:
+    dependencies:
+      chalk: 4.1.2
+      rxjs: 7.8.2
+      shell-quote: 1.8.3
+      supports-color: 8.1.1
+      tree-kill: 1.2.2
+      yargs: 17.7.2
+
+  confbox@0.1.8: {}
+
+  cookie@0.7.2: {}
+
+  cookie@1.1.1: {}
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -2640,10 +3902,14 @@ snapshots:
       '@asamuzakjp/css-color': 3.2.0
       rrweb-cssom: 0.8.0
 
+  data-uri-to-buffer@2.0.2: {}
+
   data-urls@5.0.0:
     dependencies:
       whatwg-mimetype: 4.0.0
       whatwg-url: 14.2.0
+
+  date-fns@4.1.0: {}
 
   debug@2.6.9:
     dependencies:
@@ -2659,11 +3925,17 @@ snapshots:
 
   deep-is@0.1.4: {}
 
+  defu@6.1.7: {}
+
   delayed-stream@1.0.0: {}
 
   depd@2.0.0: {}
 
   destroy@1.2.0: {}
+
+  detect-libc@2.1.2: {}
+
+  devalue@4.3.3: {}
 
   dir-glob@3.0.1:
     dependencies:
@@ -2699,6 +3971,8 @@ snapshots:
 
   entities@6.0.1: {}
 
+  error-stack-parser-es@1.0.5: {}
+
   es-define-property@1.0.1: {}
 
   es-errors@1.3.0: {}
@@ -2715,6 +3989,31 @@ snapshots:
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
       hasown: 2.0.2
+
+  esbuild@0.17.19:
+    optionalDependencies:
+      '@esbuild/android-arm': 0.17.19
+      '@esbuild/android-arm64': 0.17.19
+      '@esbuild/android-x64': 0.17.19
+      '@esbuild/darwin-arm64': 0.17.19
+      '@esbuild/darwin-x64': 0.17.19
+      '@esbuild/freebsd-arm64': 0.17.19
+      '@esbuild/freebsd-x64': 0.17.19
+      '@esbuild/linux-arm': 0.17.19
+      '@esbuild/linux-arm64': 0.17.19
+      '@esbuild/linux-ia32': 0.17.19
+      '@esbuild/linux-loong64': 0.17.19
+      '@esbuild/linux-mips64el': 0.17.19
+      '@esbuild/linux-ppc64': 0.17.19
+      '@esbuild/linux-riscv64': 0.17.19
+      '@esbuild/linux-s390x': 0.17.19
+      '@esbuild/linux-x64': 0.17.19
+      '@esbuild/netbsd-x64': 0.17.19
+      '@esbuild/openbsd-x64': 0.17.19
+      '@esbuild/sunos-x64': 0.17.19
+      '@esbuild/win32-arm64': 0.17.19
+      '@esbuild/win32-ia32': 0.17.19
+      '@esbuild/win32-x64': 0.17.19
 
   esbuild@0.21.5:
     optionalDependencies:
@@ -2770,6 +4069,37 @@ snapshots:
       '@esbuild/win32-arm64': 0.25.12
       '@esbuild/win32-ia32': 0.25.12
       '@esbuild/win32-x64': 0.25.12
+
+  esbuild@0.27.3:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.3
+      '@esbuild/android-arm': 0.27.3
+      '@esbuild/android-arm64': 0.27.3
+      '@esbuild/android-x64': 0.27.3
+      '@esbuild/darwin-arm64': 0.27.3
+      '@esbuild/darwin-x64': 0.27.3
+      '@esbuild/freebsd-arm64': 0.27.3
+      '@esbuild/freebsd-x64': 0.27.3
+      '@esbuild/linux-arm': 0.27.3
+      '@esbuild/linux-arm64': 0.27.3
+      '@esbuild/linux-ia32': 0.27.3
+      '@esbuild/linux-loong64': 0.27.3
+      '@esbuild/linux-mips64el': 0.27.3
+      '@esbuild/linux-ppc64': 0.27.3
+      '@esbuild/linux-riscv64': 0.27.3
+      '@esbuild/linux-s390x': 0.27.3
+      '@esbuild/linux-x64': 0.27.3
+      '@esbuild/netbsd-arm64': 0.27.3
+      '@esbuild/netbsd-x64': 0.27.3
+      '@esbuild/openbsd-arm64': 0.27.3
+      '@esbuild/openbsd-x64': 0.27.3
+      '@esbuild/openharmony-arm64': 0.27.3
+      '@esbuild/sunos-x64': 0.27.3
+      '@esbuild/win32-arm64': 0.27.3
+      '@esbuild/win32-ia32': 0.27.3
+      '@esbuild/win32-x64': 0.27.3
+
+  escalade@3.2.0: {}
 
   escape-html@1.0.3: {}
 
@@ -2845,6 +4175,8 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@0.6.1: {}
+
   estree-walker@2.0.2: {}
 
   estree-walker@3.0.3:
@@ -2854,6 +4186,8 @@ snapshots:
   esutils@2.0.3: {}
 
   etag@1.8.1: {}
+
+  exit-hook@2.2.1: {}
 
   expect-type@1.3.0: {}
 
@@ -2929,6 +4263,8 @@ snapshots:
 
   function-bind@1.1.2: {}
 
+  get-caller-file@2.0.5: {}
+
   get-intrinsic@1.3.0:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -2947,6 +4283,11 @@ snapshots:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
 
+  get-source@2.0.12:
+    dependencies:
+      data-uri-to-buffer: 2.0.2
+      source-map: 0.6.1
+
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
@@ -2954,6 +4295,8 @@ snapshots:
   glob-parent@6.0.2:
     dependencies:
       is-glob: 4.0.3
+
+  glob-to-regexp@0.4.1: {}
 
   glob@10.5.0:
     dependencies:
@@ -3054,6 +4397,10 @@ snapshots:
 
   inherits@2.0.4: {}
 
+  is-core-module@2.16.1:
+    dependencies:
+      hasown: 2.0.2
+
   is-extglob@2.1.1: {}
 
   is-fullwidth-code-point@3.0.0: {}
@@ -3094,6 +4441,8 @@ snapshots:
     dependencies:
       html-escaper: 2.0.2
       istanbul-lib-report: 3.0.1
+
+  itty-time@1.0.6: {}
 
   jackspeak@3.4.3:
     dependencies:
@@ -3152,6 +4501,8 @@ snapshots:
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
+
+  kleur@4.1.5: {}
 
   ktx-parse@1.1.0: {}
 
@@ -3215,6 +4566,39 @@ snapshots:
 
   mime@1.6.0: {}
 
+  mime@3.0.0: {}
+
+  miniflare@3.20241230.0:
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      acorn: 8.16.0
+      acorn-walk: 8.3.5
+      capnp-ts: 0.7.0
+      exit-hook: 2.2.1
+      glob-to-regexp: 0.4.1
+      stoppable: 1.1.0
+      undici: 5.29.0
+      workerd: 1.20241230.0
+      ws: 8.20.0
+      youch: 3.3.4
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  miniflare@4.20260415.0:
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      sharp: 0.34.5
+      undici: 7.24.8
+      workerd: 1.20260415.1
+      ws: 8.18.0
+      youch: 4.1.0-beta.10
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.5
@@ -3229,17 +4613,30 @@ snapshots:
 
   minipass@7.1.3: {}
 
+  mlly@1.8.2:
+    dependencies:
+      acorn: 8.16.0
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      ufo: 1.6.3
+
   ms@2.0.0: {}
 
   ms@2.1.3: {}
+
+  mustache@4.2.0: {}
 
   nanoid@3.3.11: {}
 
   natural-compare@1.4.0: {}
 
+  node-forge@1.4.0: {}
+
   nosleep.js@0.12.0: {}
 
   nwsapi@2.2.23: {}
+
+  ohash@1.1.6: {}
 
   on-finished@2.4.1:
     dependencies:
@@ -3286,14 +4683,20 @@ snapshots:
 
   path-key@3.1.1: {}
 
+  path-parse@1.0.7: {}
+
   path-scurry@1.11.1:
     dependencies:
       lru-cache: 10.4.3
       minipass: 7.1.3
 
+  path-to-regexp@6.3.0: {}
+
   path-type@4.0.0: {}
 
   pathe@1.1.2: {}
+
+  pathe@2.0.3: {}
 
   pathval@2.0.1: {}
 
@@ -3302,6 +4705,12 @@ snapshots:
   picomatch@2.3.2: {}
 
   picomatch@4.0.4: {}
+
+  pkg-types@1.3.1:
+    dependencies:
+      confbox: 0.1.8
+      mlly: 1.8.2
+      pathe: 2.0.3
 
   postcss@8.5.10:
     dependencies:
@@ -3312,6 +4721,8 @@ snapshots:
   prelude-ls@1.2.1: {}
 
   prettier@3.3.3: {}
+
+  printable-characters@1.0.42: {}
 
   protobufjs@8.0.1:
     dependencies:
@@ -3340,7 +4751,18 @@ snapshots:
     dependencies:
       quickselect: 3.0.0
 
+  readdirp@4.1.2: {}
+
+  require-directory@2.1.1: {}
+
   resolve-from@4.0.0: {}
+
+  resolve@1.22.12:
+    dependencies:
+      es-errors: 1.3.0
+      is-core-module: 2.16.1
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
 
   reusify@1.1.0: {}
 
@@ -3355,6 +4777,20 @@ snapshots:
       is-reference: 1.2.1
       magic-string: 0.25.9
       rollup: 4.60.1
+
+  rollup-plugin-inject@3.0.2:
+    dependencies:
+      estree-walker: 0.6.1
+      magic-string: 0.25.9
+      rollup-pluginutils: 2.8.2
+
+  rollup-plugin-node-polyfills@0.2.1:
+    dependencies:
+      rollup-plugin-inject: 3.0.2
+
+  rollup-pluginutils@2.8.2:
+    dependencies:
+      estree-walker: 0.6.1
 
   rollup@4.60.1:
     dependencies:
@@ -3395,6 +4831,10 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
+  rxjs@7.8.2:
+    dependencies:
+      tslib: 2.8.1
+
   safer-buffer@2.1.2: {}
 
   satellite.js@7.0.0: {}
@@ -3402,6 +4842,11 @@ snapshots:
   saxes@6.0.0:
     dependencies:
       xmlchars: 2.2.0
+
+  selfsigned@2.4.1:
+    dependencies:
+      '@types/node-forge': 1.3.14
+      node-forge: 1.4.0
 
   semver@7.7.4: {}
 
@@ -3434,11 +4879,44 @@ snapshots:
 
   setprototypeof@1.2.0: {}
 
+  sharp@0.34.5:
+    dependencies:
+      '@img/colour': 1.1.0
+      detect-libc: 2.1.2
+      semver: 7.7.4
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.34.5
+      '@img/sharp-darwin-x64': 0.34.5
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+      '@img/sharp-libvips-linux-arm': 1.2.4
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+      '@img/sharp-libvips-linux-x64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+      '@img/sharp-linux-arm': 0.34.5
+      '@img/sharp-linux-arm64': 0.34.5
+      '@img/sharp-linux-ppc64': 0.34.5
+      '@img/sharp-linux-riscv64': 0.34.5
+      '@img/sharp-linux-s390x': 0.34.5
+      '@img/sharp-linux-x64': 0.34.5
+      '@img/sharp-linuxmusl-arm64': 0.34.5
+      '@img/sharp-linuxmusl-x64': 0.34.5
+      '@img/sharp-wasm32': 0.34.5
+      '@img/sharp-win32-arm64': 0.34.5
+      '@img/sharp-win32-ia32': 0.34.5
+      '@img/sharp-win32-x64': 0.34.5
+
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  shell-quote@1.8.3: {}
 
   siginfo@2.0.0: {}
 
@@ -3448,13 +4926,22 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  source-map@0.6.1: {}
+
   sourcemap-codec@1.4.8: {}
 
   stackback@0.0.2: {}
 
+  stacktracey@2.2.0:
+    dependencies:
+      as-table: 1.0.55
+      get-source: 2.0.12
+
   statuses@2.0.2: {}
 
   std-env@3.10.0: {}
+
+  stoppable@1.1.0: {}
 
   string-width@4.2.3:
     dependencies:
@@ -3478,9 +4965,17 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
+  supports-color@10.2.2: {}
+
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
+
+  supports-color@8.1.1:
+    dependencies:
+      has-flag: 4.0.0
+
+  supports-preserve-symlinks-flag@1.0.0: {}
 
   symbol-tree@3.2.4: {}
 
@@ -3531,6 +5026,8 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  tree-kill@1.2.2: {}
+
   ts-api-utils@1.4.3(typescript@5.5.4):
     dependencies:
       typescript: 5.5.4
@@ -3545,7 +5042,27 @@ snapshots:
 
   typescript@5.5.4: {}
 
+  ufo@1.6.3: {}
+
   undici-types@5.26.5: {}
+
+  undici@5.29.0:
+    dependencies:
+      '@fastify/busboy': 2.1.1
+
+  undici@7.24.8: {}
+
+  unenv-nightly@2.0.0-20241218-183400-5d6aec3:
+    dependencies:
+      defu: 6.1.7
+      mlly: 1.8.2
+      ohash: 1.1.6
+      pathe: 1.1.2
+      ufo: 1.6.3
+
+  unenv@2.0.0-rc.24:
+    dependencies:
+      pathe: 2.0.3
 
   universalify@2.0.1: {}
 
@@ -3669,6 +5186,66 @@ snapshots:
 
   word-wrap@1.2.5: {}
 
+  workerd@1.20241230.0:
+    optionalDependencies:
+      '@cloudflare/workerd-darwin-64': 1.20241230.0
+      '@cloudflare/workerd-darwin-arm64': 1.20241230.0
+      '@cloudflare/workerd-linux-64': 1.20241230.0
+      '@cloudflare/workerd-linux-arm64': 1.20241230.0
+      '@cloudflare/workerd-windows-64': 1.20241230.0
+
+  workerd@1.20260415.1:
+    optionalDependencies:
+      '@cloudflare/workerd-darwin-64': 1.20260415.1
+      '@cloudflare/workerd-darwin-arm64': 1.20260415.1
+      '@cloudflare/workerd-linux-64': 1.20260415.1
+      '@cloudflare/workerd-linux-arm64': 1.20260415.1
+      '@cloudflare/workerd-windows-64': 1.20260415.1
+
+  wrangler@3.100.0(@cloudflare/workers-types@4.20260418.1):
+    dependencies:
+      '@cloudflare/kv-asset-handler': 0.3.4
+      '@esbuild-plugins/node-globals-polyfill': 0.2.3(esbuild@0.17.19)
+      '@esbuild-plugins/node-modules-polyfill': 0.2.2(esbuild@0.17.19)
+      blake3-wasm: 2.1.5
+      chokidar: 4.0.3
+      date-fns: 4.1.0
+      esbuild: 0.17.19
+      itty-time: 1.0.6
+      miniflare: 3.20241230.0
+      nanoid: 3.3.11
+      path-to-regexp: 6.3.0
+      resolve: 1.22.12
+      selfsigned: 2.4.1
+      source-map: 0.6.1
+      unenv: unenv-nightly@2.0.0-20241218-183400-5d6aec3
+      workerd: 1.20241230.0
+      xxhash-wasm: 1.1.0
+    optionalDependencies:
+      '@cloudflare/workers-types': 4.20260418.1
+      fsevents: 2.3.3
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  wrangler@4.83.0(@cloudflare/workers-types@4.20260418.1):
+    dependencies:
+      '@cloudflare/kv-asset-handler': 0.4.2
+      '@cloudflare/unenv-preset': 2.16.0(unenv@2.0.0-rc.24)(workerd@1.20260415.1)
+      blake3-wasm: 2.1.5
+      esbuild: 0.27.3
+      miniflare: 4.20260415.0
+      path-to-regexp: 6.3.0
+      unenv: 2.0.0-rc.24
+      workerd: 1.20260415.1
+    optionalDependencies:
+      '@cloudflare/workers-types': 4.20260418.1
+      fsevents: 2.3.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   wrap-ansi@7.0.0:
     dependencies:
       ansi-styles: 4.3.0
@@ -3683,10 +5260,49 @@ snapshots:
 
   wrappy@1.0.2: {}
 
+  ws@8.18.0: {}
+
   ws@8.20.0: {}
 
   xml-name-validator@5.0.0: {}
 
   xmlchars@2.2.0: {}
 
+  xxhash-wasm@1.1.0: {}
+
+  y18n@5.0.8: {}
+
+  yargs-parser@21.1.1: {}
+
+  yargs@17.7.2:
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
+
   yocto-queue@0.1.0: {}
+
+  youch-core@0.3.3:
+    dependencies:
+      '@poppinss/exception': 1.2.3
+      error-stack-parser-es: 1.0.5
+
+  youch@3.3.4:
+    dependencies:
+      cookie: 0.7.2
+      mustache: 4.2.0
+      stacktracey: 2.2.0
+
+  youch@4.1.0-beta.10:
+    dependencies:
+      '@poppinss/colors': 4.1.6
+      '@poppinss/dumper': 0.6.5
+      '@speed-highlight/core': 1.2.15
+      cookie: 1.1.1
+      youch-core: 0.3.3
+
+  zod@3.25.76: {}

--- a/scripts/check-spdx.mjs
+++ b/scripts/check-spdx.mjs
@@ -18,6 +18,7 @@ function findFiles(dir, ext, recursive) {
 
 const files = [
   ...findFiles("src", ".ts", true),
+  ...findFiles("worker", ".ts", true),
   ...findFiles("scripts", ".mjs", true),
   ...findFiles(".", ".ts", false),
 ];

--- a/src/auth.test.ts
+++ b/src/auth.test.ts
@@ -1,0 +1,148 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { currentUser, logout, requestMagicLink, type AuthUser } from "./auth";
+
+describe("requestMagicLink", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns ok when the API accepts the request (202)", async () => {
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 202 }));
+    const result = await requestMagicLink("alice@example.com");
+    expect(result.ok).toBe(true);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/auth/request-link",
+      expect.objectContaining({
+        method: "POST",
+        credentials: "include",
+        body: JSON.stringify({ email: "alice@example.com" }),
+      }),
+    );
+  });
+
+  it("returns err invalid_email on 400", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: "invalid_email" }), { status: 400 }),
+    );
+    const result = await requestMagicLink("nope");
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.kind).toBe("invalid_email");
+  });
+
+  it("returns err rate_limited on 429", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: "rate_limited" }), { status: 429 }),
+    );
+    const result = await requestMagicLink("spam@example.com");
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.kind).toBe("rate_limited");
+  });
+
+  it("returns err network when fetch itself rejects", async () => {
+    fetchMock.mockRejectedValueOnce(new TypeError("Failed to fetch"));
+    const result = await requestMagicLink("x@y.z");
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.kind).toBe("network");
+  });
+
+  it("returns err server on a 500", async () => {
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 500 }));
+    const result = await requestMagicLink("x@y.z");
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.kind).toBe("server");
+  });
+});
+
+describe("currentUser", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns null on 401", async () => {
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 401 }));
+    const user = await currentUser();
+    expect(user).toBeNull();
+  });
+
+  it("returns the user on 200", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ email: "alice@example.com", tier: "free" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    const user = await currentUser();
+    const expected: AuthUser = { email: "alice@example.com", tier: "free" };
+    expect(user).toEqual(expected);
+  });
+
+  it("returns null on a network error", async () => {
+    fetchMock.mockRejectedValueOnce(new TypeError("Failed to fetch"));
+    const user = await currentUser();
+    expect(user).toBeNull();
+  });
+
+  it("returns null on malformed JSON", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response("not-json", {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    const user = await currentUser();
+    expect(user).toBeNull();
+  });
+
+  it("returns null when tier is unknown", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ email: "a@b.c", tier: "unknown" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    const user = await currentUser();
+    expect(user).toBeNull();
+  });
+});
+
+describe("logout", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("POSTs /api/auth/logout with credentials included", async () => {
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 204 }));
+    await logout();
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/auth/logout",
+      expect.objectContaining({ method: "POST", credentials: "include" }),
+    );
+  });
+
+  it("swallows network errors", async () => {
+    fetchMock.mockRejectedValueOnce(new TypeError("Failed to fetch"));
+    await expect(logout()).resolves.toBeUndefined();
+  });
+});

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,0 +1,94 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { err, ok, type Result } from "./result";
+
+/**
+ * Client-side auth wrapper for the Phase 2 `/api/auth/*` Worker surface.
+ *
+ * Every network call returns a `Result<T, AuthError>` per CLAUDE.md — this
+ * module is the boundary where HTTP error shapes become the typed domain
+ * union the rest of the SPA consumes. `currentUser()` is a narrower shape
+ * (user | null) because "not logged in" is not an error, it's a state; the
+ * SPA calls it at bootstrap to decide what UI to show.
+ */
+
+export type AuthUserTier = "free" | "pro";
+
+export type AuthUser = {
+  readonly email: string;
+  readonly tier: AuthUserTier;
+};
+
+export type AuthError =
+  | { readonly kind: "invalid_email" }
+  | { readonly kind: "rate_limited" }
+  | { readonly kind: "invalid_token" }
+  | { readonly kind: "unauthenticated" }
+  | { readonly kind: "network" }
+  | { readonly kind: "server" };
+
+/**
+ * POST /api/auth/request-link. Triggers a magic-link email (in this PR the
+ * Worker logs the URL to its console instead of sending real mail — see
+ * `worker/email.ts`). Returns `ok` on HTTP 202, `err` on everything else.
+ */
+export async function requestMagicLink(email: string): Promise<Result<void, AuthError>> {
+  let response: Response;
+  try {
+    response = await fetch("/api/auth/request-link", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      credentials: "include",
+      body: JSON.stringify({ email }),
+    });
+  } catch {
+    return err({ kind: "network" });
+  }
+  if (response.status === 202) return ok(undefined);
+  if (response.status === 400) return err({ kind: "invalid_email" });
+  if (response.status === 429) return err({ kind: "rate_limited" });
+  return err({ kind: "server" });
+}
+
+/**
+ * GET /api/auth/me. Returns the current user if the session cookie is
+ * valid, `null` if unauthenticated, a network failure, or any malformed
+ * response. Callers treat "null" as "not logged in" — they don't need to
+ * distinguish 401 from a dropped connection.
+ */
+export async function currentUser(): Promise<AuthUser | null> {
+  let response: Response;
+  try {
+    response = await fetch("/api/auth/me", {
+      method: "GET",
+      credentials: "include",
+    });
+  } catch {
+    return null;
+  }
+  if (!response.ok) return null;
+  let body: unknown;
+  try {
+    body = await response.json();
+  } catch {
+    return null;
+  }
+  if (typeof body !== "object" || body === null) return null;
+  const email = (body as { email?: unknown }).email;
+  const tier = (body as { tier?: unknown }).tier;
+  if (typeof email !== "string" || typeof tier !== "string") return null;
+  if (tier !== "free" && tier !== "pro") return null;
+  return { email, tier };
+}
+
+/** POST /api/auth/logout. Best-effort — swallows network errors so the UI
+ *  can still clear local state even when offline. */
+export async function logout(): Promise<void> {
+  try {
+    await fetch("/api/auth/logout", {
+      method: "POST",
+      credentials: "include",
+    });
+  } catch {
+    // Best-effort: the client will still treat the user as logged-out.
+  }
+}

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -26,6 +26,8 @@ export { createTonightDrawer } from "./tonight-drawer";
 export type { TonightDrawer, TonightDrawerOptions } from "./tonight-drawer";
 export type { HelpModal, HelpModalOptions } from "./help-modal";
 export { createHelpModal } from "./help-modal";
+export type { LoginModal, LoginModalOptions } from "./login-modal";
+export { createLoginModal } from "./login-modal";
 export { createOnboardingOverlay, ONBOARDING_STORAGE_KEY } from "./onboarding-overlay";
 export type {
   OnboardingOverlay,

--- a/src/ui/login-modal.test.ts
+++ b/src/ui/login-modal.test.ts
@@ -1,0 +1,172 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createLoginModal } from "./login-modal";
+import type { AuthError } from "../auth";
+import { err, ok, type Result } from "../result";
+
+function makeOkRequester(): ReturnType<typeof vi.fn> {
+  return vi.fn().mockResolvedValue(ok(undefined) as Result<void, AuthError>);
+}
+
+describe("createLoginModal", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("starts hidden", () => {
+    const modal = createLoginModal({ requestMagicLink: makeOkRequester() });
+    document.body.appendChild(modal.element);
+    expect(modal.isOpen()).toBe(false);
+    expect(modal.element.style.display).toBe("none");
+  });
+
+  it("open() shows the modal", () => {
+    const modal = createLoginModal({ requestMagicLink: makeOkRequester() });
+    document.body.appendChild(modal.element);
+    modal.open();
+    expect(modal.isOpen()).toBe(true);
+    expect(modal.element.style.display).not.toBe("none");
+  });
+
+  it("close() hides the modal", () => {
+    const modal = createLoginModal({ requestMagicLink: makeOkRequester() });
+    document.body.appendChild(modal.element);
+    modal.open();
+    modal.close();
+    expect(modal.isOpen()).toBe(false);
+  });
+
+  it("clicking the backdrop closes the modal", () => {
+    const modal = createLoginModal({ requestMagicLink: makeOkRequester() });
+    document.body.appendChild(modal.element);
+    modal.open();
+    const backdrop = modal.element.querySelector<HTMLElement>(
+      "[data-testid='login-modal-backdrop']",
+    );
+    backdrop?.click();
+    expect(modal.isOpen()).toBe(false);
+  });
+
+  it("Escape closes the modal", () => {
+    const modal = createLoginModal({ requestMagicLink: makeOkRequester() });
+    document.body.appendChild(modal.element);
+    modal.open();
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    expect(modal.isOpen()).toBe(false);
+  });
+
+  it("submitting a valid email calls requestMagicLink and shows the sent state", async () => {
+    const requester = vi.fn().mockResolvedValue(ok(undefined) as Result<void, AuthError>);
+    const modal = createLoginModal({ requestMagicLink: requester });
+    document.body.appendChild(modal.element);
+    modal.open();
+    const input = modal.element.querySelector<HTMLInputElement>(
+      "[data-testid='login-modal-email']",
+    )!;
+    input.value = "alice@example.com";
+    const form = modal.element.querySelector<HTMLFormElement>("[data-testid='login-modal-form']")!;
+    form.dispatchEvent(new Event("submit", { cancelable: true, bubbles: true }));
+    // Let the microtask queue drain for the awaited requester.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(requester).toHaveBeenCalledWith("alice@example.com");
+    const sent = modal.element.querySelector("[data-testid='login-modal-sent']");
+    expect(sent).not.toBeNull();
+  });
+
+  it("invalid_email error renders an inline message", async () => {
+    const requester = vi
+      .fn()
+      .mockResolvedValue(err({ kind: "invalid_email" }) as Result<void, AuthError>);
+    const modal = createLoginModal({ requestMagicLink: requester });
+    document.body.appendChild(modal.element);
+    modal.open();
+    const input = modal.element.querySelector<HTMLInputElement>(
+      "[data-testid='login-modal-email']",
+    )!;
+    input.value = "not-an-email";
+    const form = modal.element.querySelector<HTMLFormElement>("[data-testid='login-modal-form']")!;
+    form.dispatchEvent(new Event("submit", { cancelable: true, bubbles: true }));
+    await Promise.resolve();
+    await Promise.resolve();
+    const error = modal.element.querySelector<HTMLElement>("[data-testid='login-modal-error']");
+    expect(error).not.toBeNull();
+    expect(error!.textContent).toContain("valid email");
+  });
+
+  it("rate_limited error renders a 'try again shortly' message", async () => {
+    const requester = vi
+      .fn()
+      .mockResolvedValue(err({ kind: "rate_limited" }) as Result<void, AuthError>);
+    const modal = createLoginModal({ requestMagicLink: requester });
+    document.body.appendChild(modal.element);
+    modal.open();
+    const input = modal.element.querySelector<HTMLInputElement>(
+      "[data-testid='login-modal-email']",
+    )!;
+    input.value = "spam@example.com";
+    modal.element
+      .querySelector<HTMLFormElement>("[data-testid='login-modal-form']")!
+      .dispatchEvent(new Event("submit", { cancelable: true, bubbles: true }));
+    await Promise.resolve();
+    await Promise.resolve();
+    const error = modal.element.querySelector<HTMLElement>("[data-testid='login-modal-error']");
+    expect(error?.textContent?.toLowerCase()).toMatch(/already sent|try again|moment/);
+  });
+
+  it("network/server error renders a generic retry message", async () => {
+    const requester = vi
+      .fn()
+      .mockResolvedValue(err({ kind: "network" }) as Result<void, AuthError>);
+    const modal = createLoginModal({ requestMagicLink: requester });
+    document.body.appendChild(modal.element);
+    modal.open();
+    const input = modal.element.querySelector<HTMLInputElement>(
+      "[data-testid='login-modal-email']",
+    )!;
+    input.value = "alice@example.com";
+    modal.element
+      .querySelector<HTMLFormElement>("[data-testid='login-modal-form']")!
+      .dispatchEvent(new Event("submit", { cancelable: true, bubbles: true }));
+    await Promise.resolve();
+    await Promise.resolve();
+    const error = modal.element.querySelector<HTMLElement>("[data-testid='login-modal-error']");
+    expect(error).not.toBeNull();
+  });
+
+  it("does not call requestMagicLink for an empty email", async () => {
+    const requester = vi.fn();
+    const modal = createLoginModal({ requestMagicLink: requester });
+    document.body.appendChild(modal.element);
+    modal.open();
+    const form = modal.element.querySelector<HTMLFormElement>("[data-testid='login-modal-form']")!;
+    form.dispatchEvent(new Event("submit", { cancelable: true, bubbles: true }));
+    await Promise.resolve();
+    expect(requester).not.toHaveBeenCalled();
+  });
+
+  it("open() resets to the email-entry state after a previous 'sent' state", async () => {
+    const requester = vi.fn().mockResolvedValue(ok(undefined) as Result<void, AuthError>);
+    const modal = createLoginModal({ requestMagicLink: requester });
+    document.body.appendChild(modal.element);
+    modal.open();
+    const input = modal.element.querySelector<HTMLInputElement>(
+      "[data-testid='login-modal-email']",
+    )!;
+    input.value = "alice@example.com";
+    modal.element
+      .querySelector<HTMLFormElement>("[data-testid='login-modal-form']")!
+      .dispatchEvent(new Event("submit", { cancelable: true, bubbles: true }));
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(modal.element.querySelector("[data-testid='login-modal-sent']")).not.toBeNull();
+    modal.close();
+    modal.open();
+    expect(modal.element.querySelector("[data-testid='login-modal-sent']")).toBeNull();
+    expect(modal.element.querySelector("[data-testid='login-modal-form']")).not.toBeNull();
+  });
+});

--- a/src/ui/login-modal.ts
+++ b/src/ui/login-modal.ts
@@ -1,0 +1,259 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import type { AuthError } from "../auth";
+import type { Result } from "../result";
+import { PANEL_BG, PANEL_BORDER, TEXT_COLOR } from "./styles";
+
+/**
+ * Minimal modal for the magic-link login flow.
+ *
+ * Two states: an email-entry form, and a "Check your email" confirmation.
+ * The caller injects `requestMagicLink` so the modal is trivially testable
+ * with a mock — no `fetch` plumbing in the UI layer.
+ *
+ * When #224 (`src/ui/email-gate-modal.ts`) lands, this modal is the real
+ * implementation and the email-gate shell becomes a thin wrapper around it.
+ */
+
+export type LoginModal = {
+  readonly element: HTMLElement;
+  open(): void;
+  close(): void;
+  isOpen(): boolean;
+};
+
+export type LoginModalOptions = {
+  readonly requestMagicLink: (email: string) => Promise<Result<void, AuthError>>;
+};
+
+export function createLoginModal(options: LoginModalOptions): LoginModal {
+  const root = document.createElement("div");
+  root.dataset.testid = "login-modal";
+  root.style.display = "none";
+  root.style.position = "fixed";
+  root.style.inset = "0";
+  root.style.zIndex = "2000";
+
+  const backdrop = document.createElement("div");
+  backdrop.dataset.testid = "login-modal-backdrop";
+  backdrop.style.position = "absolute";
+  backdrop.style.inset = "0";
+  backdrop.style.background = "rgba(0,0,0,0.6)";
+
+  const panel = document.createElement("div");
+  panel.style.position = "absolute";
+  panel.style.top = "50%";
+  panel.style.left = "50%";
+  panel.style.transform = "translate(-50%, -50%)";
+  panel.style.width = "min(92vw, 420px)";
+  panel.style.background = PANEL_BG;
+  panel.style.border = PANEL_BORDER;
+  panel.style.borderRadius = "8px";
+  panel.style.color = TEXT_COLOR;
+  panel.style.fontFamily = "sans-serif";
+  panel.style.padding = "20px 24px";
+  panel.style.boxSizing = "border-box";
+
+  const body = document.createElement("div");
+  panel.appendChild(body);
+
+  root.appendChild(backdrop);
+  root.appendChild(panel);
+
+  let open = false;
+
+  function setOpen(value: boolean): void {
+    open = value;
+    root.style.display = value ? "block" : "none";
+  }
+
+  function renderForm(): void {
+    body.innerHTML = "";
+
+    const heading = document.createElement("h2");
+    heading.textContent = "Sign in";
+    heading.style.margin = "0 0 8px";
+    heading.style.fontSize = "20px";
+    body.appendChild(heading);
+
+    const blurb = document.createElement("p");
+    blurb.textContent = "Enter your email — we'll send you a one-time login link.";
+    blurb.style.margin = "0 0 16px";
+    blurb.style.fontSize = "13px";
+    blurb.style.color = "rgba(255,255,255,0.75)";
+    body.appendChild(blurb);
+
+    const form = document.createElement("form");
+    form.dataset.testid = "login-modal-form";
+    form.style.display = "flex";
+    form.style.flexDirection = "column";
+    form.style.gap = "12px";
+
+    const input = document.createElement("input");
+    input.dataset.testid = "login-modal-email";
+    input.type = "email";
+    input.placeholder = "you@example.com";
+    input.autocomplete = "email";
+    input.required = true;
+    input.style.background = "rgba(255,255,255,0.08)";
+    input.style.border = "1px solid rgba(255,255,255,0.25)";
+    input.style.borderRadius = "4px";
+    input.style.color = TEXT_COLOR;
+    input.style.fontSize = "14px";
+    input.style.padding = "8px 10px";
+    form.appendChild(input);
+
+    const errorBox = document.createElement("div");
+    errorBox.dataset.testid = "login-modal-error";
+    errorBox.style.display = "none";
+    errorBox.style.color = "#ff9a9a";
+    errorBox.style.fontSize = "12px";
+    form.appendChild(errorBox);
+
+    const buttons = document.createElement("div");
+    buttons.style.display = "flex";
+    buttons.style.gap = "8px";
+    buttons.style.justifyContent = "flex-end";
+
+    const cancel = document.createElement("button");
+    cancel.dataset.testid = "login-modal-cancel";
+    cancel.type = "button";
+    cancel.textContent = "Cancel";
+    cancel.style.background = "rgba(255,255,255,0.08)";
+    cancel.style.border = "1px solid rgba(255,255,255,0.25)";
+    cancel.style.borderRadius = "4px";
+    cancel.style.color = TEXT_COLOR;
+    cancel.style.cursor = "pointer";
+    cancel.style.fontSize = "13px";
+    cancel.style.padding = "6px 12px";
+    cancel.addEventListener("click", doClose);
+    buttons.appendChild(cancel);
+
+    const submit = document.createElement("button");
+    submit.dataset.testid = "login-modal-submit";
+    submit.type = "submit";
+    submit.textContent = "Send login link";
+    submit.style.background = "rgba(100,180,255,0.25)";
+    submit.style.border = "1px solid rgba(100,180,255,0.7)";
+    submit.style.borderRadius = "4px";
+    submit.style.color = TEXT_COLOR;
+    submit.style.cursor = "pointer";
+    submit.style.fontSize = "13px";
+    submit.style.padding = "6px 12px";
+    buttons.appendChild(submit);
+
+    form.appendChild(buttons);
+    body.appendChild(form);
+
+    form.addEventListener("submit", (event) => {
+      event.preventDefault();
+      const email = input.value.trim();
+      if (email.length === 0) return;
+      submit.disabled = true;
+      submit.textContent = "Sending…";
+      errorBox.style.display = "none";
+      errorBox.textContent = "";
+
+      void options
+        .requestMagicLink(email)
+        .then((result) => {
+          if (result.ok) {
+            renderSent(email);
+          } else {
+            submit.disabled = false;
+            submit.textContent = "Send login link";
+            errorBox.textContent = messageForError(result.error);
+            errorBox.style.display = "block";
+          }
+        })
+        .catch(() => {
+          submit.disabled = false;
+          submit.textContent = "Send login link";
+          errorBox.textContent = messageForError({ kind: "network" });
+          errorBox.style.display = "block";
+        });
+    });
+
+    // Focus the email input for keyboard users.
+    setTimeout(() => input.focus(), 0);
+  }
+
+  function renderSent(email: string): void {
+    body.innerHTML = "";
+
+    const heading = document.createElement("h2");
+    heading.textContent = "Check your email";
+    heading.style.margin = "0 0 12px";
+    heading.style.fontSize = "20px";
+    body.appendChild(heading);
+
+    const sent = document.createElement("div");
+    sent.dataset.testid = "login-modal-sent";
+    sent.style.fontSize = "13px";
+    sent.style.lineHeight = "1.5";
+    sent.innerHTML = "";
+    const line1 = document.createElement("p");
+    line1.style.margin = "0 0 8px";
+    line1.textContent = `We sent a one-time login link to ${email}.`;
+    const line2 = document.createElement("p");
+    line2.style.margin = "0 0 16px";
+    line2.style.color = "rgba(255,255,255,0.7)";
+    line2.textContent = "Click the link to finish signing in. You can close this dialog.";
+    sent.appendChild(line1);
+    sent.appendChild(line2);
+    body.appendChild(sent);
+
+    const close = document.createElement("button");
+    close.dataset.testid = "login-modal-done";
+    close.type = "button";
+    close.textContent = "Done";
+    close.style.background = "rgba(100,180,255,0.25)";
+    close.style.border = "1px solid rgba(100,180,255,0.7)";
+    close.style.borderRadius = "4px";
+    close.style.color = TEXT_COLOR;
+    close.style.cursor = "pointer";
+    close.style.fontSize = "13px";
+    close.style.padding = "6px 12px";
+    close.style.float = "right";
+    close.addEventListener("click", doClose);
+    body.appendChild(close);
+  }
+
+  function doOpen(): void {
+    renderForm();
+    setOpen(true);
+  }
+
+  function doClose(): void {
+    setOpen(false);
+  }
+
+  backdrop.addEventListener("click", doClose);
+  document.addEventListener("keydown", (event) => {
+    if (event.key === "Escape" && open) {
+      doClose();
+    }
+  });
+
+  return {
+    element: root,
+    open: doOpen,
+    close: doClose,
+    isOpen: () => open,
+  };
+}
+
+function messageForError(error: AuthError): string {
+  switch (error.kind) {
+    case "invalid_email":
+      return "Please enter a valid email address.";
+    case "rate_limited":
+      return "A login link was already sent. Try again in a moment.";
+    case "network":
+      return "Couldn't reach the server. Check your connection and try again.";
+    case "server":
+      return "Something went wrong on our end. Please try again.";
+    case "invalid_token":
+    case "unauthenticated":
+      return "Please try again.";
+  }
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -8,5 +8,5 @@
     "skipLibCheck": true,
     "types": ["node"]
   },
-  "include": ["vite.config.ts", "vitest.config.ts"]
+  "include": ["vite.config.ts", "vitest.config.ts", "vitest.worker.config.ts"]
 }

--- a/tsconfig.worker.json
+++ b/tsconfig.worker.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "WebWorker"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "allowImportingTsExtensions": false,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+
+    "strict": true,
+    "noImplicitOverride": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "exactOptionalPropertyTypes": true,
+
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+
+    "types": ["@cloudflare/workers-types", "@cloudflare/vitest-pool-workers"]
+  },
+  "include": ["worker"]
+}

--- a/vitest.worker.config.ts
+++ b/vitest.worker.config.ts
@@ -1,0 +1,29 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { defineWorkersConfig } from "@cloudflare/vitest-pool-workers/config";
+
+/**
+ * Worker-only Vitest config. Runs each `worker/*.test.ts` file inside a
+ * real `workerd` isolate with a bound in-memory D1 database and the
+ * migrations in `migrations/` applied on startup. Completely separate from
+ * `vitest.config.ts` (which runs the SPA tests under jsdom) — the two
+ * runs don't share coverage numbers or config.
+ */
+export default defineWorkersConfig({
+  test: {
+    include: ["worker/**/*.test.ts"],
+    poolOptions: {
+      workers: {
+        singleWorker: true,
+        miniflare: {
+          compatibilityDate: "2026-04-16",
+          compatibilityFlags: ["nodejs_compat"],
+          d1Databases: ["DB"],
+          bindings: {
+            APP_ORIGIN: "http://localhost:5173",
+            SESSION_SECRET: "test-secret-at-least-32-bytes-long-please!!",
+          },
+        },
+      },
+    },
+  },
+});

--- a/worker/README.md
+++ b/worker/README.md
@@ -1,0 +1,161 @@
+# `worker/` — Cloudflare Worker (Phase 2 API)
+
+First backend code in this repo. Scope and rationale are in
+[ADR 009](../docs/adr/009-backend-selection.md); the dev-dep choices for
+testing and local dev are in [ADR 010](../docs/adr/010-worker-deps.md).
+
+This Worker owns the `/api/*` surface for the Notebook-tier features. Milestone
+2C (this PR, closes #218) ships the magic-link auth slice; notebook CRUD
+(#219), Stripe (#221), and follow-ups are layered in later without changing
+the module shape.
+
+## Layout
+
+```
+worker/
+  index.ts      Fetch handler. Parses the URL, dispatches to a route module.
+  routes/
+    auth.ts     /api/auth/* — request-link, callback, logout, me.
+  db.ts         Thin helpers over the D1 binding. Hand-rolled prepared
+                statements; no ORM.
+  crypto.ts     Token generation + HMAC cookie signing / verification via
+                the workers `crypto.subtle` runtime.
+  email.ts      EmailSender interface + a console-log stub for dev.
+                Swap in Resend/Postmark/SES in a one-file change.
+  types.ts      Shared types: Env binding, User row, MagicLink row,
+                AuthError domain union, SessionPayload.
+  *.test.ts     Vitest tests running under @cloudflare/vitest-pool-workers
+                — real workerd + real D1. See vitest.worker.config.ts.
+
+migrations/
+  0001_init.sql  users, magic_links, sessions tables + indexes.
+```
+
+## Module-boundary rule
+
+- `worker/` is the **only** directory that imports `@cloudflare/workers-types`
+  and uses the Workers runtime.
+- `worker/` does **not** import anything from `src/`, and `src/` does not
+  import anything from `worker/`. The two are deployed separately and the
+  shapes they share (e.g. `{email, tier}` from `/api/auth/me`) live on
+  the wire only — the client's own `AuthUser` type is declared in
+  `src/auth.ts`.
+
+## Result types
+
+Worker code does not currently use the client's `Result<T, E>` helper; route
+handlers produce `Response` objects directly. Domain error cases are returned
+as typed JSON with well-known `code` strings (`invalid_email`,
+`rate_limited`, `invalid_token`, …) and the right HTTP status. The client's
+`src/auth.ts` maps those back into `Result<T, AuthError>` for the rest of
+the SPA. This keeps the Worker's HTTP layer idiomatic while still giving the
+client the strict-Result contract CLAUDE.md mandates.
+
+## Magic-link flow
+
+```
+  client                Worker                 D1                 email
+  ------                ------                 --                 -----
+  POST /api/auth/
+  request-link          rate-limit (60s/email)
+  {email}        ─────► check magic_links.created_at
+                        crypto.randomUUID() as token
+                        INSERT users IF NOT EXISTS
+                        INSERT magic_links  ──────► magic_links row
+                        EmailSender.sendMagicLink
+                                                                  console.log
+                        HTTP 202
+                ◄──────
+  GET /api/auth/
+  callback?token=T                                        (user clicks link)
+                 ─────► SELECT magic_links WHERE token=T AND used_at IS NULL
+                        UPDATE magic_links SET used_at=now   ► marks one-use
+                        INSERT sessions  ──────────► sessions row
+                        Set-Cookie: ps_session=<signed>
+                        Location: APP_ORIGIN/
+                ◄──────
+
+  GET /api/auth/me
+  (cookie attached) ──► verify HMAC on cookie
+                        SELECT sessions, users
+                        HTTP 200 {email, tier}
+                ◄──────
+
+  POST /api/auth/
+  logout        ───────► Set-Cookie: ps_session=; Max-Age=0
+                ◄──────  HTTP 204
+```
+
+**Single-use tokens.** A token is usable exactly once; the second GET
+returns 401 `invalid_token`. Tokens have no explicit TTL in this PR — a
+follow-up will add `expires_at` and a periodic cleanup job (#TBD).
+
+**Rate limiting.** One pending magic link per email per 60 seconds. If
+the previous link has been used (`used_at IS NOT NULL`) it doesn't count
+toward the limit; a freshly-requested second link replaces the pending
+one.
+
+**Cookie.** `ps_session` — HTTP-only, `Secure` (in prod), `SameSite=Lax`,
+`Path=/`, signed `HMAC-SHA256(SESSION_SECRET, session_id)`. Max-Age 30 days,
+matching the `sessions.expires_at` in D1. Verification rejects a cookie
+whose signature fails _or_ whose `sessions` row is missing / expired.
+
+## Env / secrets
+
+Declared as the `Env` type in `worker/types.ts`:
+
+```ts
+type Env = {
+  DB: D1Database;
+  APP_ORIGIN: string; // e.g. "https://planisphere.app" — cookie redirects
+  SESSION_SECRET: string; // HMAC key — set via `wrangler secret put`
+};
+```
+
+`SESSION_SECRET` is a Worker secret (never committed). `APP_ORIGIN` and the
+D1 binding are in `wrangler.worker.jsonc`. The dev SESSION_SECRET is a
+placeholder string — fine for local development, not for any deployed
+environment.
+
+## What's stubbed in this PR
+
+- **Email delivery.** `email.ts` logs `[auth] magic link for <email>: <url>`
+  to the Worker console. Extracting a `EmailSender` interface means swapping
+  in Resend / Postmark / SES is a one-file change.
+- **Session expiry cleanup.** Expired `sessions` rows are rejected at read
+  time but not pruned. Follow-up.
+- **Magic-link expiry.** Tokens are single-use but have no time-to-live
+  beyond that. Follow-up.
+
+## Deferred (out of scope)
+
+- Stripe billing / webhooks — milestone 2F (#221).
+- Notebook content persistence to D1 — milestone 2D (#219).
+- Rate-limiting beyond the request-link rule.
+- Admin UI.
+
+## Running locally
+
+```
+wrangler d1 create planisphere-dev --local   # one-time
+wrangler d1 migrations apply planisphere-dev --local --config wrangler.worker.jsonc
+pnpm dev                                     # vite + wrangler dev in parallel
+```
+
+`pnpm dev:client` and `pnpm dev:worker` are available for running only one
+side. See `docs/adr/010-worker-deps.md` for why we use `concurrently`.
+
+## Testing
+
+Worker tests colocate with source (`worker/*.test.ts`) and run under
+`@cloudflare/vitest-pool-workers`, which spins up a real workerd isolate +
+D1 binding per test file.
+
+```
+pnpm test:worker
+```
+
+These tests are **not** part of `pnpm test` / `pnpm test:cov` today — per
+the PR scope, Worker code doesn't count toward the Phase-1 `src/**`
+coverage gates. A follow-up will decide what a Worker coverage gate looks
+like.

--- a/worker/crypto.test.ts
+++ b/worker/crypto.test.ts
@@ -1,0 +1,61 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { describe, expect, it } from "vitest";
+import { generateToken, signCookie, verifyCookie } from "./crypto";
+
+const SECRET = "test-secret-at-least-32-bytes-long-please!!";
+
+describe("generateToken", () => {
+  it("produces a UUID-shaped string", () => {
+    const token = generateToken();
+    // RFC 4122 v4: 36 chars, 4 hyphens, hex
+    expect(token).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[1-9a-f][0-9a-f]{3}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+    );
+  });
+
+  it("produces distinct values across calls", () => {
+    const a = generateToken();
+    const b = generateToken();
+    expect(a).not.toBe(b);
+  });
+});
+
+describe("signCookie / verifyCookie", () => {
+  it("round-trips a session id", async () => {
+    const sid = "session-abc-123";
+    const cookie = await signCookie(SECRET, sid);
+    expect(cookie).toContain(sid);
+    expect(cookie).toContain(".");
+    const verified = await verifyCookie(SECRET, cookie);
+    expect(verified).toBe(sid);
+  });
+
+  it("rejects a cookie with a tampered payload", async () => {
+    const sid = "session-abc-123";
+    const cookie = await signCookie(SECRET, sid);
+    const dotIdx = cookie.indexOf(".");
+    const tampered = "session-xyz" + cookie.slice(dotIdx);
+    const verified = await verifyCookie(SECRET, tampered);
+    expect(verified).toBeNull();
+  });
+
+  it("rejects a cookie with a tampered signature", async () => {
+    const sid = "session-abc-123";
+    const cookie = await signCookie(SECRET, sid);
+    const tampered = cookie.slice(0, -4) + "AAAA";
+    const verified = await verifyCookie(SECRET, tampered);
+    expect(verified).toBeNull();
+  });
+
+  it("rejects a cookie with no separator", async () => {
+    const verified = await verifyCookie(SECRET, "no-dot-here");
+    expect(verified).toBeNull();
+  });
+
+  it("rejects a cookie signed with a different secret", async () => {
+    const sid = "session-abc-123";
+    const cookie = await signCookie(SECRET, sid);
+    const verified = await verifyCookie("different-secret", cookie);
+    expect(verified).toBeNull();
+  });
+});

--- a/worker/crypto.ts
+++ b/worker/crypto.ts
@@ -1,0 +1,86 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/**
+ * Small crypto helpers for magic-link tokens + HMAC-signed session cookies.
+ *
+ * Uses the Workers runtime `crypto` / `crypto.subtle` globals directly — no
+ * Node-only APIs, no third-party deps. Runs inside workerd in production and
+ * inside `@cloudflare/vitest-pool-workers` during tests.
+ */
+
+/** Opaque single-use login token. `crypto.randomUUID()` is 122 bits of
+ *  entropy — plenty for a short-lived one-use credential. */
+export function generateToken(): string {
+  return crypto.randomUUID();
+}
+
+/**
+ * Sign a session id with HMAC-SHA256 so the client can carry it in a cookie
+ * without being able to forge it.
+ *
+ * Returns `"<sessionId>.<base64url(signature)>"`. The session id is not
+ * secret — the signature is what makes the pair unforgeable. Verification
+ * uses constant-time byte comparison.
+ */
+export async function signCookie(secret: string, sessionId: string): Promise<string> {
+  const sig = await hmac(secret, sessionId);
+  return `${sessionId}.${b64urlEncode(sig)}`;
+}
+
+/**
+ * Verify a signed cookie and return the session id, or `null` if the cookie
+ * is malformed / tampered / signed with a different secret.
+ */
+export async function verifyCookie(secret: string, cookie: string): Promise<string | null> {
+  const dot = cookie.lastIndexOf(".");
+  if (dot < 1 || dot === cookie.length - 1) return null;
+  const sessionId = cookie.slice(0, dot);
+  const providedSig = b64urlDecode(cookie.slice(dot + 1));
+  if (providedSig === null) return null;
+  const expectedSig = await hmac(secret, sessionId);
+  if (!timingSafeEqual(providedSig, expectedSig)) return null;
+  return sessionId;
+}
+
+async function hmac(secret: string, message: string): Promise<ArrayBuffer> {
+  const enc = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    "raw",
+    enc.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  return crypto.subtle.sign("HMAC", key, enc.encode(message));
+}
+
+function timingSafeEqual(a: ArrayBuffer, b: ArrayBuffer): boolean {
+  if (a.byteLength !== b.byteLength) return false;
+  const av = new Uint8Array(a);
+  const bv = new Uint8Array(b);
+  let diff = 0;
+  for (let i = 0; i < av.length; i++) {
+    // Non-null assertions are safe: i < length.
+    diff |= av[i]! ^ bv[i]!;
+  }
+  return diff === 0;
+}
+
+function b64urlEncode(buf: ArrayBuffer): string {
+  const bytes = new Uint8Array(buf);
+  let s = "";
+  for (let i = 0; i < bytes.length; i++) s += String.fromCharCode(bytes[i]!);
+  return btoa(s).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function b64urlDecode(s: string): ArrayBuffer | null {
+  try {
+    const padded = s.replace(/-/g, "+").replace(/_/g, "/");
+    const pad = padded.length % 4 === 0 ? "" : "=".repeat(4 - (padded.length % 4));
+    const bin = atob(padded + pad);
+    const out = new Uint8Array(bin.length);
+    for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+    return out.buffer;
+  } catch {
+    return null;
+  }
+}

--- a/worker/db.ts
+++ b/worker/db.ts
@@ -1,0 +1,133 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import type { MagicLinkRow, SessionRow, UserRow, UserTier } from "./types";
+
+/**
+ * Hand-rolled D1 helpers. No ORM. Every statement is prepared with bound
+ * parameters — never string concatenation.
+ *
+ * All reads return `null` (or `[]`) rather than throwing when a row is
+ * missing. Route handlers interpret that as a domain condition (e.g.
+ * `invalid_token`) and respond with the right HTTP status.
+ */
+
+const NOW = (): number => Date.now();
+
+export async function getUserByEmail(db: D1Database, email: string): Promise<UserRow | null> {
+  const row = await db
+    .prepare("SELECT id, email, tier, created_at FROM users WHERE email = ? LIMIT 1")
+    .bind(email)
+    .first<UserRow>();
+  return row ?? null;
+}
+
+export async function getUserById(db: D1Database, id: number): Promise<UserRow | null> {
+  const row = await db
+    .prepare("SELECT id, email, tier, created_at FROM users WHERE id = ? LIMIT 1")
+    .bind(id)
+    .first<UserRow>();
+  return row ?? null;
+}
+
+/**
+ * Ensure a user exists for the given email, returning the row. Idempotent —
+ * repeated calls for the same email return the same `id`.
+ */
+export async function upsertUser(
+  db: D1Database,
+  email: string,
+  tier: UserTier = "free",
+): Promise<UserRow> {
+  const existing = await getUserByEmail(db, email);
+  if (existing) return existing;
+  const createdAt = NOW();
+  const result = await db
+    .prepare("INSERT INTO users (email, tier, created_at) VALUES (?, ?, ?)")
+    .bind(email, tier, createdAt)
+    .run();
+  const id = Number(result.meta.last_row_id);
+  return { id, email, tier, created_at: createdAt };
+}
+
+/**
+ * Return the newest pending (unused) magic link for an email, or `null` if
+ * none. Used for the 60-second rate-limit check.
+ */
+export async function getPendingMagicLinkForEmail(
+  db: D1Database,
+  email: string,
+): Promise<MagicLinkRow | null> {
+  const row = await db
+    .prepare(
+      "SELECT token, email, created_at, used_at FROM magic_links " +
+        "WHERE email = ? AND used_at IS NULL ORDER BY created_at DESC LIMIT 1",
+    )
+    .bind(email)
+    .first<MagicLinkRow>();
+  return row ?? null;
+}
+
+export async function insertMagicLink(
+  db: D1Database,
+  token: string,
+  email: string,
+): Promise<MagicLinkRow> {
+  const createdAt = NOW();
+  await db
+    .prepare("INSERT INTO magic_links (token, email, created_at, used_at) VALUES (?, ?, ?, NULL)")
+    .bind(token, email, createdAt)
+    .run();
+  return { token, email, created_at: createdAt, used_at: null };
+}
+
+/**
+ * Consume a magic-link token atomically: return the unused row and mark it
+ * used in the same step. Returns `null` if the token is unknown or already
+ * used.
+ */
+export async function consumeMagicLink(
+  db: D1Database,
+  token: string,
+): Promise<MagicLinkRow | null> {
+  const now = NOW();
+  // UPDATE ... WHERE used_at IS NULL RETURNING * is the atomic "claim" step.
+  const row = await db
+    .prepare(
+      "UPDATE magic_links SET used_at = ? WHERE token = ? AND used_at IS NULL " +
+        "RETURNING token, email, created_at, used_at",
+    )
+    .bind(now, token)
+    .first<MagicLinkRow>();
+  return row ?? null;
+}
+
+export async function insertSession(
+  db: D1Database,
+  sessionId: string,
+  userId: number,
+  expiresAt: number,
+): Promise<SessionRow> {
+  const createdAt = NOW();
+  await db
+    .prepare("INSERT INTO sessions (id, user_id, created_at, expires_at) VALUES (?, ?, ?, ?)")
+    .bind(sessionId, userId, createdAt, expiresAt)
+    .run();
+  return { id: sessionId, user_id: userId, created_at: createdAt, expires_at: expiresAt };
+}
+
+/** Return the session row if present and not yet expired, else `null`. */
+export async function getActiveSession(
+  db: D1Database,
+  sessionId: string,
+): Promise<SessionRow | null> {
+  const row = await db
+    .prepare("SELECT id, user_id, created_at, expires_at FROM sessions WHERE id = ? LIMIT 1")
+    .bind(sessionId)
+    .first<SessionRow>();
+  if (!row) return null;
+  if (row.expires_at <= NOW()) return null;
+  return row;
+}
+
+export async function deleteSession(db: D1Database, sessionId: string): Promise<void> {
+  await db.prepare("DELETE FROM sessions WHERE id = ?").bind(sessionId).run();
+}

--- a/worker/email.ts
+++ b/worker/email.ts
@@ -1,0 +1,29 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/**
+ * Email delivery abstraction. For this PR the only implementation is a
+ * console-log stub — the magic-link token is visible in the Worker log so
+ * a developer can paste it into the callback URL by hand.
+ *
+ * Swapping in a real provider (Resend / Postmark / SES) is a one-file
+ * change: add `ResendEmailSender` (or similar) that implements the
+ * `EmailSender` interface, and wire it in `index.ts`'s factory.
+ */
+
+export type EmailSender = {
+  sendMagicLink(to: string, loginUrl: string): Promise<void>;
+};
+
+/** Dev / test stub. Prints a one-line log that's easy to grep for. */
+export class ConsoleEmailSender implements EmailSender {
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async sendMagicLink(to: string, loginUrl: string): Promise<void> {
+    // eslint-disable-next-line no-console
+    console.log(`[auth] magic link for ${to}: ${loginUrl}`);
+  }
+}
+
+/** Factory used by `index.ts`. In the future this will select based on a
+ *  Worker binding (e.g. `env.EMAIL_PROVIDER`). */
+export function createEmailSender(): EmailSender {
+  return new ConsoleEmailSender();
+}

--- a/worker/env.d.ts
+++ b/worker/env.d.ts
@@ -1,0 +1,10 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/// <reference types="@cloudflare/vitest-pool-workers" />
+
+// Tell `cloudflare:test`'s ProvidedEnv what bindings the Worker expects.
+// Keeps test code honest and lets `test-helpers.ts` export a narrowly-typed
+// `env` without a cast.
+import type { Env } from "./types";
+declare module "cloudflare:test" {
+  interface ProvidedEnv extends Env {}
+}

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -1,0 +1,59 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { createEmailSender } from "./email";
+import { handleCallback, handleLogout, handleMe, handleRequestLink } from "./routes/auth";
+import type { Env } from "./types";
+
+/**
+ * Entry point for the Phase 2 API Worker. Dispatches `/api/auth/*` to the
+ * auth routes. Everything else is a 404. Method-mismatch on a known path
+ * returns 405. See `worker/README.md` for the overall shape.
+ */
+export default {
+  async fetch(request: Request, env: Env, _ctx: ExecutionContext): Promise<Response> {
+    const url = new URL(request.url);
+    const path = url.pathname;
+    const method = request.method.toUpperCase();
+    const emailSender = createEmailSender();
+
+    try {
+      if (path === "/api/auth/request-link") {
+        if (method !== "POST") return methodNotAllowed();
+        return await handleRequestLink(request, env, emailSender);
+      }
+      if (path === "/api/auth/callback") {
+        if (method !== "GET") return methodNotAllowed();
+        return await handleCallback(request, env);
+      }
+      if (path === "/api/auth/logout") {
+        if (method !== "POST") return methodNotAllowed();
+        return await handleLogout(request, env);
+      }
+      if (path === "/api/auth/me") {
+        if (method !== "GET") return methodNotAllowed();
+        return await handleMe(request, env);
+      }
+      return notFound();
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error("[worker] unhandled error", err);
+      return new Response(JSON.stringify({ error: "server_error" }), {
+        status: 500,
+        headers: { "content-type": "application/json" },
+      });
+    }
+  },
+} satisfies ExportedHandler<Env>;
+
+function methodNotAllowed(): Response {
+  return new Response(JSON.stringify({ error: "method_not_allowed" }), {
+    status: 405,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function notFound(): Response {
+  return new Response(JSON.stringify({ error: "not_found" }), {
+    status: 404,
+    headers: { "content-type": "application/json" },
+  });
+}

--- a/worker/routes/auth.test.ts
+++ b/worker/routes/auth.test.ts
@@ -1,0 +1,236 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import worker from "../index";
+import { testEnv, resetDb, extractSessionCookie } from "../test-helpers";
+import type { EmailSender } from "../email";
+
+/**
+ * End-to-end auth-route tests. Runs inside a real workerd isolate via
+ * `@cloudflare/vitest-pool-workers` with an in-memory D1 binding.
+ */
+
+async function fetchWorker(req: Request): Promise<Response> {
+  if (!worker.fetch) throw new Error("worker has no fetch handler");
+  return worker.fetch(req, testEnv, {} as unknown as ExecutionContext);
+}
+
+const BASE = "http://localhost";
+
+beforeEach(async () => {
+  await resetDb();
+});
+
+describe("POST /api/auth/request-link", () => {
+  it("accepts a valid email and returns 202", async () => {
+    const res = await fetchWorker(
+      new Request(`${BASE}/api/auth/request-link`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ email: "alice@example.com" }),
+      }),
+    );
+    expect(res.status).toBe(202);
+  });
+
+  it("persists a users row for the email on first request", async () => {
+    await fetchWorker(
+      new Request(`${BASE}/api/auth/request-link`, {
+        method: "POST",
+        body: JSON.stringify({ email: "Bob@Example.COM" }),
+      }),
+    );
+    const row = await testEnv.DB.prepare("SELECT email FROM users WHERE email = ?")
+      .bind("bob@example.com")
+      .first<{ email: string }>();
+    expect(row?.email).toBe("bob@example.com");
+  });
+
+  it("returns 400 for a malformed email", async () => {
+    const res = await fetchWorker(
+      new Request(`${BASE}/api/auth/request-link`, {
+        method: "POST",
+        body: JSON.stringify({ email: "not-an-email" }),
+      }),
+    );
+    expect(res.status).toBe(400);
+    const body: { error: string } = await res.json();
+    expect(body.error).toBe("invalid_email");
+  });
+
+  it("returns 400 when the body is not JSON", async () => {
+    const res = await fetchWorker(
+      new Request(`${BASE}/api/auth/request-link`, {
+        method: "POST",
+        body: "not json",
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 429 when a second link is requested within 60s", async () => {
+    await fetchWorker(
+      new Request(`${BASE}/api/auth/request-link`, {
+        method: "POST",
+        body: JSON.stringify({ email: "spam@example.com" }),
+      }),
+    );
+    const res = await fetchWorker(
+      new Request(`${BASE}/api/auth/request-link`, {
+        method: "POST",
+        body: JSON.stringify({ email: "spam@example.com" }),
+      }),
+    );
+    expect(res.status).toBe(429);
+    const body: { error: string } = await res.json();
+    expect(body.error).toBe("rate_limited");
+  });
+
+  it("returns 405 for non-POST", async () => {
+    const res = await fetchWorker(new Request(`${BASE}/api/auth/request-link`));
+    expect(res.status).toBe(405);
+  });
+});
+
+describe("GET /api/auth/callback", () => {
+  it("consumes the token, sets a cookie, and redirects to APP_ORIGIN", async () => {
+    // Request a link, read the token straight out of D1.
+    await fetchWorker(
+      new Request(`${BASE}/api/auth/request-link`, {
+        method: "POST",
+        body: JSON.stringify({ email: "claire@example.com" }),
+      }),
+    );
+    const pending = await testEnv.DB.prepare(
+      "SELECT token FROM magic_links WHERE email = ? ORDER BY created_at DESC LIMIT 1",
+    )
+      .bind("claire@example.com")
+      .first<{ token: string }>();
+    expect(pending?.token).toBeTruthy();
+
+    const res = await fetchWorker(new Request(`${BASE}/api/auth/callback?token=${pending!.token}`));
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toContain("http://localhost:5173");
+    const cookie = extractSessionCookie(res);
+    expect(cookie).toBeTruthy();
+    expect(cookie).toContain(".");
+
+    // Session row exists in D1.
+    const session = await testEnv.DB.prepare("SELECT COUNT(*) as n FROM sessions").first<{
+      n: number;
+    }>();
+    expect(session?.n).toBe(1);
+
+    // Second use of the same token should fail — one-shot.
+    const res2 = await fetchWorker(
+      new Request(`${BASE}/api/auth/callback?token=${pending!.token}`),
+    );
+    expect(res2.status).toBe(401);
+  });
+
+  it("returns 400 when token is missing", async () => {
+    const res = await fetchWorker(new Request(`${BASE}/api/auth/callback`));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 401 for an unknown token", async () => {
+    const res = await fetchWorker(new Request(`${BASE}/api/auth/callback?token=does-not-exist`));
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("GET /api/auth/me", () => {
+  async function login(email: string): Promise<string> {
+    await fetchWorker(
+      new Request(`${BASE}/api/auth/request-link`, {
+        method: "POST",
+        body: JSON.stringify({ email }),
+      }),
+    );
+    const pending = await testEnv.DB.prepare(
+      "SELECT token FROM magic_links WHERE email = ? ORDER BY created_at DESC LIMIT 1",
+    )
+      .bind(email)
+      .first<{ token: string }>();
+    const res = await fetchWorker(new Request(`${BASE}/api/auth/callback?token=${pending!.token}`));
+    const cookie = extractSessionCookie(res);
+    return cookie!;
+  }
+
+  it("returns 401 without a cookie", async () => {
+    const res = await fetchWorker(new Request(`${BASE}/api/auth/me`));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401 with a malformed cookie", async () => {
+    const res = await fetchWorker(
+      new Request(`${BASE}/api/auth/me`, {
+        headers: { cookie: "ps_session=bogus" },
+      }),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("returns {email, tier} with a valid session cookie", async () => {
+    const cookie = await login("dave@example.com");
+    const res = await fetchWorker(
+      new Request(`${BASE}/api/auth/me`, {
+        headers: { cookie: `ps_session=${cookie}` },
+      }),
+    );
+    expect(res.status).toBe(200);
+    const body: { email: string; tier: string } = await res.json();
+    expect(body.email).toBe("dave@example.com");
+    expect(body.tier).toBe("free");
+  });
+
+  it("returns 401 after logout", async () => {
+    const cookie = await login("evan@example.com");
+    const logoutRes = await fetchWorker(
+      new Request(`${BASE}/api/auth/logout`, {
+        method: "POST",
+        headers: { cookie: `ps_session=${cookie}` },
+      }),
+    );
+    expect(logoutRes.status).toBe(204);
+
+    const meRes = await fetchWorker(
+      new Request(`${BASE}/api/auth/me`, {
+        headers: { cookie: `ps_session=${cookie}` },
+      }),
+    );
+    expect(meRes.status).toBe(401);
+  });
+});
+
+describe("routing", () => {
+  it("returns 404 for unknown paths", async () => {
+    const res = await fetchWorker(new Request(`${BASE}/api/auth/unknown`));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 405 for wrong method on /me", async () => {
+    const res = await fetchWorker(new Request(`${BASE}/api/auth/me`, { method: "POST" }));
+    expect(res.status).toBe(405);
+  });
+});
+
+describe("email stub", () => {
+  it("logs the magic link URL on request", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    await fetchWorker(
+      new Request(`${BASE}/api/auth/request-link`, {
+        method: "POST",
+        body: JSON.stringify({ email: "logme@example.com" }),
+      }),
+    );
+    const logged = logSpy.mock.calls.some(
+      (c) => typeof c[0] === "string" && c[0].includes("[auth] magic link for logme@example.com"),
+    );
+    expect(logged).toBe(true);
+    logSpy.mockRestore();
+    // Silence the unused-param lint on _ in EmailSender (indirect check).
+    const _shape: EmailSender = { sendMagicLink: async () => {} };
+    void _shape;
+  });
+});

--- a/worker/routes/auth.ts
+++ b/worker/routes/auth.ts
@@ -1,0 +1,150 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { generateToken, signCookie, verifyCookie } from "../crypto";
+import {
+  consumeMagicLink,
+  deleteSession,
+  getActiveSession,
+  getPendingMagicLinkForEmail,
+  getUserById,
+  insertMagicLink,
+  insertSession,
+  upsertUser,
+} from "../db";
+import type { EmailSender } from "../email";
+import {
+  MAGIC_LINK_RATE_WINDOW_MS,
+  SESSION_COOKIE,
+  SESSION_MAX_AGE_SECONDS,
+  type ApiErrorCode,
+  type Env,
+} from "../types";
+
+/**
+ * Routes for `/api/auth/*`. Each handler returns a plain `Response`; the
+ * error shape on the wire is `{error: ApiErrorCode, message?: string}`.
+ */
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+function normalizeEmail(raw: unknown): string | null {
+  if (typeof raw !== "string") return null;
+  const trimmed = raw.trim().toLowerCase();
+  if (!EMAIL_PATTERN.test(trimmed)) return null;
+  return trimmed;
+}
+
+function json(body: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(body), {
+    ...init,
+    headers: { "content-type": "application/json", ...init?.headers },
+  });
+}
+
+function errorJson(code: ApiErrorCode, status: number, message?: string): Response {
+  return json({ error: code, ...(message ? { message } : {}) }, { status });
+}
+
+/** POST /api/auth/request-link */
+export async function handleRequestLink(
+  req: Request,
+  env: Env,
+  email: EmailSender,
+): Promise<Response> {
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return errorJson("invalid_email", 400);
+  }
+  const emailInput =
+    typeof body === "object" && body !== null && "email" in body
+      ? (body as { email: unknown }).email
+      : undefined;
+  const normalized = normalizeEmail(emailInput);
+  if (normalized === null) return errorJson("invalid_email", 400);
+
+  // Rate-limit: one pending link per 60s.
+  const pending = await getPendingMagicLinkForEmail(env.DB, normalized);
+  if (pending && Date.now() - pending.created_at < MAGIC_LINK_RATE_WINDOW_MS) {
+    return errorJson("rate_limited", 429);
+  }
+
+  await upsertUser(env.DB, normalized);
+  const token = generateToken();
+  await insertMagicLink(env.DB, token, normalized);
+
+  const callbackUrl = new URL("/api/auth/callback", env.APP_ORIGIN);
+  callbackUrl.searchParams.set("token", token);
+  await email.sendMagicLink(normalized, callbackUrl.toString());
+
+  return new Response(null, { status: 202 });
+}
+
+/** GET /api/auth/callback?token=... */
+export async function handleCallback(req: Request, env: Env): Promise<Response> {
+  const url = new URL(req.url);
+  const token = url.searchParams.get("token");
+  if (!token) return errorJson("invalid_token", 400);
+
+  const consumed = await consumeMagicLink(env.DB, token);
+  if (!consumed) return errorJson("invalid_token", 401);
+
+  const user = await upsertUser(env.DB, consumed.email);
+  const sessionId = generateToken();
+  const expiresAt = Date.now() + SESSION_MAX_AGE_SECONDS * 1000;
+  await insertSession(env.DB, sessionId, user.id, expiresAt);
+  const signed = await signCookie(env.SESSION_SECRET, sessionId);
+
+  const secureFlag = url.protocol === "https:" ? "; Secure" : "";
+  const cookie =
+    `${SESSION_COOKIE}=${signed}; HttpOnly${secureFlag}; SameSite=Lax; ` +
+    `Path=/; Max-Age=${SESSION_MAX_AGE_SECONDS}`;
+
+  return new Response(null, {
+    status: 302,
+    headers: {
+      "Set-Cookie": cookie,
+      Location: env.APP_ORIGIN + "/",
+    },
+  });
+}
+
+/** POST /api/auth/logout */
+export async function handleLogout(req: Request, env: Env): Promise<Response> {
+  const sessionId = await readSessionId(req, env);
+  if (sessionId !== null) {
+    await deleteSession(env.DB, sessionId);
+  }
+  const url = new URL(req.url);
+  const secureFlag = url.protocol === "https:" ? "; Secure" : "";
+  const cookie = `${SESSION_COOKIE}=; HttpOnly${secureFlag}; SameSite=Lax; Path=/; Max-Age=0`;
+  return new Response(null, { status: 204, headers: { "Set-Cookie": cookie } });
+}
+
+/** GET /api/auth/me */
+export async function handleMe(req: Request, env: Env): Promise<Response> {
+  const sessionId = await readSessionId(req, env);
+  if (sessionId === null) return errorJson("unauthenticated", 401);
+  const session = await getActiveSession(env.DB, sessionId);
+  if (!session) return errorJson("unauthenticated", 401);
+  const user = await getUserById(env.DB, session.user_id);
+  if (!user) return errorJson("unauthenticated", 401);
+  return json({ email: user.email, tier: user.tier });
+}
+
+async function readSessionId(req: Request, env: Env): Promise<string | null> {
+  const raw = parseCookie(req.headers.get("cookie"), SESSION_COOKIE);
+  if (raw === null) return null;
+  return verifyCookie(env.SESSION_SECRET, raw);
+}
+
+function parseCookie(header: string | null, name: string): string | null {
+  if (!header) return null;
+  for (const part of header.split(";")) {
+    const eq = part.indexOf("=");
+    if (eq < 0) continue;
+    const k = part.slice(0, eq).trim();
+    if (k === name) return part.slice(eq + 1).trim();
+  }
+  return null;
+}

--- a/worker/test-helpers.ts
+++ b/worker/test-helpers.ts
@@ -1,0 +1,56 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/**
+ * Small helpers used only by Worker tests — creates the schema on the
+ * in-memory D1 binding before each test and extracts the signed session
+ * cookie from a `Set-Cookie` header.
+ *
+ * The schema DDL is kept identical to `migrations/0001_init.sql`; the
+ * migration file is the source of truth for production, and this helper
+ * mirrors it for tests. Keep them in sync by hand — small cost, no extra
+ * tooling.
+ */
+import { env } from "cloudflare:test";
+import type { Env } from "./types";
+
+// Re-export the bound env so test files get narrow types.
+export const testEnv = env as unknown as Env;
+
+const SCHEMA_STATEMENTS = [
+  `CREATE TABLE users (
+    id INTEGER PRIMARY KEY,
+    email TEXT UNIQUE NOT NULL,
+    tier TEXT NOT NULL DEFAULT 'free',
+    created_at INTEGER NOT NULL
+  )`,
+  `CREATE TABLE magic_links (
+    token TEXT PRIMARY KEY,
+    email TEXT NOT NULL,
+    created_at INTEGER NOT NULL,
+    used_at INTEGER
+  )`,
+  `CREATE TABLE sessions (
+    id TEXT PRIMARY KEY,
+    user_id INTEGER NOT NULL,
+    created_at INTEGER NOT NULL,
+    expires_at INTEGER NOT NULL,
+    FOREIGN KEY (user_id) REFERENCES users(id)
+  )`,
+  `CREATE INDEX idx_magic_links_email ON magic_links(email)`,
+  `CREATE INDEX idx_sessions_expires ON sessions(expires_at)`,
+] as const;
+
+export async function resetDb(): Promise<void> {
+  await testEnv.DB.prepare("DROP TABLE IF EXISTS sessions").run();
+  await testEnv.DB.prepare("DROP TABLE IF EXISTS magic_links").run();
+  await testEnv.DB.prepare("DROP TABLE IF EXISTS users").run();
+  for (const stmt of SCHEMA_STATEMENTS) {
+    await testEnv.DB.prepare(stmt).run();
+  }
+}
+
+export function extractSessionCookie(res: Response): string | null {
+  const header = res.headers.get("set-cookie");
+  if (!header) return null;
+  const match = header.match(/ps_session=([^;]+)/);
+  return match ? match[1]! : null;
+}

--- a/worker/types.ts
+++ b/worker/types.ts
@@ -1,0 +1,52 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/** D1 + secret bindings available to the Worker. Populated by the runtime
+ *  from `wrangler.worker.jsonc` + `wrangler secret put`. */
+export type Env = {
+  readonly DB: D1Database;
+  readonly APP_ORIGIN: string;
+  readonly SESSION_SECRET: string;
+};
+
+/** User row in D1. Tier is a string column; the narrow union is enforced
+ *  in TypeScript at every read site. */
+export type UserTier = "free" | "pro";
+
+export type UserRow = {
+  readonly id: number;
+  readonly email: string;
+  readonly tier: UserTier;
+  readonly created_at: number;
+};
+
+export type MagicLinkRow = {
+  readonly token: string;
+  readonly email: string;
+  readonly created_at: number;
+  readonly used_at: number | null;
+};
+
+export type SessionRow = {
+  readonly id: string;
+  readonly user_id: number;
+  readonly created_at: number;
+  readonly expires_at: number;
+};
+
+/** Wire error code used in API JSON bodies. The client maps these into a
+ *  narrow `AuthError` union in `src/auth.ts`. */
+export type ApiErrorCode =
+  | "invalid_email"
+  | "rate_limited"
+  | "invalid_token"
+  | "unauthenticated"
+  | "server_error"
+  | "method_not_allowed"
+  | "not_found";
+
+/** The session cookie name. HTTP-only + signed (see `crypto.ts`). */
+export const SESSION_COOKIE = "ps_session";
+/** Max session age, in seconds (30 days). */
+export const SESSION_MAX_AGE_SECONDS = 60 * 60 * 24 * 30;
+/** One-pending-link-per-email window, in milliseconds. */
+export const MAGIC_LINK_RATE_WINDOW_MS = 60_000;

--- a/wrangler.worker.jsonc
+++ b/wrangler.worker.jsonc
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Standalone Worker config for the Phase 2 API (auth, notebooks, Stripe webhooks).
+// The Pages SPA is still deployed via the top-level `wrangler.jsonc` against the
+// `dist/` static bundle — see ADR 009. Keeping the two configs separate means
+// `wrangler dev` / `wrangler deploy` for the Worker never touches the SPA build,
+// and the SPA deploy pipeline keeps its old shape.
+{
+  "name": "planisphere-api",
+  "main": "worker/index.ts",
+  "compatibility_date": "2026-04-16",
+  "compatibility_flags": ["nodejs_compat"],
+
+  // D1 binding. The database ID below is a placeholder — before first deploy,
+  // run `wrangler d1 create planisphere-dev` (and a prod equivalent) and paste
+  // the returned UUID here. Local `wrangler dev` uses an in-memory SQLite
+  // instance automatically.
+  "d1_databases": [
+    {
+      "binding": "DB",
+      "database_name": "planisphere-dev",
+      "database_id": "00000000-0000-0000-0000-000000000000",
+      "migrations_dir": "migrations",
+    },
+  ],
+
+  // Non-secret defaults. The real SESSION_SECRET must be set out-of-band with
+  //   wrangler secret put SESSION_SECRET
+  // (never committed). APP_ORIGIN is the client URL that magic-link callbacks
+  // redirect to; override per environment.
+  "vars": {
+    "APP_ORIGIN": "http://localhost:5173",
+    "SESSION_SECRET": "dev-only-placeholder-replace-with-wrangler-secret-put",
+  },
+
+  "observability": {
+    "enabled": true,
+  },
+}


### PR DESCRIPTION
Milestone 2C of Plan 07 Phase 2. First real backend work in the repo: a
Cloudflare Worker + D1 magic-link auth slice, wired through a typed client
hook.

## What's real

**Backend — `worker/` (new top-level dir; separate deploy from the Pages SPA).**

- `POST /api/auth/request-link` — validates email, rate-limits to one
  pending token per email per 60s, inserts a `magic_links` row, calls
  `EmailSender.sendMagicLink`.
- `GET /api/auth/callback?token=...` — atomically claims the token
  (`UPDATE ... WHERE used_at IS NULL RETURNING *`), upserts the user,
  inserts a session, sets a signed `ps_session` cookie
  (HTTP-only + SameSite=Lax; `Secure` when the callback is HTTPS),
  redirects to `APP_ORIGIN/`.
- `POST /api/auth/logout` — deletes the session row, clears the cookie.
- `GET /api/auth/me` — verifies the cookie signature + live `sessions`
  row; returns `{email, tier}` or 401.

Sessions are HMAC-SHA256-signed via `crypto.subtle` (no deps). Tokens are
`crypto.randomUUID()` — single-use. D1 helpers are hand-rolled prepared
statements — no ORM. Schema + indexes in `migrations/0001_init.sql`.

**Client — `src/`**

- `src/auth.ts` — `requestMagicLink() -> Result<void, AuthError>`,
  `currentUser() -> AuthUser | null`, `logout() -> void`. 100% line /
  92.3% branch coverage.
- `src/ui/login-modal.ts` — email input + "Check your email" state,
  callback-injected requester so it's trivially mockable. 97% line /
  88% branch.

**Infra**

- `wrangler.worker.jsonc` — new, standalone Worker config (keeps the
  existing SPA `wrangler.jsonc` untouched).
- `tsconfig.worker.json` + `pnpm typecheck` now covers both SPA and
  Worker.
- `vitest.worker.config.ts` + `pnpm test:worker` run the Worker tests
  under `@cloudflare/vitest-pool-workers` (real workerd + in-memory D1,
  23 tests, all passing).
- `pnpm dev` runs Vite and `wrangler dev` in parallel via `concurrently`.
- ADR 010 covers the two new dev deps (both MIT, dev-only).

## What's stubbed

- **Email delivery.** `worker/email.ts` exposes an `EmailSender`
  interface; the one implementation is `ConsoleEmailSender`, which
  `console.log`s `[auth] magic link for <email>: <url>`. Swapping in a
  real provider (Resend / Postmark / SES) is a one-file change
  — tracked as a follow-up.

## What's deferred (out of scope for this PR)

- Stripe billing / webhooks — milestone 2F (#221).
- Notebook content persistence to D1 — milestone 2D (#219).
- Magic-link time-to-live beyond single-use, and expired-session pruning
  — small follow-up.
- Rate-limiting beyond the one-link-per-60s-per-email rule.
- CI job to run Worker tests + Worker coverage gates — follow-up.
  Right now `pnpm test:cov` covers only `src/**`, per the PR scope.
- Admin UI.

## Coordination with #224 (`features.ts` + email-gate-modal)

#224 is still open at the time this PR was drafted. This PR **does not**
yet swap `src/features.ts` to read `currentUser()` — because `features.ts`
doesn't exist yet. When #224 merges, one small follow-up will:

1. Repoint `features.ts::isPro()` at `currentUser()` (keeping the
   localStorage shape as a fallback so existing users don't get dumped
   out).
2. Rebadge `email-gate-modal` to call `requestMagicLink` and share the
   rendering with `login-modal.ts` (likely: `login-modal.ts` is the real
   impl, `email-gate-modal` becomes a thin wrapper).

If #224 lands after this PR and before that follow-up, no user-facing
regression — the two modules are wired independently today and the gate
still works via localStorage.

## Pre-push gate

`pnpm typecheck && pnpm lint && pnpm format:check && pnpm test:cov && pnpm build` — all green locally.
Worker tests (`pnpm test:worker`) — 23/23 passing.

## Heads-up for reviewers

- **Secrets.** `SESSION_SECRET` is a Worker secret (`wrangler secret
  put`); the value in `wrangler.worker.jsonc` is a dev-only placeholder.
- **D1 binding.** The `database_id` in `wrangler.worker.jsonc` is a
  placeholder UUID — before first deploy, run
  `wrangler d1 create planisphere-dev` and paste the returned id.
- **Dev loop.** `pnpm dev` now runs two processes (Vite + wrangler).
  `pnpm dev:client` and `pnpm dev:worker` are available for running just
  one.
- **Scope.** Module-boundary rule updated in `worker/README.md`: `src/`
  and `worker/` do not import each other. Shared shapes (like
  `{email, tier}`) live on the wire only.

Closes #218.

🤖 Generated with [Claude Code](https://claude.com/claude-code)