### PR TITLE
fix(ui): auto-size side panel, wrap header icons (closes #228)

### DIFF
--- a/src/ui/panel.test.ts
+++ b/src/ui/panel.test.ts
@@ -322,6 +322,36 @@ describe("createPanel", () => {
     });
   });
 
+  describe("layout regressions (issue #228)", () => {
+    it("allows the header button group to wrap so the row of icons cannot force horizontal overflow", () => {
+      // Post-Phase-1 the header carries 7+ icon buttons. With PANEL_WIDTH
+      // fixed at 280px, a single non-wrapping row overflows and makes the
+      // panel appear wider at the top than at its body. The header row
+      // (or its btn group) must permit flex wrapping.
+      const { element } = createPanel(container);
+      const header = element.querySelector<HTMLElement>("[data-testid='panel-header']")!;
+      const btnGroup = header.children[1] as HTMLElement;
+      const headerWraps = header.style.flexWrap === "wrap";
+      const btnGroupWraps = btnGroup.style.flexWrap === "wrap";
+      expect(headerWraps || btnGroupWraps).toBe(true);
+    });
+
+    it("does not impose an overflow-y:auto that would render a spurious scrollbar on short content", () => {
+      // After Phase 1 the body content is short (search + location + view +
+      // fov). A panel-wide overflow-y:auto combined with max-height:80vh is
+      // sized for the pre-Phase-1 content and renders an unwanted scrollbar.
+      const { element } = createPanel(container);
+      expect(element.style.overflowY).not.toBe("auto");
+    });
+
+    it("does not clamp the panel to a viewport-relative max-height larger than its content", () => {
+      // Let block layout size the panel to its content; the old 80vh cap is
+      // left over from when the panel carried the events/time/layers UIs.
+      const { element } = createPanel(container);
+      expect(element.style.maxHeight).toBe("");
+    });
+  });
+
   describe("copy-link button", () => {
     beforeEach(() => {
       Object.defineProperty(navigator, "clipboard", {

--- a/src/ui/panel.ts
+++ b/src/ui/panel.ts
@@ -5,7 +5,6 @@ import {
   PANEL_BORDER,
   PANEL_RADIUS,
   PANEL_WIDTH,
-  PANEL_MAX_HEIGHT,
   TEXT_COLOR,
   applyButton,
 } from "./styles";
@@ -49,8 +48,10 @@ export function createPanel(
   panel.style.top = "16px";
   panel.style.right = "16px";
   panel.style.width = PANEL_WIDTH;
-  panel.style.maxHeight = PANEL_MAX_HEIGHT;
-  panel.style.overflowY = "auto";
+  // Let the panel auto-size to its (post-Phase-1) short content. The old
+  // 80vh cap + overflow-y:auto was sized for the pre-Phase-1 UI and now
+  // renders an unwanted scrollbar. See issue #228.
+  panel.style.overflowY = "visible";
   panel.style.background = PANEL_BG;
   panel.style.border = PANEL_BORDER;
   panel.style.borderRadius = PANEL_RADIUS;
@@ -63,6 +64,10 @@ export function createPanel(
   header.style.display = "flex";
   header.style.justifyContent = "space-between";
   header.style.alignItems = "center";
+  // Title + 7 icon buttons don't fit on one row inside PANEL_WIDTH. Allow
+  // the row to wrap so the header cannot force horizontal overflow.
+  header.style.flexWrap = "wrap";
+  header.style.gap = "4px";
   header.style.padding = "8px 12px";
   header.style.borderBottom = "1px solid rgba(255,255,255,0.15)";
 
@@ -75,6 +80,7 @@ export function createPanel(
 
   const btnGroup = document.createElement("div");
   btnGroup.style.display = "flex";
+  btnGroup.style.flexWrap = "wrap";
   btnGroup.style.gap = "4px";
   btnGroup.style.alignItems = "center";
 

--- a/src/ui/styles.ts
+++ b/src/ui/styles.ts
@@ -4,7 +4,6 @@ export const PANEL_BG = "rgba(0, 0, 0, 0.85)";
 export const PANEL_BORDER = "1px solid rgba(255, 255, 255, 0.2)";
 export const PANEL_RADIUS = "8px";
 export const PANEL_WIDTH = "280px";
-export const PANEL_MAX_HEIGHT = "80vh";
 export const ACCENT_COLOR = "#00FF88";
 export const TEXT_COLOR = "#ffffff";
 export const FONT_SIZE = "13px";


### PR DESCRIPTION
## Summary
- Allow the panel header (and its btn group) to flex-wrap so the 7-icon row cannot force horizontal overflow on the 280px panel.
- Drop the `maxHeight: 80vh` cap and switch `overflowY` to `visible` so the panel auto-sizes to its (post-Phase-1) short content instead of rendering a spurious scrollbar.
- Remove the now-unused `PANEL_MAX_HEIGHT` constant.

Closes #228.

## Test plan
- [x] 3 new failing-first tests in `src/ui/panel.test.ts` under `layout regressions (issue #228)` — header wrap, no `overflow-y: auto`, no `max-height` clamp
- [x] `pnpm typecheck && pnpm lint && pnpm format:check && pnpm test:cov && pnpm build` green locally (1141 tests pass, coverage gates met)
- [ ] Manual: verify on a 1080p viewport — panel fits header on one row, no vertical scrollbar in default state
- [ ] Manual: verify narrow viewport (< 520px) — header wraps, drawers/modals still layer on top as expected

https://claude.ai/code/session_014DzXBVSCw5T2nnQvQjJtzS