### PR TITLE
feat(auth): magic-link TTL + scheduled sweep of expired rows

### DIFF
--- a/migrations/0003_magic_link_ttl.sql
+++ b/migrations/0003_magic_link_ttl.sql
@@ -1,0 +1,11 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Add a TTL to magic_links so unused tokens expire (15-minute default
+-- enforced server-side; see worker/types.ts MAGIC_LINK_TTL_SECONDS).
+-- Existing rows backfill to created_at + 15 minutes; any token older than
+-- that is treated as expired immediately, which is the safe default.
+
+ALTER TABLE magic_links ADD COLUMN expires_at INTEGER NOT NULL DEFAULT 0;
+
+UPDATE magic_links SET expires_at = created_at + (15 * 60 * 1000) WHERE expires_at = 0;
+
+CREATE INDEX idx_magic_links_expires ON magic_links(expires_at);

--- a/worker/README.md
+++ b/worker/README.md
@@ -167,12 +167,22 @@ Until both `RESEND_API_KEY` and `EMAIL_FROM` are non-empty, the Worker
 uses `ConsoleEmailSender` — grep `wrangler tail --search "[auth]"` for
 `[auth] magic link for <email>: <url>`.
 
-## What's stubbed in this PR
+## Background sweep (cron trigger)
 
-- **Session expiry cleanup.** Expired `sessions` rows are rejected at read
-  time but not pruned. Follow-up.
-- **Magic-link expiry.** Tokens are single-use but have no time-to-live
-  beyond that. Follow-up.
+`worker/index.ts` exports a `scheduled` handler invoked by Cloudflare on
+the cron schedule declared in `wrangler.jsonc` (`triggers.crons`,
+hourly). Each run calls:
+
+- `deleteExpiredMagicLinks(env.DB)` — drops rows past their `expires_at`
+  **or** already used. Magic-link TTL is `MAGIC_LINK_TTL_SECONDS` (15
+  minutes) — `consumeMagicLink` enforces it on the read path too.
+- `deleteExpiredSessions(env.DB)` — drops sessions past `expires_at`.
+  `getActiveSession` already rejects them at read time, so the rows
+  linger harmlessly between sweeps; this just keeps the table from
+  growing forever.
+
+Both helpers return the row count, which is logged as
+`[sweep] magic_links=N sessions=N` for `wrangler tail` visibility.
 
 ## Deferred (out of scope)
 

