### PR TITLE
fix(2d): fetch content_json on notebook load (#219)

### DIFF
--- a/src/ui/notebook-workspace.test.ts
+++ b/src/ui/notebook-workspace.test.ts
@@ -15,11 +15,12 @@ import type { NotebookDoc, NotebookError, NotebookSummary } from "../notebooks";
 type Calls = {
   list: number;
   create: number;
+  gets: number[];
   updates: Array<{ id: number; content_json: string; title: string }>;
 };
 
 function stubApi(overrides: Partial<NotebookApi> = {}): { api: NotebookApi; calls: Calls } {
-  const calls: Calls = { list: 0, create: 0, updates: [] };
+  const calls: Calls = { list: 0, create: 0, gets: [], updates: [] };
   const api: NotebookApi = {
     list:
       overrides.list ??
@@ -35,6 +36,18 @@ function stubApi(overrides: Partial<NotebookApi> = {}): { api: NotebookApi; call
           id: 1,
           title: payload.title,
           content_json: payload.content_json,
+          created_at: 1,
+          updated_at: 1,
+        });
+      }),
+    get:
+      overrides.get ??
+      (async (id) => {
+        calls.gets.push(id);
+        return ok({
+          id,
+          title: "stub",
+          content_json: JSON.stringify({ type: "doc", content: [] }),
           created_at: 1,
           updated_at: 1,
         });
@@ -157,12 +170,26 @@ describe("createNotebookWorkspace — load / create", () => {
     ws.destroy();
   });
 
-  it("adopts the first notebook from the list without creating a new one", async () => {
+  it("adopts the first notebook from the list, fetches its content, and mounts the editor", async () => {
+    const savedContent = JSON.stringify({
+      type: "doc",
+      content: [{ type: "paragraph", content: [{ type: "text", text: "Perseids tonight" }] }],
+    });
     let listHits = 0;
     const { api, calls } = stubApi({
       list: async () => {
         listHits += 1;
         return ok([{ id: 42, title: "Existing", created_at: 1, updated_at: 2 }]);
+      },
+      get: async (id) => {
+        calls.gets.push(id);
+        return ok({
+          id,
+          title: "Existing",
+          content_json: savedContent,
+          created_at: 1,
+          updated_at: 2,
+        });
       },
     });
     const ws = createNotebookWorkspace({
@@ -174,7 +201,26 @@ describe("createNotebookWorkspace — load / create", () => {
     await ws.ready;
     expect(listHits).toBe(1);
     expect(calls.create).toBe(0);
-    expect(ws.element.querySelector("[data-testid='notebook-editor']")).not.toBeNull();
+    expect(calls.gets).toEqual([42]);
+    // The editor's contenteditable surface carries the saved text.
+    const surface = ws.element.querySelector<HTMLElement>(".ProseMirror");
+    expect(surface?.textContent).toContain("Perseids tonight");
+    ws.destroy();
+  });
+
+  it("shows an error when list() succeeds but get() fails", async () => {
+    const { api } = stubApi({
+      list: async () => ok([{ id: 7, title: "Existing", created_at: 1, updated_at: 2 }]),
+      get: async () => err<NotebookError>({ kind: "server" }),
+    });
+    const ws = createNotebookWorkspace({
+      notebookApi: api,
+      saveDebounceMs: SAVE_DEBOUNCE,
+      initiallyVisible: true,
+    });
+    await vi.runAllTimersAsync();
+    await ws.ready;
+    expect(ws.element.querySelector("[data-testid='notebook-error']")).not.toBeNull();
     ws.destroy();
   });
 
@@ -452,6 +498,8 @@ describe("NotebookError branch — every kind maps to a message", () => {
         list: async (): Promise<Result<NotebookSummary[], NotebookError>> =>
           err({ kind } as NotebookError),
         create: async (): Promise<Result<NotebookDoc, NotebookError>> =>
+          err({ kind: "server" } as NotebookError),
+        get: async (): Promise<Result<NotebookDoc, NotebookError>> =>
           err({ kind: "server" } as NotebookError),
         update: async (): Promise<Result<NotebookDoc, NotebookError>> =>
           err({ kind: "server" } as NotebookError),

--- a/src/ui/notebook-workspace.ts
+++ b/src/ui/notebook-workspace.ts
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 import { isPro } from "../features";
 import type { NotebookDoc, NotebookError, NotebookPayload, NotebookSummary } from "../notebooks";
-import { createNotebook, listNotebooks, updateNotebook } from "../notebooks";
+import { createNotebook, getNotebook, listNotebooks, updateNotebook } from "../notebooks";
 import type { Result } from "../result";
 import { createNotebookEditor, EMPTY_DOC_JSON, type NotebookEditor } from "./notebook-editor";
 import { FONT_FAMILY, PANEL_BG, PANEL_BORDER, TEXT_COLOR } from "./styles";
@@ -11,6 +11,7 @@ import { FONT_FAMILY, PANEL_BG, PANEL_BORDER, TEXT_COLOR } from "./styles";
 export type NotebookApi = {
   list(): Promise<Result<NotebookSummary[], NotebookError>>;
   create(payload: NotebookPayload): Promise<Result<NotebookDoc, NotebookError>>;
+  get(id: number): Promise<Result<NotebookDoc, NotebookError>>;
   update(id: number, payload: NotebookPayload): Promise<Result<NotebookDoc, NotebookError>>;
 };
 
@@ -49,6 +50,7 @@ export type NotebookWorkspace = {
 const DEFAULT_API: NotebookApi = {
   list: listNotebooks,
   create: createNotebook,
+  get: getNotebook,
   update: updateNotebook,
 };
 
@@ -168,15 +170,15 @@ export function createNotebookWorkspace(options: NotebookWorkspaceOptions = {}):
     }
     const first = listRes.value[0];
     if (first !== undefined) {
-      currentId = first.id;
-      currentTitle = first.title;
-      mountEditor(EMPTY_DOC_JSON);
-      // Load the full doc. listRes only has summaries (no content_json).
-      // To keep this PR tight we fetch content by re-creating with the
-      // summary shape — the individual GET lives in the notebooks client
-      // but is not yet needed here. Upload-only shape for now: the editor
-      // starts empty, and the user's next edit overwrites any server
-      // content. Follow-up PR (#219 list view) swaps this for a true read.
+      const getRes = await api.get(first.id);
+      if (!getRes.ok) {
+        renderError(errorToMessage(getRes.error));
+        statusLine.textContent = "";
+        return;
+      }
+      currentId = getRes.value.id;
+      currentTitle = getRes.value.title;
+      mountEditor(getRes.value.content_json);
     } else {
       const createRes = await api.create({
         title: DEFAULT_NOTEBOOK_TITLE,


### PR DESCRIPTION
## Summary

Closes the "reload loses my content" gap flagged as a follow-up in #237. After that PR the workspace adopted an existing notebook from the list but mounted the editor with `EMPTY_DOC_JSON`, because `GET /api/notebooks` only returns summaries. The next keystroke then PUT the empty doc over the server content — the scary part.

**Fix:** add `get(id)` to `NotebookApi`, wire it to the existing `getNotebook` client (already in `src/notebooks.ts` since #237), and have `load()` fetch the full doc after picking the first summary. A `get()` failure renders the same friendly error box the other boundaries use.

## Scope

- `src/ui/notebook-workspace.ts` — `NotebookApi` grows a `get` method, `DEFAULT_API` points it at `getNotebook`, `load()` awaits `api.get(first.id)` and mounts with the real `content_json`.

## TDD

- One existing test tightened — "adopts the first notebook, **fetches its content, and mounts the editor**" now asserts the saved text appears in the ProseMirror surface.
- One new test — `list()` succeeds, `get()` returns `{kind: "server"}` → error box rendered.
- The `NotebookError`-kind sweep (every branch of the union maps to a message) grew its inline `NotebookApi` stub to cover `get`.

## Test plan

- [x] `pnpm typecheck && pnpm lint && pnpm format:check && pnpm test:cov && pnpm build` green locally
- [x] 1183 SPA tests (+1), 61 worker tests unchanged
- [ ] On the preview URL: sign in, type in the Notebook, reload the page → content persists; reload again → still persists; no "empty editor then overwrite" race

## Remaining within #219

- Notebook list view (switch between multiple notebooks per user).
- `@`-mention linked entities.

https://claude.ai/code/session_014DzXBVSCw5T2nnQvQjJtzS