### PR TITLE
fix(auth): magic-link URL uses request origin, drop APP_ORIGIN

### DIFF
--- a/vitest.worker.config.ts
+++ b/vitest.worker.config.ts
@@ -19,7 +19,6 @@ export default defineWorkersConfig({
           compatibilityFlags: ["nodejs_compat"],
           d1Databases: ["DB"],
           bindings: {
-            APP_ORIGIN: "http://localhost:5173",
             SESSION_SECRET: "test-secret-at-least-32-bytes-long-please!!",
           },
         },

--- a/worker/README.md
+++ b/worker/README.md
@@ -77,7 +77,7 @@ client the strict-Result contract CLAUDE.md mandates.
                         UPDATE magic_links SET used_at=now   ► marks one-use
                         INSERT sessions  ──────────► sessions row
                         Set-Cookie: ps_session=<signed>
-                        Location: APP_ORIGIN/
+                        Location: <request-origin>/
                 ◄──────
 
   GET /api/auth/me
@@ -137,7 +137,6 @@ Declared as the `Env` type in `worker/types.ts`:
 ```ts
 type Env = {
   DB: D1Database;
-  APP_ORIGIN: string; // e.g. "https://planisphere.app" — cookie redirects
   SESSION_SECRET: string; // HMAC key — set via `wrangler secret put`
   RESEND_API_KEY?: string; // Resend secret — ADR 014
   EMAIL_FROM?: string; // verified sender on Resend
@@ -145,11 +144,15 @@ type Env = {
 ```
 
 `SESSION_SECRET` and `RESEND_API_KEY` are Worker secrets (never committed).
-`APP_ORIGIN`, `EMAIL_FROM`, and the D1 binding are in `wrangler.jsonc` —
-the single Worker-with-Static-Assets config that deploys both this
-module and the SPA `dist/` bundle. The dev `SESSION_SECRET` is a
-placeholder string — fine for local development, not for any deployed
-environment.
+`EMAIL_FROM` and the D1 binding are in `wrangler.jsonc` — the single
+Worker-with-Static-Assets config that deploys both this module and the
+SPA `dist/` bundle. The dev `SESSION_SECRET` is a placeholder string —
+fine for local development, not for any deployed environment.
+
+Magic-link callback URLs and post-login redirects are built against the
+**request's own origin** (not an env var). The Worker is same-origin
+with the SPA per ADR 009, so this gives the right URL on `localhost`,
+preview deploys, and production with no per-environment config.
 
 ### Email delivery (Resend)
 

--- a/worker/routes/auth.test.ts
+++ b/worker/routes/auth.test.ts
@@ -92,7 +92,7 @@ describe("POST /api/auth/request-link", () => {
 });
 
 describe("GET /api/auth/callback", () => {
-  it("consumes the token, sets a cookie, and redirects to APP_ORIGIN", async () => {
+  it("consumes the token, sets a cookie, and redirects to the request origin", async () => {
     // Request a link, read the token straight out of D1.
     await fetchWorker(
       new Request(`${BASE}/api/auth/request-link`, {
@@ -109,7 +109,8 @@ describe("GET /api/auth/callback", () => {
 
     const res = await fetchWorker(new Request(`${BASE}/api/auth/callback?token=${pending!.token}`));
     expect(res.status).toBe(302);
-    expect(res.headers.get("Location")).toContain("http://localhost:5173");
+    // Location uses the request's own origin (no APP_ORIGIN env var).
+    expect(res.headers.get("Location")).toBe(`${BASE}/`);
     const cookie = extractSessionCookie(res);
     expect(cookie).toBeTruthy();
     expect(cookie).toContain(".");

--- a/worker/routes/auth.ts
+++ b/worker/routes/auth.ts
@@ -76,7 +76,12 @@ export async function handleRequestLink(
   const expiresAt = Date.now() + MAGIC_LINK_TTL_SECONDS * 1000;
   await insertMagicLink(env.DB, token, normalized, expiresAt);
 
-  const callbackUrl = new URL("/api/auth/callback", env.APP_ORIGIN);
+  // Build the callback URL against the request's own origin, not a fixed
+  // env var. The Worker is same-origin with the SPA (ADR 009), so the
+  // request URL's origin is exactly where the user should land back —
+  // works correctly for `localhost`, preview URLs, and production
+  // without any per-environment config.
+  const callbackUrl = new URL("/api/auth/callback", new URL(req.url).origin);
   callbackUrl.searchParams.set("token", token);
   await email.sendMagicLink(normalized, callbackUrl.toString());
 
@@ -107,7 +112,7 @@ export async function handleCallback(req: Request, env: Env): Promise<Response> 
     status: 302,
     headers: {
       "Set-Cookie": cookie,
-      Location: env.APP_ORIGIN + "/",
+      Location: url.origin + "/",
     },
   });
 }

--- a/worker/types.ts
+++ b/worker/types.ts
@@ -4,7 +4,6 @@
  *  from `wrangler.jsonc` + `wrangler secret put`. */
 export type Env = {
   readonly DB: D1Database;
-  readonly APP_ORIGIN: string;
   readonly SESSION_SECRET: string;
   /** Resend API key (Worker secret). Absent / empty in dev → auth falls
    *  back to the console-log stub. See ADR 014. */

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -33,9 +33,8 @@
 
   // Non-secret defaults. The real SESSION_SECRET must be set out-of-band
   //   wrangler secret put SESSION_SECRET
-  // (never committed). APP_ORIGIN is the URL magic-link callbacks redirect
-  // to — override per environment via Cloudflare dashboard or `vars`
-  // overrides in a deploy-time config.
+  // (never committed). Magic-link callback URLs are built against the
+  // request's own origin, so no APP_ORIGIN var is needed.
   //
   // Email (ADR 014): `RESEND_API_KEY` is a Worker secret
   //   wrangler secret put RESEND_API_KEY
@@ -43,7 +42,6 @@
   // either is unset, the Worker falls back to the console-log stub —
   // grep `wrangler tail` for `[auth] magic link`.
   "vars": {
-    "APP_ORIGIN": "http://localhost:5173",
     "SESSION_SECRET": "dev-only-placeholder-replace-with-wrangler-secret-put",
     "EMAIL_FROM": "noreply@rabbitsatin.com", // ← or "onboarding@resend.dev" for the shortcut
   },


### PR DESCRIPTION
## Summary

Magic-link emails sent from the production deploy point at `http://localhost:5173` because `env.APP_ORIGIN` was hard-coded in `wrangler.jsonc`. Fix: build the callback URL (and the post-callback redirect Location) from `new URL(request.url).origin` instead. The Worker is same-origin with the SPA per ADR 009, so the request URL's origin is exactly the right host on localhost, preview URLs, and production — **no per-environment config**.

This was bundled into #242 but didn't make it through the squash-merge — only the entity-catalog half landed. Re-applying as its own PR.

## Changes

- `worker/routes/auth.ts` — `handleRequestLink` builds the callback URL against `new URL(req.url).origin`; `handleCallback` redirects to `url.origin + "/"`. Inline comment explains why.
- `worker/types.ts` — drop `APP_ORIGIN` from the `Env` shape.
- `wrangler.jsonc` — drop `APP_ORIGIN` from vars; comment refreshed.
- `vitest.worker.config.ts` — drop `APP_ORIGIN` from miniflare bindings.
- `worker/routes/auth.test.ts` — assert Location matches the request's own origin.
- `worker/README.md` — `Env` block updated; magic-link flow diagram shows `<request-origin>/` instead of `APP_ORIGIN/`; new paragraph explaining the choice.

## Operator follow-up

**None.** No DB migration, no secret to set. A redeploy ships the fix; the next magic link carries the right URL.

## Test plan

- [x] `pnpm typecheck && pnpm lint && pnpm format:check && pnpm test:cov && pnpm build` green locally
- [x] 1197 SPA tests, 68 Worker tests
- [ ] After merge + redeploy, request a magic link in prod; verify the URL points at your production hostname (not localhost)

https://claude.ai/code/session_014DzXBVSCw5T2nnQvQjJtzS