--- a/worker/db.ts
+++ b/worker/db.ts
@@ -65,7 +65,7 @@ export async function getPendingMagicLinkForEmail(
 ): Promise<MagicLinkRow | null> {
   const row = await db
     .prepare(
-      "SELECT token, email, created_at, used_at FROM magic_links " +
+      "SELECT token, email, created_at, used_at, expires_at FROM magic_links " +
         "WHERE email = ? AND used_at IS NULL ORDER BY created_at DESC LIMIT 1",
     )
     .bind(email)
@@ -77,34 +77,65 @@ export async function insertMagicLink(
   db: D1Database,
   token: string,
   email: string,
+  expiresAt: number,
 ): Promise<MagicLinkRow> {
   const createdAt = NOW();
   await db
-    .prepare("INSERT INTO magic_links (token, email, created_at, used_at) VALUES (?, ?, ?, NULL)")
-    .bind(token, email, createdAt)
+    .prepare(
+      "INSERT INTO magic_links (token, email, created_at, used_at, expires_at) " +
+        "VALUES (?, ?, ?, NULL, ?)",
+    )
+    .bind(token, email, createdAt, expiresAt)
     .run();
-  return { token, email, created_at: createdAt, used_at: null };
+  return { token, email, created_at: createdAt, used_at: null, expires_at: expiresAt };
 }
 
 /**
  * Consume a magic-link token atomically: return the unused row and mark it
- * used in the same step. Returns `null` if the token is unknown or already
- * used.
+ * used in the same step. Returns `null` if the token is unknown, already
+ * used, or past its `expires_at`.
  */
 export async function consumeMagicLink(
   db: D1Database,
   token: string,
 ): Promise<MagicLinkRow | null> {
   const now = NOW();
-  // UPDATE ... WHERE used_at IS NULL RETURNING * is the atomic "claim" step.
   const row = await db
     .prepare(
-      "UPDATE magic_links SET used_at = ? WHERE token = ? AND used_at IS NULL " +
-        "RETURNING token, email, created_at, used_at",
+      "UPDATE magic_links SET used_at = ? " +
+        "WHERE token = ? AND used_at IS NULL AND expires_at > ? " +
+        "RETURNING token, email, created_at, used_at, expires_at",
     )
-    .bind(now, token)
+    .bind(now, token, now)
     .first<MagicLinkRow>();
   return row ?? null;
+}
+
+/**
+ * Background sweep: drop magic_links rows that are either past their TTL
+ * or have already been used. Called by the scheduled handler on the cron
+ * trigger declared in wrangler.jsonc. Returns the row count for log /
+ * test assertions.
+ */
+export async function deleteExpiredMagicLinks(db: D1Database): Promise<number> {
+  const now = NOW();
+  const result = await db
+    .prepare("DELETE FROM magic_links WHERE expires_at <= ? OR used_at IS NOT NULL")
+    .bind(now)
+    .run();
+  return Number(result.meta.changes ?? 0);
+}
+
+/**
+ * Background sweep: drop sessions whose `expires_at` has passed. The read
+ * path in `getActiveSession` already rejects them, so the rows linger
+ * harmlessly between sweeps; this just keeps the table from growing
+ * forever.
+ */
+export async function deleteExpiredSessions(db: D1Database): Promise<number> {
+  const now = NOW();
+  const result = await db.prepare("DELETE FROM sessions WHERE expires_at <= ?").bind(now).run();
+  return Number(result.meta.changes ?? 0);
 }
 
 export async function insertSession(

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -1,4 +1,5 @@
 /* SPDX-License-Identifier: Apache-2.0 */
+import { deleteExpiredMagicLinks, deleteExpiredSessions } from "./db";
 import { createEmailSender } from "./email";
 import { handleCallback, handleLogout, handleMe, handleRequestLink } from "./routes/auth";
 import {
@@ -63,6 +64,23 @@ export default {
         status: 500,
         headers: { "content-type": "application/json" },
       });
+    }
+  },
+
+  /**
+   * Cron-triggered cleanup. Runs on the cadence declared by `triggers.crons`
+   * in `wrangler.jsonc`. Sweeps expired / used magic_links and expired
+   * sessions so the tables don't grow unboundedly.
+   */
+  async scheduled(_event: ScheduledController, env: Env, _ctx: ExecutionContext): Promise<void> {
+    try {
+      const links = await deleteExpiredMagicLinks(env.DB);
+      const sessions = await deleteExpiredSessions(env.DB);
+      // eslint-disable-next-line no-console
+      console.log(`[sweep] magic_links=${String(links)} sessions=${String(sessions)}`);
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error("[sweep] failed", err);
     }
   },
 } satisfies ExportedHandler<Env>;

--- a/worker/routes/auth.test.ts
+++ b/worker/routes/auth.test.ts
@@ -136,6 +136,24 @@ describe("GET /api/auth/callback", () => {
     const res = await fetchWorker(new Request(`${BASE}/api/auth/callback?token=does-not-exist`));
     expect(res.status).toBe(401);
   });
