### PR TITLE
feat(email): magic-link email via Resend (ADR 014)

### DIFF
--- a/docs/adr/014-email-delivery.md
+++ b/docs/adr/014-email-delivery.md
@@ -1,0 +1,102 @@
+# ADR 014 — Email delivery: Resend HTTP API
+
+**Date:** 2026-04-20
+**Status:** Accepted
+
+## Context
+
+ADR 011 and the shipped auth slice (#227) added `worker/email.ts` with an
+`EmailSender` interface and a `ConsoleEmailSender` stub that logs the
+magic-link URL to the Worker console. That stub is fine for local dev
+and the private beta — a grepable `[auth] magic link for …` line in
+`wrangler tail` is faster than a round trip to an inbox — but it means
+nobody outside the development loop can actually sign in.
+
+We need real email delivery before we ship sign-in to anyone who isn't
+tailing the Worker logs. The requirements:
+
+1. **Transactional**, not marketing — magic links, deliverability-first.
+2. **HTTP-API-based**, reachable from a Cloudflare Worker using only
+   `fetch()`. No Node-only SMTP libs, no `@aws-sdk/*` packages bloating
+   the Worker bundle.
+3. **Permissive license on any SDK we might eventually add** — in
+   practice we'll use raw `fetch`, keeping the dep surface zero.
+4. **Sensible free / low-volume pricing** for the private beta.
+5. **Domain-verification story** that lives in DNS (SPF, DKIM), so the
+   migration cost to another provider later is "swap the sender class +
+   update DNS," not "re-architect email."
+
+## Decision
+
+Use **Resend** (https://resend.com) as the email provider, called via
+its HTTP API (`POST https://api.resend.com/emails`) directly from the
+Worker with `fetch`.
+
+Concretely:
+
+- No new npm dependency. `ResendEmailSender` lives in
+  `worker/email.ts` alongside the existing `ConsoleEmailSender` and
+  implements the same `EmailSender` interface.
+- API key is a Worker secret: `RESEND_API_KEY` (set via
+  `wrangler secret put`). Missing / empty → factory falls back to
+  `ConsoleEmailSender`. This keeps local dev and the Vitest worker
+  tests running offline.
+- `EMAIL_FROM` is a non-secret var in `wrangler.jsonc` — the verified
+  sender address on the Resend side (e.g. `noreply@planisphere.app`).
+- The Worker boot path passes `env` into `createEmailSender(env)`; the
+  factory picks the right implementation.
+
+Licensing: Resend's customer-facing service has no license bearing on
+our code. We're not taking a runtime Resend SDK dep — just calling
+their REST API — so there's no OSS license to audit here. An account
+TOS applies, not a software license.
+
+## Consequences
+
+- **Dependency surface:** unchanged (zero new npm packages). The
+  provider is an external service, not a library.
+- **Operational steps** (one-time, per environment):
+  1. Verify a sender domain in the Resend dashboard (SPF + DKIM
+     TXT records on the domain's DNS).
+  2. Create an API key with "Send Email" scope.
+  3. `wrangler secret put RESEND_API_KEY` — paste the key.
+  4. Update `EMAIL_FROM` in `wrangler.jsonc` to the verified sender
+     address and redeploy.
+- **Offline / test friendliness:** the factory's secret-presence check
+  means `pnpm dev`, `pnpm test:worker`, and the preview deploy all
+  keep working when no Resend key is configured. The fallback is the
+  existing console stub — tests don't need to mock Resend.
+- **Swap cost** (if we ever leave Resend):
+  - Add a new `FooEmailSender` class implementing `EmailSender`.
+  - Flip the factory's selector (env-var name + implementation class).
+  - Update DNS if the new provider needs different records.
+  - No change to routes, no migration of data. The boundary is clean.
+- **Deliverability:** Resend's shared IPs are reputable and it ships
+  SPF/DKIM by default when a domain is verified. Dedicated IPs are a
+  paid add-on we don't need at beta volumes.
+
+## Alternatives considered
+
+- **Postmark.** Comparable quality, arguably better reputation for
+  pure transactional. Rejected on minor DX factors: its API requires a
+  `Server-Token` header with a per-server token; its account model
+  separates transactional and broadcast servers up-front; pricing
+  tiers kick in sooner. Nothing disqualifying — a reasonable swap if
+  Resend deliverability disappoints.
+- **AWS SES.** Cheapest at scale and the most mature. Rejected for
+  Worker fit: the first-class path is the AWS SDK, which is heavyweight
+  for a Worker. The raw SigV4-signed HTTP request is doable but
+  substantially more code than Resend's `Authorization: Bearer` +
+  JSON body. Account setup (IAM, sandbox-exit process) also adds
+  days, not hours.
+- **Mailgun.** Historically the transactional default; the service
+  has drifted toward marketing-first in recent years and its
+  documentation lags the API. No compelling DX or price advantage
+  over Resend at our volume.
+- **SendGrid.** Ownership change + recent deliverability incidents
+  made it the weakest option on reputation among the names considered.
+- **Cloudflare Email Workers / Email Routing.** Cloudflare-native and
+  tempting for the "one vendor" reason, but **inbound-only** at the
+  time of writing. Not applicable to sending magic links.
+- **Staying on `ConsoleEmailSender` forever.** Rejected — we can't
+  ship sign-in to real users who aren't tailing `wrangler`.

--- a/worker/README.md
+++ b/worker/README.md
@@ -139,20 +139,36 @@ type Env = {
   DB: D1Database;
   APP_ORIGIN: string; // e.g. "https://planisphere.app" — cookie redirects
   SESSION_SECRET: string; // HMAC key — set via `wrangler secret put`
+  RESEND_API_KEY?: string; // Resend secret — ADR 014
+  EMAIL_FROM?: string; // verified sender on Resend
 };
 ```
 
-`SESSION_SECRET` is a Worker secret (never committed). `APP_ORIGIN` and the
-D1 binding are in `wrangler.jsonc` — the single Worker-with-Static-Assets
-config that deploys both this module and the SPA `dist/` bundle. The dev
-`SESSION_SECRET` is a placeholder string — fine for local development, not
-for any deployed environment.
+`SESSION_SECRET` and `RESEND_API_KEY` are Worker secrets (never committed).
+`APP_ORIGIN`, `EMAIL_FROM`, and the D1 binding are in `wrangler.jsonc` —
+the single Worker-with-Static-Assets config that deploys both this
+module and the SPA `dist/` bundle. The dev `SESSION_SECRET` is a
+placeholder string — fine for local development, not for any deployed
+environment.
+
+### Email delivery (Resend)
+
+Real magic-link email uses the [Resend](https://resend.com) HTTP API
+(ADR 014). To switch off the dev stub in a deployed environment:
+
+1. Verify your sender domain in the Resend dashboard — add the SPF +
+   DKIM TXT records they emit to your DNS.
+2. Create an API key scoped to "Send Email".
+3. `pnpm exec wrangler secret put RESEND_API_KEY` — paste the key.
+4. Set `EMAIL_FROM` in `wrangler.jsonc` to the verified address
+   (e.g. `noreply@planisphere.app`) and redeploy.
+
+Until both `RESEND_API_KEY` and `EMAIL_FROM` are non-empty, the Worker
+uses `ConsoleEmailSender` — grep `wrangler tail --search "[auth]"` for
+`[auth] magic link for <email>: <url>`.
 
 ## What's stubbed in this PR
 
-- **Email delivery.** `email.ts` logs `[auth] magic link for <email>: <url>`
-  to the Worker console. Extracting a `EmailSender` interface means swapping
-  in Resend / Postmark / SES is a one-file change.
 - **Session expiry cleanup.** Expired `sessions` rows are rejected at read
   time but not pruned. Follow-up.
 - **Magic-link expiry.** Tokens are single-use but have no time-to-live

--- a/worker/email.test.ts
+++ b/worker/email.test.ts
@@ -1,0 +1,139 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ConsoleEmailSender, ResendEmailSender, createEmailSender, RESEND_API_URL } from "./email";
+
+/**
+ * Isolated tests for the email providers. These don't touch D1 or the
+ * route handlers — just verify the factory picks the right implementation
+ * and that `ResendEmailSender` hits the Resend REST API correctly.
+ */
+
+type FetchStub = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+
+function setFetch(stub: FetchStub): void {
+  globalThis.fetch = stub as typeof fetch;
+}
+
+beforeEach(() => {
+  setFetch(() => Promise.reject(new Error("fetch not stubbed")));
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("createEmailSender factory", () => {
+  it("returns ConsoleEmailSender when RESEND_API_KEY is unset", () => {
+    const sender = createEmailSender({ EMAIL_FROM: "noreply@example.com" });
+    expect(sender).toBeInstanceOf(ConsoleEmailSender);
+  });
+
+  it("returns ConsoleEmailSender when RESEND_API_KEY is the dev placeholder", () => {
+    const sender = createEmailSender({
+      RESEND_API_KEY: "",
+      EMAIL_FROM: "noreply@example.com",
+    });
+    expect(sender).toBeInstanceOf(ConsoleEmailSender);
+  });
+
+  it("returns ConsoleEmailSender when EMAIL_FROM is missing even if a key is set", () => {
+    const sender = createEmailSender({
+      RESEND_API_KEY: "re_test_key",
+      EMAIL_FROM: "",
+    });
+    expect(sender).toBeInstanceOf(ConsoleEmailSender);
+  });
+
+  it("returns ResendEmailSender when both are set", () => {
+    const sender = createEmailSender({
+      RESEND_API_KEY: "re_test_key",
+      EMAIL_FROM: "noreply@example.com",
+    });
+    expect(sender).toBeInstanceOf(ResendEmailSender);
+  });
+});
+
+describe("ResendEmailSender", () => {
+  it("POSTs to the Resend API with Bearer auth and a JSON body", async () => {
+    let capturedUrl: string | URL | Request | undefined;
+    let capturedInit: RequestInit | undefined;
+    setFetch((url, init) => {
+      capturedUrl = url;
+      capturedInit = init;
+      return Promise.resolve(new Response(JSON.stringify({ id: "x" }), { status: 200 }));
+    });
+    const sender = new ResendEmailSender({
+      apiKey: "re_test_key",
+      from: "noreply@example.com",
+    });
+    await sender.sendMagicLink("alice@example.com", "https://example.com/cb?token=abc");
+
+    expect(capturedUrl).toBe(RESEND_API_URL);
+    expect(capturedInit?.method).toBe("POST");
+    const headers = new Headers(capturedInit?.headers);
+    expect(headers.get("authorization")).toBe("Bearer re_test_key");
+    expect(headers.get("content-type")).toBe("application/json");
+
+    const body = JSON.parse(String(capturedInit?.body)) as {
+      from: string;
+      to: string[];
+      subject: string;
+      text: string;
+      html: string;
+    };
+    expect(body.from).toBe("noreply@example.com");
+    expect(body.to).toEqual(["alice@example.com"]);
+    expect(body.subject.length).toBeGreaterThan(0);
+    expect(body.text).toContain("https://example.com/cb?token=abc");
+    expect(body.html).toContain("https://example.com/cb?token=abc");
+  });
+
+  it("throws on a non-2xx response, carrying the status", async () => {
+    setFetch(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ message: "domain not verified" }), { status: 422 }),
+      ),
+    );
+    const sender = new ResendEmailSender({
+      apiKey: "re_test_key",
+      from: "noreply@example.com",
+    });
+    await expect(
+      sender.sendMagicLink("alice@example.com", "https://example.com/cb"),
+    ).rejects.toThrow(/422/);
+  });
+
+  it("throws when fetch rejects (network failure)", async () => {
+    setFetch(() => Promise.reject(new Error("offline")));
+    const sender = new ResendEmailSender({
+      apiKey: "re_test_key",
+      from: "noreply@example.com",
+    });
+    await expect(
+      sender.sendMagicLink("alice@example.com", "https://example.com/cb"),
+    ).rejects.toThrow(/offline/);
+  });
+
+  it("accepts any 2xx status, not only 200", async () => {
+    setFetch(() => Promise.resolve(new Response(null, { status: 202 })));
+    const sender = new ResendEmailSender({
+      apiKey: "re_test_key",
+      from: "noreply@example.com",
+    });
+    await expect(
+      sender.sendMagicLink("alice@example.com", "https://example.com/cb"),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe("ConsoleEmailSender", () => {
+  it("logs a line containing the address and URL", async () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const sender = new ConsoleEmailSender();
+    await sender.sendMagicLink("alice@example.com", "https://example.com/cb?token=abc");
+    expect(spy).toHaveBeenCalled();
+    const line = String(spy.mock.calls[0]?.[0]);
+    expect(line).toContain("alice@example.com");
+    expect(line).toContain("https://example.com/cb?token=abc");
+  });
+});

--- a/worker/email.ts
+++ b/worker/email.ts
@@ -1,17 +1,31 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /**
- * Email delivery abstraction. For this PR the only implementation is a
- * console-log stub — the magic-link token is visible in the Worker log so
- * a developer can paste it into the callback URL by hand.
+ * Email delivery. `EmailSender` is the interface every provider implements;
+ * `createEmailSender(env)` picks one based on what the Worker has been
+ * configured with.
  *
- * Swapping in a real provider (Resend / Postmark / SES) is a one-file
- * change: add `ResendEmailSender` (or similar) that implements the
- * `EmailSender` interface, and wire it in `index.ts`'s factory.
+ * - `ResendEmailSender` — production-ish. Calls the Resend HTTP API
+ *   (ADR 014). Requires `env.RESEND_API_KEY` + `env.EMAIL_FROM`.
+ * - `ConsoleEmailSender` — dev / test fallback. Logs the magic-link URL
+ *   to the Worker console for grepping via `wrangler tail`. Selected
+ *   automatically when either required Resend env var is missing.
+ *
+ * No SDK. Resend's REST API is one `fetch` call with a Bearer token — a
+ * runtime dep would be pure bloat for the Worker bundle.
  */
 
 export type EmailSender = {
   sendMagicLink(to: string, loginUrl: string): Promise<void>;
 };
+
+export type EmailEnv = {
+  readonly RESEND_API_KEY?: string;
+  readonly EMAIL_FROM?: string;
+};
+
+/** Resend's production REST endpoint. Exported so tests can assert
+ *  against it without hard-coding the string twice. */
+export const RESEND_API_URL = "https://api.resend.com/emails";
 
 /** Dev / test stub. Prints a one-line log that's easy to grep for. */
 export class ConsoleEmailSender implements EmailSender {
@@ -22,8 +36,61 @@ export class ConsoleEmailSender implements EmailSender {
   }
 }
 
-/** Factory used by `index.ts`. In the future this will select based on a
- *  Worker binding (e.g. `env.EMAIL_PROVIDER`). */
-export function createEmailSender(): EmailSender {
-  return new ConsoleEmailSender();
+export type ResendEmailSenderOptions = {
+  readonly apiKey: string;
+  readonly from: string;
+};
+
+export class ResendEmailSender implements EmailSender {
+  private readonly apiKey: string;
+  private readonly from: string;
+
+  constructor(options: ResendEmailSenderOptions) {
+    this.apiKey = options.apiKey;
+    this.from = options.from;
+  }
+
+  async sendMagicLink(to: string, loginUrl: string): Promise<void> {
+    const subject = "Your planisphere sign-in link";
+    const text =
+      `Click this single-use link to sign in to planisphere:\n\n${loginUrl}\n\n` +
+      `If you didn't request this, you can ignore the email.`;
+    const html =
+      `<p>Click this single-use link to sign in to planisphere:</p>` +
+      `<p><a href="${loginUrl}">${loginUrl}</a></p>` +
+      `<p>If you didn't request this, you can ignore the email.</p>`;
+
+    const response = await fetch(RESEND_API_URL, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${this.apiKey}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        from: this.from,
+        to: [to],
+        subject,
+        text,
+        html,
+      }),
+    });
+
+    if (!response.ok) {
+      // Surface the status so the top-level handler's catch can log it.
+      // We don't swallow — a failed send means the user got no link.
+      throw new Error(`Resend ${String(response.status)}: send failed`);
+    }
+  }
+}
+
+/** Picks the implementation based on env. Falls back to the console stub
+ *  when any required Resend config is missing — keeps local dev and
+ *  Vitest-worker tests running offline. */
+export function createEmailSender(env: EmailEnv): EmailSender {
+  const apiKey = env.RESEND_API_KEY ?? "";
+  const from = env.EMAIL_FROM ?? "";
+  if (apiKey.length === 0 || from.length === 0) {
+    return new ConsoleEmailSender();
+  }
+  return new ResendEmailSender({ apiKey, from });
 }

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -20,7 +20,7 @@ export default {
     const url = new URL(request.url);
     const path = url.pathname;
     const method = request.method.toUpperCase();
-    const emailSender = createEmailSender();
+    const emailSender = createEmailSender(env);
 
     try {
       if (path === "/api/auth/request-link") {

--- a/worker/types.ts
+++ b/worker/types.ts
@@ -6,6 +6,12 @@ export type Env = {
   readonly DB: D1Database;
   readonly APP_ORIGIN: string;
   readonly SESSION_SECRET: string;
+  /** Resend API key (Worker secret). Absent / empty in dev → auth falls
+   *  back to the console-log stub. See ADR 014. */
+  readonly RESEND_API_KEY?: string;
+  /** Verified sender address on the Resend side, e.g. `noreply@your-domain`.
+   *  Required alongside `RESEND_API_KEY` to switch off the dev stub. */
+  readonly EMAIL_FROM?: string;
 };
 
 /** User row in D1. Tier is a string column; the narrow union is enforced

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -36,6 +36,12 @@
   // (never committed). APP_ORIGIN is the URL magic-link callbacks redirect
   // to — override per environment via Cloudflare dashboard or `vars`
   // overrides in a deploy-time config.
+  //
+  // Email (ADR 014): `RESEND_API_KEY` is a Worker secret
+  //   wrangler secret put RESEND_API_KEY
+  // and `EMAIL_FROM` is the verified sender address on Resend. When
+  // either is unset, the Worker falls back to the console-log stub —
+  // grep `wrangler tail` for `[auth] magic link`.
   "vars": {
     "APP_ORIGIN": "http://localhost:5173",
     "SESSION_SECRET": "dev-only-placeholder-replace-with-wrangler-secret-put",


### PR DESCRIPTION
## Summary

Swaps the `ConsoleEmailSender` stub for real magic-link email via **Resend** (ADR 014). Now someone who isn't tailing `wrangler` can actually sign in.

## What changed

- **`docs/adr/014-email-delivery.md`** — Resend accepted. Postmark / SES / Mailgun / SendGrid / Cloudflare Email Routing all evaluated and rejected (rationale inline). Key constraints: transactional-first, Worker-runtime friendly (HTTP + `fetch`, no SDK), usable free tier for beta, clean DNS-based swap cost.
- **`worker/email.ts`** — adds `ResendEmailSender` implementing the existing `EmailSender` interface. `createEmailSender(env)` now inspects env and picks the right impl: both `RESEND_API_KEY` and `EMAIL_FROM` non-empty → Resend; otherwise → console stub. Subject + plain-text + HTML bodies included. No SDK added; plain `fetch` to `https://api.resend.com/emails` with Bearer auth.
- **`worker/types.ts`** — `Env` gains optional `RESEND_API_KEY` (secret) and `EMAIL_FROM` (var).
- **`wrangler.jsonc`** — `EMAIL_FROM: ""` placeholder in vars, comment pointing at ADR 014 and the `wrangler secret put` step.
- **`worker/index.ts`** — passes `env` through to `createEmailSender(env)`.
- **`worker/README.md`** — new "Email delivery (Resend)" section with the one-time operator steps. "Email delivery" removed from "What's stubbed in this PR".

## TDD trail

9 tests added in `worker/email.test.ts`:

- Factory selection: key missing, key blank, `EMAIL_FROM` missing, both set.
- Resend POST shape: correct URL, `Bearer` auth header, JSON body with `from`/`to`/`subject`/`text`/`html`, the URL appears in both text and HTML bodies.
- Non-2xx response → throws (carries status).
- `fetch` rejects → throws (network).
- Any 2xx (not just 200) → resolves.
- Console stub still logs a grepable line.

All 61 Worker tests pass. Auth + notebook routes unchanged since they go through the `EmailSender` interface, not a concrete class.

## Operator steps — one-time per environment

```bash
# 1. Verify your sender domain in the Resend dashboard (adds SPF + DKIM
#    TXT records to DNS). No code change required.

# 2. Paste a Resend API key in as a Worker secret:
pnpm exec wrangler secret put RESEND_API_KEY

# 3. In wrangler.jsonc set
#      "EMAIL_FROM": "noreply@<verified-domain>"
#    then redeploy.
```

Until those are set, every environment (local dev, preview URL, production) keeps logging `[auth] magic link for …` to the Worker console — `wrangler tail --search "[auth]"` still works as a fallback.

## Test plan

- [x] `pnpm typecheck && pnpm lint && pnpm format:check && pnpm test:cov && pnpm build` green locally
- [x] 61 Worker tests (+9), 1182 SPA tests unchanged
- [ ] After `RESEND_API_KEY` + `EMAIL_FROM` are set on the preview env, submit email on the preview URL and confirm delivery to the inbox
- [ ] Confirm `wrangler tail` shows `Resend 200` / no `Resend <4xx>` noise

https://claude.ai/code/session_014DzXBVSCw5T2nnQvQjJtzS