### PR TITLE
fix(scene): reposition Cesium credit bar to top-right of the viewer (#255)

### DIFF
--- a/src/scene/viewer.test.ts
+++ b/src/scene/viewer.test.ts
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 import { describe, expect, it, vi } from "vitest";
 import { isOk, isErr } from "../result";
-import { createViewer } from "./viewer";
+import { createViewer, repositionCreditBar } from "./viewer";
 
 vi.mock("cesium", () => {
   const MockViewer = vi.fn().mockImplementation(() => ({
@@ -53,5 +53,31 @@ describe("createViewer", () => {
     expect(isErr(r)).toBe(true);
     if (isErr(r)) expect(r.error.message).toContain("WebGL not available");
     document.body.removeChild(container);
+  });
+});
+
+describe("repositionCreditBar", () => {
+  it("moves Cesium's default credit bar from bottom-left to top-right", () => {
+    const container = document.createElement("div");
+    const creditBar = document.createElement("div");
+    creditBar.className = "cesium-viewer-bottom";
+    creditBar.style.bottom = "0";
+    creditBar.style.left = "0";
+    container.appendChild(creditBar);
+
+    repositionCreditBar(container);
+
+    expect(creditBar.style.top).toBe("8px");
+    expect(creditBar.style.right).toBe("8px");
+    expect(creditBar.style.bottom).toBe("auto");
+    expect(creditBar.style.left).toBe("auto");
+    expect(creditBar.dataset.testid).toBe("cesium-credit-bar");
+  });
+
+  it("is a no-op if the viewer has no .cesium-viewer-bottom child", () => {
+    const container = document.createElement("div");
+    expect(() => {
+      repositionCreditBar(container);
+    }).not.toThrow();
   });
 });

--- a/src/scene/viewer.ts
+++ b/src/scene/viewer.ts
@@ -41,6 +41,8 @@ export function createViewer(containerId: string): Result<Viewer, SceneInitError
     viewer.scene.globe.show = false;
     viewer.imageryLayers.removeAll();
 
+    repositionCreditBar(container);
+
     return ok(viewer);
   } catch (e) {
     return err({
@@ -48,4 +50,26 @@ export function createViewer(containerId: string): Result<Viewer, SceneInitError
       message: `Cesium Viewer creation failed: ${String(e)}`,
     });
   }
+}
+
+/**
+ * Move Cesium's default credit bar (the `.cesium-viewer-bottom` child of the
+ * viewer container) from its default bottom-left position to the top-right
+ * corner of the viewer. Cesium's own CSS renders the "Powered by Cesium"
+ * logo + attributions inside it; we're only overriding the outer container's
+ * position so it doesn't collide with the bottom-hud (time / observer /
+ * scrubber). Exported for testing.
+ *
+ * Cesium's Apache-2.0 licence expects the credit display to stay visible;
+ * we keep it visible and clickable, just out of the hud's way.
+ */
+export function repositionCreditBar(viewerContainer: HTMLElement): void {
+  const creditBar = viewerContainer.querySelector<HTMLElement>(".cesium-viewer-bottom");
+  if (creditBar === null) return;
+  creditBar.style.bottom = "auto";
+  creditBar.style.left = "auto";
+  creditBar.style.top = "8px";
+  creditBar.style.right = "8px";
+  creditBar.style.zIndex = "100";
+  creditBar.dataset.testid = "cesium-credit-bar";
 }


### PR DESCRIPTION
## Summary

Cesium's default credit container (Ion logo + attribution) sits bottom-left of the viewer, colliding with the 56 px bottom-hud (time / observer / scrubber).

**First approach in this PR** passed a custom `creditContainer` element, but that bypassed Cesium's internal CSS and the logo stopped rendering. Reverted.

**Current approach**: let Cesium build its default `.cesium-viewer-bottom` element, then restyle the outer container in place after construction:

- `bottom / left: auto`
- `top / right: 8px`
- `z-index: 100`

Cesium's internal CSS for the logo + attribution keeps working; only the outer container moves. Apache-2.0 credit stays visible and clickable.

New exported helper `repositionCreditBar(viewerContainer)` keeps the DOM manipulation testable without mocking Cesium's internals.

## TDD

Two new tests in `viewer.test.ts`:
- The bar gets the expected top-right styling + `data-testid="cesium-credit-bar"` after `repositionCreditBar` runs.
- A container without a `.cesium-viewer-bottom` child is a safe no-op.

All 5 viewer tests pass.

## Test plan

- [x] `pnpm typecheck && pnpm lint && pnpm format:check && pnpm test:cov && pnpm build` green locally
- [x] 1205 SPA tests (+2), 68 worker tests unchanged
- [ ] On the preview URL: Cesium logo sits top-right, doesn't overlap the bottom-hud, and the attribution link is still clickable

Closes #255.

https://claude.ai/code/session_014DzXBVSCw5T2nnQvQjJtzS