### PR TITLE
feat(astro): @-mention entity catalog + fix(auth): magic-link URL on prod

### DIFF
--- a/src/astro/entities.test.ts
+++ b/src/astro/entities.test.ts
@@ -1,0 +1,90 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { describe, expect, it } from "vitest";
+import { resolveEntityLabel, searchEntities, type EntityKind } from "./entities";
+
+/**
+ * Catalog used by the Notebook's @-mention popover (ADR 013). Source data:
+ * `data/constellations.json` (88 IAU), `data/meteor-showers.json` (annual
+ * IMO calendar), and a hardcoded list of the planisphere's named bodies
+ * (matches `src/astro/search.ts` BODY_MAP — Sun, Moon, Mercury…Saturn).
+ */
+
+describe("resolveEntityLabel", () => {
+  it("returns the display label for a known body", () => {
+    expect(resolveEntityLabel({ kind: "body", id: "Sun" })).toBe("Sun");
+    expect(resolveEntityLabel({ kind: "body", id: "Mars" })).toBe("Mars");
+  });
+
+  it("returns the IAU name for a known constellation", () => {
+    expect(resolveEntityLabel({ kind: "constellation", id: "And" })).toBe("Andromeda");
+    expect(resolveEntityLabel({ kind: "constellation", id: "Ori" })).toBe("Orion");
+  });
+
+  it("returns the meteor-shower name for a known event", () => {
+    expect(resolveEntityLabel({ kind: "event", id: "perseids" })).toBe("Perseids");
+  });
+
+  it("returns null for an unknown id", () => {
+    expect(resolveEntityLabel({ kind: "body", id: "Pluto" })).toBeNull();
+    expect(resolveEntityLabel({ kind: "constellation", id: "Zzz" })).toBeNull();
+    expect(resolveEntityLabel({ kind: "event", id: "made-up-shower" })).toBeNull();
+  });
+
+  it("returns null for an unknown kind", () => {
+    expect(resolveEntityLabel({ kind: "nope" as EntityKind, id: "x" })).toBeNull();
+  });
+});
+
+describe("searchEntities", () => {
+  it("returns case-insensitive substring matches", () => {
+    const results = searchEntities("ori");
+    const labels = results.map((r) => r.label);
+    expect(labels).toContain("Orion");
+  });
+
+  it("matches across kinds", () => {
+    const results = searchEntities("ar"); // Mars (body), Aries (constellation), …
+    const kinds = new Set(results.map((r) => r.kind));
+    expect(kinds.size).toBeGreaterThanOrEqual(2);
+  });
+
+  it("respects the limit argument", () => {
+    const results = searchEntities("a", 5);
+    expect(results.length).toBeLessThanOrEqual(5);
+  });
+
+  it("defaults to a sensible upper bound", () => {
+    const results = searchEntities("a");
+    expect(results.length).toBeLessThanOrEqual(8);
+  });
+
+  it("returns an empty list for an empty query", () => {
+    expect(searchEntities("")).toEqual([]);
+    expect(searchEntities("   ")).toEqual([]);
+  });
+
+  it("returns an empty list when nothing matches", () => {
+    expect(searchEntities("zzznosuchthing")).toEqual([]);
+  });
+
+  it("trims and lowercases the query", () => {
+    expect(searchEntities("  ORION  ").map((r) => r.label)).toContain("Orion");
+  });
+
+  it("each result carries kind + id + label", () => {
+    const results = searchEntities("perseids");
+    expect(results.length).toBeGreaterThan(0);
+    const first = results[0]!;
+    expect(first.kind).toBe("event");
+    expect(first.id).toBe("perseids");
+    expect(first.label).toBe("Perseids");
+  });
+
+  it("results are stably ordered (alphabetical by label)", () => {
+    const a = searchEntities("a", 8).map((r) => r.label);
+    const b = searchEntities("a", 8).map((r) => r.label);
+    expect(a).toEqual(b);
+    const sorted = [...a].sort((x, y) => x.localeCompare(y));
+    expect(a).toEqual(sorted);
+  });
+});