+
+  it("returns 401 for a token whose TTL has elapsed", async () => {
+    // Insert an expired magic link directly so we don't have to wait the TTL.
+    const now = Date.now();
+    await testEnv.DB.prepare(
+      "INSERT INTO magic_links (token, email, created_at, used_at, expires_at) " +
+        "VALUES (?, ?, ?, NULL, ?)",
+    )
+      .bind("stale-token", "stale@example.com", now - 60 * 60_000, now - 60_000)
+      .run();
+    const res = await fetchWorker(new Request(`${BASE}/api/auth/callback?token=stale-token`));
+    expect(res.status).toBe(401);
+    // Stale token should not have been marked used (still NULL).
+    const row = await testEnv.DB.prepare("SELECT used_at FROM magic_links WHERE token = ?")
+      .bind("stale-token")
+      .first<{ used_at: number | null }>();
+    expect(row?.used_at).toBeNull();
+  });
 });
 
 describe("GET /api/auth/me", () => {

--- a/worker/routes/auth.ts
+++ b/worker/routes/auth.ts
@@ -14,6 +14,7 @@ import type { EmailSender } from "../email";
 import { readSessionId } from "../session";
 import {
   MAGIC_LINK_RATE_WINDOW_MS,
+  MAGIC_LINK_TTL_SECONDS,
   SESSION_COOKIE,
   SESSION_MAX_AGE_SECONDS,
   type ApiErrorCode,
@@ -72,7 +73,8 @@ export async function handleRequestLink(
 
   await upsertUser(env.DB, normalized);
   const token = generateToken();
-  await insertMagicLink(env.DB, token, normalized);
+  const expiresAt = Date.now() + MAGIC_LINK_TTL_SECONDS * 1000;
+  await insertMagicLink(env.DB, token, normalized, expiresAt);
 
   const callbackUrl = new URL("/api/auth/callback", env.APP_ORIGIN);
   callbackUrl.searchParams.set("token", token);

--- a/worker/sweep.test.ts
+++ b/worker/sweep.test.ts
@@ -1,0 +1,156 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { beforeEach, describe, expect, it } from "vitest";
+import worker from "./index";
+import { testEnv, resetDb } from "./test-helpers";
+import { deleteExpiredMagicLinks, deleteExpiredSessions } from "./db";
+
+/**
+ * Tests for the background cleanup of expired magic_links and sessions.
+ * Rows that hit their expires_at are already rejected at read time; these
+ * sweeps delete them so D1 doesn't grow unboundedly.
+ */
+
+const MINUTE_MS = 60_000;
+
+beforeEach(async () => {
+  await resetDb();
+});
+
+async function insertMagicLinkRow(
+  token: string,
+  email: string,
+  createdAt: number,
+  expiresAt: number,
+  usedAt: number | null = null,
+): Promise<void> {
+  await testEnv.DB.prepare(
+    "INSERT INTO magic_links (token, email, created_at, used_at, expires_at) VALUES (?, ?, ?, ?, ?)",
+  )
+    .bind(token, email, createdAt, usedAt, expiresAt)
+    .run();
+}
+
+async function insertSessionRow(
+  id: string,
+  userId: number,
+  createdAt: number,
+  expiresAt: number,
+): Promise<void> {
+  await testEnv.DB.prepare(
+    "INSERT INTO sessions (id, user_id, created_at, expires_at) VALUES (?, ?, ?, ?)",
+  )
+    .bind(id, userId, createdAt, expiresAt)
+    .run();
+}
+
+async function countRows(table: "magic_links" | "sessions"): Promise<number> {
+  const row = await testEnv.DB.prepare(`SELECT COUNT(*) as n FROM ${table}`).first<{
+    n: number;
+  }>();
+  return row?.n ?? 0;
+}
+
+describe("deleteExpiredMagicLinks", () => {
+  it("removes rows whose expires_at is in the past", async () => {
+    const now = Date.now();
+    await insertMagicLinkRow("expired-1", "a@example.com", now - 30 * MINUTE_MS, now - MINUTE_MS);
+    await insertMagicLinkRow("expired-2", "b@example.com", now - 20 * MINUTE_MS, now - MINUTE_MS);
+    await insertMagicLinkRow("fresh", "c@example.com", now, now + 15 * MINUTE_MS);
+
+    const deleted = await deleteExpiredMagicLinks(testEnv.DB);
+    expect(deleted).toBe(2);
+    expect(await countRows("magic_links")).toBe(1);
+  });
+
+  it("also removes used rows even if their expires_at is still in the future", async () => {
+    // A used token is never reusable — no reason to keep it.
+    const now = Date.now();
+    await insertMagicLinkRow(
+      "used",
+      "a@example.com",
+      now - 5 * MINUTE_MS,
+      now + 30 * MINUTE_MS,
+      now - MINUTE_MS,
+    );
+    await insertMagicLinkRow("fresh", "b@example.com", now, now + 30 * MINUTE_MS);
+
+    const deleted = await deleteExpiredMagicLinks(testEnv.DB);
+    expect(deleted).toBe(1);
+    expect(await countRows("magic_links")).toBe(1);
+  });
+
+  it("is a no-op when nothing is expired", async () => {
+    const now = Date.now();
+    await insertMagicLinkRow("fresh", "a@example.com", now, now + 30 * MINUTE_MS);
+    const deleted = await deleteExpiredMagicLinks(testEnv.DB);
+    expect(deleted).toBe(0);
+    expect(await countRows("magic_links")).toBe(1);
+  });
+});
+
+describe("deleteExpiredSessions", () => {
+  it("removes sessions whose expires_at is in the past", async () => {
+    const now = Date.now();
+    // Need a user row for the FK.
+    await testEnv.DB.prepare(
+      "INSERT INTO users (email, tier, created_at) VALUES ('u@example.com', 'free', ?)",
+    )
+      .bind(now)
+      .run();
+    const user = await testEnv.DB.prepare("SELECT id FROM users WHERE email = ?")
+      .bind("u@example.com")
+      .first<{ id: number }>();
+    const uid = user!.id;
+
+    await insertSessionRow("old-1", uid, now - 31 * 24 * 60 * MINUTE_MS, now - MINUTE_MS);
+    await insertSessionRow("old-2", uid, now - 60 * 24 * 60 * MINUTE_MS, now - 5 * MINUTE_MS);
+    await insertSessionRow("live", uid, now, now + 30 * 24 * 60 * MINUTE_MS);
+
+    const deleted = await deleteExpiredSessions(testEnv.DB);
+    expect(deleted).toBe(2);
+    expect(await countRows("sessions")).toBe(1);
+  });
+
+  it("is a no-op when nothing is expired", async () => {
+    const now = Date.now();
+    await testEnv.DB.prepare(
+      "INSERT INTO users (email, tier, created_at) VALUES ('v@example.com', 'free', ?)",
+    )
+      .bind(now)
+      .run();
+    const user = await testEnv.DB.prepare("SELECT id FROM users WHERE email = ?")
+      .bind("v@example.com")
+      .first<{ id: number }>();
+    await insertSessionRow("live", user!.id, now, now + MINUTE_MS);
+    const deleted = await deleteExpiredSessions(testEnv.DB);
+    expect(deleted).toBe(0);
+    expect(await countRows("sessions")).toBe(1);
+  });
+});
+
+describe("worker.scheduled handler", () => {
+  it("runs both sweeps when invoked", async () => {
+    const now = Date.now();
+    await insertMagicLinkRow("expired", "a@example.com", now - MINUTE_MS, now - 1);
+    await testEnv.DB.prepare(
+      "INSERT INTO users (email, tier, created_at) VALUES ('w@example.com', 'free', ?)",
+    )
+      .bind(now)
+      .run();
+    const user = await testEnv.DB.prepare("SELECT id FROM users WHERE email = ?")
+      .bind("w@example.com")
+      .first<{ id: number }>();
+    await insertSessionRow("expired-s", user!.id, now - MINUTE_MS, now - 1);
+
+    if (!worker.scheduled) throw new Error("worker has no scheduled handler");
+    const event = { cron: "0 * * * *", scheduledTime: now, type: "scheduled" };
+    await worker.scheduled(
+      event as unknown as ScheduledController,
+      testEnv,
+      {} as unknown as ExecutionContext,
+    );
+
+    expect(await countRows("magic_links")).toBe(0);
+    expect(await countRows("sessions")).toBe(0);
+  });
+});

--- a/worker/test-helpers.ts
+++ b/worker/test-helpers.ts
@@ -26,7 +26,8 @@ const SCHEMA_STATEMENTS = [
     token TEXT PRIMARY KEY,
     email TEXT NOT NULL,
     created_at INTEGER NOT NULL,
-    used_at INTEGER
+    used_at INTEGER,
+    expires_at INTEGER NOT NULL
   )`,
   `CREATE TABLE sessions (
     id TEXT PRIMARY KEY,
@@ -45,6 +46,7 @@ const SCHEMA_STATEMENTS = [
     FOREIGN KEY (user_id) REFERENCES users(id)
   )`,
   `CREATE INDEX idx_magic_links_email ON magic_links(email)`,
+  `CREATE INDEX idx_magic_links_expires ON magic_links(expires_at)`,
   `CREATE INDEX idx_sessions_expires ON sessions(expires_at)`,
   `CREATE INDEX idx_notebooks_user_updated ON notebooks(user_id, updated_at DESC)`,
 ] as const;

--- a/worker/types.ts
+++ b/worker/types.ts
@@ -30,6 +30,7 @@ export type MagicLinkRow = {
   readonly email: string;
   readonly created_at: number;
   readonly used_at: number | null;
+  readonly expires_at: number;
 };
 
 export type SessionRow = {
@@ -76,3 +77,7 @@ export const SESSION_COOKIE = "ps_session";
 export const SESSION_MAX_AGE_SECONDS = 60 * 60 * 24 * 30;
 /** One-pending-link-per-email window, in milliseconds. */
 export const MAGIC_LINK_RATE_WINDOW_MS = 60_000;
+/** Magic-link single-use token TTL, in seconds (15 minutes). Long enough
+ *  for email delivery + the user clicking the link, short enough to keep
+ *  the abuse window tight if a token leaks. */
+export const MAGIC_LINK_TTL_SECONDS = 15 * 60;

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -48,6 +48,12 @@
     "EMAIL_FROM": "noreply@rabbitsatin.com", // ← or "onboarding@resend.dev" for the shortcut
   },
 
+  // Hourly sweep of expired magic-link tokens and sessions.
+  // The handler is the `scheduled()` export in worker/index.ts.
+  "triggers": {
+    "crons": ["0 * * * *"],
+  },
+
   "observability": {
     "enabled": true,
   },


### PR DESCRIPTION
## Summary

Closes the two "follow-up" notes from `worker/README.md`'s "What's stubbed" section:

1. **Magic-link tokens now expire** after 15 minutes. `consumeMagicLink` rejects stale tokens at the read path **and** leaves `used_at` NULL (the consume guard never accidentally claims them).
2. **Cron-triggered cleanup** sweeps expired/used `magic_links` and expired `sessions` so the tables don't grow unboundedly. Hourly trigger declared in `wrangler.jsonc`; handler logs `[sweep] magic_links=N sessions=N` so `wrangler tail` can see it.

## Schema (migration 0003)

```sql
ALTER TABLE magic_links ADD COLUMN expires_at INTEGER NOT NULL DEFAULT 0;
UPDATE magic_links SET expires_at = created_at + (15 * 60 * 1000) WHERE expires_at = 0;
CREATE INDEX idx_magic_links_expires ON magic_links(expires_at);
```

Existing rows backfill to `created_at + 15 min` — any in-flight token older than 15 minutes is treated as expired immediately, which is the safe default.

## TDD

- **6 new tests** in `worker/sweep.test.ts` covering both delete helpers (expired-vs-fresh, used-stays-deletable, no-op-when-clean) and an integration test that drives `worker.scheduled` end to end.
- **1 new test** in `worker/routes/auth.test.ts` — `/api/auth/callback` with a stale token returns 401 AND `magic_links.used_at` stays NULL (proves the `expires_at > ?` guard runs before the UPDATE claim).

68 worker tests total (+7). 1183 SPA tests unchanged.

## Scope

| File | Change |
|------|--------|
| `migrations/0003_magic_link_ttl.sql` | new — `expires_at` + index |
| `worker/types.ts` | `MAGIC_LINK_TTL_SECONDS = 15 * 60`; `MagicLinkRow.expires_at` |
| `worker/db.ts` | `insertMagicLink` takes `expiresAt`; `consumeMagicLink` enforces it; new `deleteExpiredMagicLinks` / `deleteExpiredSessions` |
| `worker/routes/auth.ts` | computes `expiresAt`, threads it through |
| `worker/index.ts` | new `scheduled()` export |
| `wrangler.jsonc` | `triggers.crons: ["0 * * * *"]` |
| `worker/test-helpers.ts` | mirrors the schema change |
| `worker/README.md` | new "Background sweep (cron trigger)" section; "What's stubbed" pruned |

## Operator follow-up — one-time per environment

```bash
pnpm exec wrangler d1 migrations apply planisphere-dev --remote
```

Cron trigger deploys automatically with the Git integration. First sweep fires at the next hour boundary.

## Test plan

- [x] `pnpm typecheck && pnpm lint && pnpm format:check && pnpm test:cov && pnpm build` green locally
- [x] 68 worker tests (+7), 1183 SPA tests
- [ ] After migration is applied to preview D1, request a magic link; confirm the email/log shows a URL that works for ~15 min and 401s afterwards
- [ ] Watch `wrangler tail` after the next hour boundary for `[sweep] magic_links=N sessions=N`

https://claude.ai/code/session_014DzXBVSCw5T2nnQvQjJtzS