### PR TITLE
chore: post-#227 cleanup — renumber ADR 010→012, ignore .wrangler/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ coverage/
 # Claude Code
 .claude/
 
+# Wrangler / miniflare local dev state (local D1 sqlite, caches)
+.wrangler/
+
 # Editor / OS
 .DS_Store
 .vscode/

--- a/docs/adr/011-auth-mechanism-shipped.md
+++ b/docs/adr/011-auth-mechanism-shipped.md
@@ -94,8 +94,8 @@ SESSION_SECRET`). The value in `wrangler.worker.jsonc` is a dev-only
 - **Naming: `ADR 010` in this repo is this repo's first auth-mechanism
   decision; `ADR 011` is the shipped revision.** PR #227 authored its own
   ADR at `docs/adr/010-worker-deps.md` before 010-auth-mechanism landed;
-  on rebase that file must be renumbered (the next free slot after this
-  ADR is `ADR 012`). The rename is mechanical; no content change.
+  that file is renumbered to `docs/adr/012-worker-deps.md` as part of the
+  cleanup following #227's merge.
 
 ## Follow-ups tracked against #218 (not this ADR)
 

--- a/docs/adr/012-worker-deps.md
+++ b/docs/adr/012-worker-deps.md
@@ -1,4 +1,4 @@
-# ADR 010 — Worker dev deps: `@cloudflare/vitest-pool-workers` + `concurrently`
+# ADR 012 — Worker dev deps: `@cloudflare/vitest-pool-workers` + `concurrently`
 
 **Date:** 2026-04-18
 **Status:** Accepted

--- a/worker/README.md
+++ b/worker/README.md
@@ -2,7 +2,9 @@
 
 First backend code in this repo. Scope and rationale are in
 [ADR 009](../docs/adr/009-backend-selection.md); the dev-dep choices for
-testing and local dev are in [ADR 010](../docs/adr/010-worker-deps.md).
+testing and local dev are in [ADR 012](../docs/adr/012-worker-deps.md).
+The shipped auth design is [ADR 011](../docs/adr/011-auth-mechanism-shipped.md)
+(supersedes the initial [ADR 010](../docs/adr/010-auth-mechanism.md)).
 
 This Worker owns the `/api/*` surface for the Notebook-tier features. Milestone
 2C (this PR, closes #218) ships the magic-link auth slice; notebook CRUD
@@ -143,7 +145,7 @@ pnpm dev                                     # vite + wrangler dev in parallel
 ```
 
 `pnpm dev:client` and `pnpm dev:worker` are available for running only one
-side. See `docs/adr/010-worker-deps.md` for why we use `concurrently`.
+side. See `docs/adr/012-worker-deps.md` for why we use `concurrently`.
 
 ## Testing
 


### PR DESCRIPTION
## Summary

Two small cleanup items flagged during #227's merge review:

- **ADR numbering collision.** After #230 (ADR 010 auth-mechanism), #232 (ADR 011 auth-mechanism-shipped), and #227 (which carried its own ADR as `010-worker-deps.md`), `main` had two files both numbered 010. ADR 011 explicitly named `012` as the next free slot. This PR renames `docs/adr/010-worker-deps.md` → `docs/adr/012-worker-deps.md`, fixes the heading inside, and updates the two references (`worker/README.md`, `docs/adr/011-auth-mechanism-shipped.md`).
- **`.wrangler/` in `.gitignore`.** Miniflare's local-dev state (local D1 sqlite + caches) was showing as untracked after every `pnpm dev`.

Docs + gitignore only. No code, no test changes. Full gate green locally (1164 tests, typecheck covers both SPA and Worker).

Follow-ups still queued from my #227 comment (not in this PR):
- D1 migration auto-apply on `pnpm dev` (currently manual)
- `APP_ORIGIN` vs Vite proxy for local callback URL
- Wire `src/ui/login-modal.ts` into `src/app.ts` so the dialog actually renders

https://claude.ai/code/session_014DzXBVSCw5T2nnQvQjJtzS