--- a/src/astro/entities.ts
+++ b/src/astro/entities.ts
@@ -1,0 +1,81 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import rawConstellations from "../../data/constellations.json";
+import rawMeteorShowers from "../../data/meteor-showers.json";
+
+/**
+ * Catalog used by the Notebook's @-mention popover (ADR 013).
+ *
+ * Mentions persist as `{ kind, id }` attribute pairs in the tiptap doc;
+ * the renderer calls `resolveEntityLabel` at display time so labels stay
+ * correct as the underlying catalogs evolve. The entity set is
+ * intentionally narrow for v1: planisphere-named bodies (Sun…Saturn),
+ * the 88 IAU constellations, and IMO meteor showers. Stars and places
+ * are deferred — they need fuzzy search beyond a 100ish-item substring
+ * match.
+ */
+
+export type EntityKind = "body" | "constellation" | "event";
+
+export type EntityRef = {
+  readonly kind: EntityKind;
+  readonly id: string;
+};
+
+export type EntityRecord = EntityRef & {
+  readonly label: string;
+};
+
+const DEFAULT_LIMIT = 8;
+
+/** Named bodies the planisphere renders. Mirrors `BODY_MAP` in
+ *  `src/astro/search.ts`. Uranus / Neptune / Pluto are intentionally
+ *  out of scope for v1. */
+const BODY_ENTITIES: readonly EntityRecord[] = [
+  { kind: "body", id: "Sun", label: "Sun" },
+  { kind: "body", id: "Moon", label: "Moon" },
+  { kind: "body", id: "Mercury", label: "Mercury" },
+  { kind: "body", id: "Venus", label: "Venus" },
+  { kind: "body", id: "Mars", label: "Mars" },
+  { kind: "body", id: "Jupiter", label: "Jupiter" },
+  { kind: "body", id: "Saturn", label: "Saturn" },
+];
+
+type ConstellationData = { readonly id: string; readonly name: string };
+type MeteorShowerData = { readonly id: string; readonly name: string };
+
+const CONSTELLATION_ENTITIES: readonly EntityRecord[] = (
+  rawConstellations as readonly ConstellationData[]
+).map((c) => ({ kind: "constellation", id: c.id, label: c.name }));
+
+const EVENT_ENTITIES: readonly EntityRecord[] = (
+  rawMeteorShowers as readonly MeteorShowerData[]
+).map((m) => ({ kind: "event", id: m.id, label: m.name }));
+
+const ALL_ENTITIES: readonly EntityRecord[] = [
+  ...BODY_ENTITIES,
+  ...CONSTELLATION_ENTITIES,
+  ...EVENT_ENTITIES,
+];
+
+/** O(1) lookup from `${kind}:${id}` to the label. Built once at module load. */
+const LABELS_BY_KEY: ReadonlyMap<string, string> = new Map(
+  ALL_ENTITIES.map((e) => [`${e.kind}:${e.id}`, e.label]),
+);
+
+export function resolveEntityLabel(ref: EntityRef): string | null {
+  return LABELS_BY_KEY.get(`${ref.kind}:${ref.id}`) ?? null;
+}
+
+/**
+ * Substring (case-insensitive) search across all kinds. Trimmed empty
+ * queries return `[]` so the popover stays closed on bare `@`. Results
+ * are sorted alphabetically by label so the popover order is stable
+ * across keystrokes.
+ */
+export function searchEntities(query: string, limit: number = DEFAULT_LIMIT): EntityRecord[] {
+  const needle = query.trim().toLowerCase();
+  if (needle.length === 0) return [];
+  const matches = ALL_ENTITIES.filter((e) => e.label.toLowerCase().includes(needle));
+  matches.sort((a, b) => a.label.localeCompare(b.label));
+  return matches.slice(0, limit);
+}


### PR DESCRIPTION
Two changes bundled because the second is a hot-fix the user is blocked on; bundling beats serialising the merges.

## 1. fix(auth): magic-link URL uses request origin (urgent)

The Resend email was pointing at `http://localhost:5173` from production because `env.APP_ORIGIN` was hard-coded in `wrangler.jsonc`. Build the callback URL from `new URL(request.url).origin` instead — the Worker is same-origin with the SPA per ADR 009, so the request URL's origin is exactly where the user should land back. Works on localhost, preview URLs, and production with **no per-environment config**.

- `worker/routes/auth.ts` — `handleRequestLink` builds the callback URL against `new URL(req.url).origin`; `handleCallback` redirects to `url.origin + "/"`.
- `worker/types.ts` — drop `APP_ORIGIN` from the `Env` shape.
- `wrangler.jsonc`, `vitest.worker.config.ts` — drop the `APP_ORIGIN` var/binding.
- `worker/routes/auth.test.ts` — assert Location matches the request's own origin.
- `worker/README.md` — explanation of the request-origin choice.

**Operator follow-up:** none. Redeploy is enough — next magic link carries the right URL.

## 2. feat(astro): @-mention entity catalog (#219, PR-A)

Pure-data slice for the Notebook's `@`-mention popover (ADR 013). No UI changes; the editor wire-up + tiptap mention extension lands in PR-B.

```ts
// src/astro/entities.ts
export type EntityKind = "body" | "constellation" | "event";
export function resolveEntityLabel(ref: { kind: EntityKind; id: string }): string | null;
export function searchEntities(query: string, limit?: number): EntityRecord[];
```

| Kind | Source | Count |
|------|--------|-------|
| `body` | mirrors `BODY_MAP` in `src/astro/search.ts` | 7 (Sun…Saturn) |
| `constellation` | `data/constellations.json` | 88 IAU |
| `event` | `data/meteor-showers.json` | IMO calendar |

Stars + places are out of scope for v1 — they need fuzzy ranking beyond a 100ish-item substring match.

14 tests in `src/astro/entities.test.ts` cover both APIs across known/unknown ids, unknown kind, query edge cases (empty, whitespace, no-match, case insensitivity), default + explicit limits, and stable alphabetical ordering.

## Test plan

- [x] `pnpm typecheck && pnpm lint && pnpm format:check && pnpm test:cov && pnpm build` green locally
- [x] 1197 SPA tests (+14), 68 Worker tests (auth Location-redirect test updated)
- [ ] After merge + redeploy: trigger a new magic link in prod; verify the email URL points at your production hostname (not localhost)
- [ ] PR-B (tiptap mention extension wired to the catalog) follows in a separate PR

https://claude.ai/code/session_014DzXBVSCw5T2nnQvQjJtzS