### PR TITLE
feat(worker): session-cookie + session-id helpers (#218)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,8 @@ src/
   state/     URL-synced app state
   result/    Result<T, E> + helpers
   app.ts     composition root
+worker/      Cloudflare Worker backend (Phase 2; see ADR 009, ADR 010).
+             Not importable from src/. src/ does not import Workers types.
 data/        bundled star, constellation, TLE data
 docs/
   specs/     design specs (source of truth)

--- a/scripts/check-spdx.mjs
+++ b/scripts/check-spdx.mjs
@@ -18,6 +18,7 @@ function findFiles(dir, ext, recursive) {
 
 const files = [
   ...findFiles("src", ".ts", true),
+  ...findFiles("worker", ".ts", true),
   ...findFiles("scripts", ".mjs", true),
   ...findFiles(".", ".ts", false),
 ];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,6 +28,6 @@
 
     "types": ["vite/client"]
   },
-  "include": ["src"],
+  "include": ["src", "worker"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,13 +11,19 @@ export default defineConfig({
   test: {
     environment: "jsdom",
     globals: false,
-    include: ["src/**/*.test.ts"],
+    include: ["src/**/*.test.ts", "worker/**/*.test.ts"],
     coverage: {
       provider: "v8",
       reporter: ["text", "html", "lcov"],
       reportsDirectory: "./coverage",
-      include: ["src/**/*.ts"],
-      exclude: ["src/**/*.test.ts", "src/main.ts", "src/env.d.ts", "src/**/index.ts"],
+      include: ["src/**/*.ts", "worker/**/*.ts"],
+      exclude: [
+        "src/**/*.test.ts",
+        "worker/**/*.test.ts",
+        "src/main.ts",
+        "src/env.d.ts",
+        "src/**/index.ts",
+      ],
       thresholds: {
         // Project-wide floor
         lines: 85,
@@ -78,6 +84,16 @@ export default defineConfig({
           statements: 60,
           functions: 60,
           branches: 50,
+        },
+
+        // Cloudflare Worker (backend) — pure utilities in this slice; hold to
+        // the same bar as src/astro etc. Raise later if we add runtime code
+        // that's impractical to test under jsdom.
+        "worker/**": {
+          lines: 90,
+          statements: 90,
+          functions: 90,
+          branches: 85,
         },
       },
     },

--- a/worker/session.test.ts
+++ b/worker/session.test.ts
@@ -1,0 +1,144 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { describe, expect, it } from "vitest";
+import {
+  SESSION_COOKIE_NAME,
+  SESSION_MAX_AGE_SECONDS,
+  buildClearSessionCookie,
+  buildSessionCookie,
+  generateSessionId,
+  parseCookieHeader,
+  readSessionCookie,
+} from "./session";
+
+describe("generateSessionId", () => {
+  it("returns a 43-char base64url string (32 random bytes, no padding)", () => {
+    const id = generateSessionId();
+    expect(id).toMatch(/^[A-Za-z0-9_-]{43}$/);
+  });
+
+  it("produces distinct values on repeat calls (randomness is actually used)", () => {
+    const seen = new Set<string>();
+    for (let i = 0; i < 10; i++) seen.add(generateSessionId());
+    expect(seen.size).toBe(10);
+  });
+});
+
+describe("parseCookieHeader", () => {
+  it("returns an empty map for a null header", () => {
+    expect(parseCookieHeader(null).size).toBe(0);
+  });
+
+  it("returns an empty map for an empty string", () => {
+    expect(parseCookieHeader("").size).toBe(0);
+  });
+
+  it("parses a single cookie", () => {
+    const m = parseCookieHeader("foo=bar");
+    expect(m.get("foo")).toBe("bar");
+  });
+
+  it("parses multiple cookies separated by semicolons", () => {
+    const m = parseCookieHeader("foo=1; bar=2; baz=3");
+    expect(m.get("foo")).toBe("1");
+    expect(m.get("bar")).toBe("2");
+    expect(m.get("baz")).toBe("3");
+    expect(m.size).toBe(3);
+  });
+
+  it("trims whitespace around keys and values", () => {
+    const m = parseCookieHeader("  foo  =  bar  ;  baz=qux  ");
+    expect(m.get("foo")).toBe("bar");
+    expect(m.get("baz")).toBe("qux");
+  });
+
+  it("URL-decodes cookie values (RFC 6265 interop)", () => {
+    const m = parseCookieHeader("greeting=hello%20world");
+    expect(m.get("greeting")).toBe("hello world");
+  });
+
+  it("leaves values alone when they are not well-formed percent-encoded", () => {
+    const m = parseCookieHeader("bad=%E0%A4");
+    expect(m.get("bad")).toBe("%E0%A4");
+  });
+
+  it("ignores malformed entries that have no '='", () => {
+    const m = parseCookieHeader("malformed; foo=bar");
+    expect(m.get("foo")).toBe("bar");
+    expect(m.size).toBe(1);
+  });
+
+  it("ignores entries whose key is empty after trimming", () => {
+    const m = parseCookieHeader("=orphan; foo=bar");
+    expect(m.get("foo")).toBe("bar");
+    expect(m.size).toBe(1);
+  });
+
+  it("uses the last value when the same name appears twice", () => {
+    const m = parseCookieHeader("foo=1; foo=2");
+    expect(m.get("foo")).toBe("2");
+  });
+});
+
+describe("readSessionCookie", () => {
+  it("returns null when the header is null", () => {
+    expect(readSessionCookie(null)).toBeNull();
+  });
+
+  it("returns null when the session cookie is absent", () => {
+    expect(readSessionCookie("other=1; nope=2")).toBeNull();
+  });
+
+  it("returns the session value when present among other cookies", () => {
+    const header = `other=1; ${SESSION_COOKIE_NAME}=abc123; nope=2`;
+    expect(readSessionCookie(header)).toBe("abc123");
+  });
+});
+
+describe("buildSessionCookie", () => {
+  it("emits a Set-Cookie value with the ADR-10 attributes", () => {
+    const s = buildSessionCookie("abc", { maxAgeSeconds: 60 });
+    expect(s).toMatch(new RegExp(`^${SESSION_COOKIE_NAME}=abc;`));
+    expect(s).toContain("HttpOnly");
+    expect(s).toContain("Secure");
+    expect(s).toContain("SameSite=Lax");
+    expect(s).toContain("Path=/");
+    expect(s).toContain("Max-Age=60");
+  });
+
+  it("floors fractional Max-Age values and clamps negatives to zero", () => {
+    expect(buildSessionCookie("x", { maxAgeSeconds: 3.9 })).toContain("Max-Age=3");
+    expect(buildSessionCookie("x", { maxAgeSeconds: -5 })).toContain("Max-Age=0");
+  });
+
+  it("URL-encodes special characters in the session id", () => {
+    const s = buildSessionCookie("a b", { maxAgeSeconds: 60 });
+    expect(s.startsWith(`${SESSION_COOKIE_NAME}=a%20b;`)).toBe(true);
+  });
+
+  it("round-trips through parseCookieHeader / readSessionCookie", () => {
+    const id = generateSessionId();
+    const setCookie = buildSessionCookie(id, { maxAgeSeconds: SESSION_MAX_AGE_SECONDS });
+    // A browser sends back only `name=value` on subsequent requests (attrs
+    // aren't echoed), so emulate that by slicing at the first `;`.
+    const cookieHeader = setCookie.split(";")[0] ?? "";
+    expect(readSessionCookie(cookieHeader)).toBe(id);
+  });
+});
+
+describe("buildClearSessionCookie", () => {
+  it("emits a Set-Cookie that expires the session cookie immediately", () => {
+    const s = buildClearSessionCookie();
+    expect(s).toMatch(new RegExp(`^${SESSION_COOKIE_NAME}=;`));
+    expect(s).toContain("Max-Age=0");
+    expect(s).toContain("HttpOnly");
+    expect(s).toContain("Secure");
+    expect(s).toContain("SameSite=Lax");
+    expect(s).toContain("Path=/");
+  });
+});
+
+describe("SESSION_MAX_AGE_SECONDS", () => {
+  it("is 30 days per ADR 010", () => {
+    expect(SESSION_MAX_AGE_SECONDS).toBe(30 * 24 * 60 * 60);
+  });
+});

--- a/worker/session.ts
+++ b/worker/session.ts
@@ -1,0 +1,90 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/**
+ * Session cookie + session-id helpers for the Workers auth layer.
+ *
+ * Pure, side-effect-free utilities against Web-standard APIs
+ * (`crypto.getRandomValues`, `btoa`, `encodeURIComponent`). No Cloudflare
+ * runtime types, no D1, no `fetch`. Callable from the Worker and testable
+ * under plain vitest. See ADR 010 for the session model.
+ */
+
+export const SESSION_COOKIE_NAME = "planisphere_session";
+
+/** 30 days. Rolling: refreshed on each authenticated request (ADR 010). */
+export const SESSION_MAX_AGE_SECONDS = 30 * 24 * 60 * 60;
+
+/** 32 bytes of randomness, base64url-encoded (43 chars, no padding). */
+export function generateSessionId(): string {
+  const bytes = new Uint8Array(32);
+  crypto.getRandomValues(bytes);
+  return base64UrlEncode(bytes);
+}
+
+function base64UrlEncode(bytes: Uint8Array): string {
+  let binary = "";
+  for (const b of bytes) binary += String.fromCharCode(b);
+  return btoa(binary).replaceAll("+", "-").replaceAll("/", "_").replaceAll("=", "");
+}
+
+/**
+ * Parse the HTTP `Cookie:` request header into a key→value map. Duplicate
+ * names resolve to the last occurrence (the simple, predictable rule —
+ * matches how `document.cookie` is usually consumed). Malformed segments
+ * without `=` or with an empty key are skipped. Values are
+ * percent-decoded; malformed sequences pass through untouched.
+ */
+export function parseCookieHeader(header: string | null): Map<string, string> {
+  const out = new Map<string, string>();
+  if (header === null || header.length === 0) return out;
+  for (const part of header.split(";")) {
+    const idx = part.indexOf("=");
+    if (idx < 0) continue;
+    const key = part.slice(0, idx).trim();
+    if (key.length === 0) continue;
+    const rawVal = part.slice(idx + 1).trim();
+    let val = rawVal;
+    try {
+      val = decodeURIComponent(rawVal);
+    } catch {
+      // Leave raw if the value isn't well-formed percent-encoded.
+    }
+    out.set(key, val);
+  }
+  return out;
+}
+
+/** Return the session token from a Cookie header, or null if not present. */
+export function readSessionCookie(header: string | null): string | null {
+  const cookies = parseCookieHeader(header);
+  return cookies.get(SESSION_COOKIE_NAME) ?? null;
+}
+
+/**
+ * Build a `Set-Cookie` value that establishes a session cookie with the
+ * security attributes mandated by ADR 010: HttpOnly, Secure, SameSite=Lax,
+ * Path=/, and an explicit Max-Age (clamped to a non-negative integer).
+ */
+export function buildSessionCookie(id: string, opts: { maxAgeSeconds: number }): string {
+  const maxAge = Math.max(0, Math.floor(opts.maxAgeSeconds));
+  return [
+    `${SESSION_COOKIE_NAME}=${encodeURIComponent(id)}`,
+    `Max-Age=${maxAge}`,
+    "Path=/",
+    "HttpOnly",
+    "Secure",
+    "SameSite=Lax",
+  ].join("; ");
+}
+
+/** Build a `Set-Cookie` value that clears the session cookie immediately. */
+export function buildClearSessionCookie(): string {
+  return [
+    `${SESSION_COOKIE_NAME}=`,
+    "Max-Age=0",
+    "Path=/",
+    "HttpOnly",
+    "Secure",
+    "SameSite=Lax",
+  ].join("; ");
+}


### PR DESCRIPTION
## Summary

First implementation slice of issue #218 / ADR 010. Deliberately small and deploy-safe: pure utilities only, no Workers entrypoint, no `wrangler.jsonc` changes, no D1, no routes. The next PR (schema + `/api/auth/me`) builds on these.

- `worker/session.ts` — `generateSessionId()` (32 random bytes, base64url), `parseCookieHeader()`, `readSessionCookie()`, `buildSessionCookie()`, `buildClearSessionCookie()`. All Web-standard APIs (`crypto.getRandomValues`, `btoa`, `encodeURIComponent`), no Cloudflare runtime imports.
- Cookie attributes are ADR-010-mandated: `HttpOnly; Secure; SameSite=Lax; Path=/; Max-Age=30d` (rolling).
- `worker/session.test.ts` — 21 tests written red-first, covering randomness, cookie round-trip, malformed input, duplicates, and attribute emission.

## Tooling plumbing

- `tsconfig.json` — `include` now covers `worker/`.
- `vitest.config.ts` — discovers `worker/**/*.test.ts`, adds coverage for `worker/**.ts` with the same 90%/85% pure-module floor used by `src/astro` etc.
- `scripts/check-spdx.mjs` — scans `worker/` for Apache-2.0 headers.
- `CLAUDE.md` — documents `worker/` in the repo-layout section with the module-boundary rule from ADR 009 ("not importable from `src/`").
- No new npm dependencies.
- No change to `wrangler.jsonc` or the production deploy path.

## Test plan
- [x] `pnpm typecheck && pnpm lint && pnpm format:check && pnpm test:cov && pnpm build` green locally
- [x] `worker/session.ts` at 100% line / 100% branch coverage
- [x] All 1162 existing tests still pass
- [ ] CI to confirm Cloudflare preview still deploys the static SPA unchanged (no Worker entrypoint introduced here)

## Follow-ups (tracked against #218, not this PR)
- Schema migration (users, sessions, magic_link_tokens, oauth_identities, oauth_states)
- Worker entrypoint + `wrangler.jsonc` D1 binding + `GET /api/auth/me`
- Magic-link flow + Resend integration
- OAuth flows (Google + GitHub)
- Client integration + 14-day trial mechanic

https://claude.ai/code/session_014DzXBVSCw5T2nnQvQjJtzS