### PR TITLE
chore(worker): structured logging helper + migrate 3 console.* sites (#246)

### DIFF
--- a/worker/index.ts
+++ b/worker/index.ts
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 import { deleteExpiredMagicLinks, deleteExpiredSessions } from "./db";
 import { createEmailSender } from "./email";
+import { logError, logEvent } from "./log";
 import { handleCallback, handleLogout, handleMe, handleRequestLink } from "./routes/auth";
 import {
   handleCreateNotebook,
@@ -58,8 +59,7 @@ export default {
       }
       return notFound();
     } catch (err) {
-      // eslint-disable-next-line no-console
-      console.error("[worker] unhandled error", err);
+      logError("worker.unhandled", err, { path, method });
       return new Response(JSON.stringify({ error: "server_error" }), {
         status: 500,
         headers: { "content-type": "application/json" },
@@ -74,13 +74,11 @@ export default {
    */
   async scheduled(_event: ScheduledController, env: Env, _ctx: ExecutionContext): Promise<void> {
     try {
-      const links = await deleteExpiredMagicLinks(env.DB);
+      const magicLinks = await deleteExpiredMagicLinks(env.DB);
       const sessions = await deleteExpiredSessions(env.DB);
-      // eslint-disable-next-line no-console
-      console.log(`[sweep] magic_links=${String(links)} sessions=${String(sessions)}`);
+      logEvent("sweep.completed", { magicLinks, sessions });
     } catch (err) {
-      // eslint-disable-next-line no-console
-      console.error("[sweep] failed", err);
+      logError("sweep.failed", err);
     }
   },
 } satisfies ExportedHandler<Env>;

--- a/worker/log.test.ts
+++ b/worker/log.test.ts
@@ -1,0 +1,112 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { logError, logEvent } from "./log";
+
+/**
+ * Tests for the Worker's tiny structured-logging helper. Both functions
+ * emit a single-line JSON string via `console.log` / `console.error` so
+ * Cloudflare's observability feed can parse events without regex.
+ */
+
+type LoggedLine = { event: string; t: number; [k: string]: unknown };
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function captureStdout(): { lines: string[] } {
+  const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+  return {
+    get lines() {
+      return spy.mock.calls.map((c) => String(c[0]));
+    },
+  };
+}
+
+function captureStderr(): { lines: string[] } {
+  const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+  return {
+    get lines() {
+      return spy.mock.calls.map((c) => String(c[0]));
+    },
+  };
+}
+
+describe("logEvent", () => {
+  it("writes one JSON line to console.log with event + t", () => {
+    const out = captureStdout();
+    logEvent("sweep.completed");
+    expect(out.lines).toHaveLength(1);
+    const parsed = JSON.parse(out.lines[0]!) as LoggedLine;
+    expect(parsed.event).toBe("sweep.completed");
+    expect(typeof parsed.t).toBe("number");
+  });
+
+  it("merges extra fields into the JSON line", () => {
+    const out = captureStdout();
+    logEvent("sweep.completed", { magicLinks: 3, sessions: 7 });
+    const parsed = JSON.parse(out.lines[0]!) as LoggedLine;
+    expect(parsed.magicLinks).toBe(3);
+    expect(parsed.sessions).toBe(7);
+  });
+
+  it("doesn't let a `t` field in extras overwrite the timestamp", () => {
+    const out = captureStdout();
+    logEvent("x", { t: "nope" });
+    const parsed = JSON.parse(out.lines[0]!) as LoggedLine;
+    expect(typeof parsed.t).toBe("number");
+  });
+});
+
+describe("logError", () => {
+  it("writes one JSON line to console.error with event + t + error", () => {
+    const err = captureStderr();
+    logError("worker.unhandled", new Error("boom"), { path: "/api/x" });
+    expect(err.lines).toHaveLength(1);
+    const parsed = JSON.parse(err.lines[0]!) as LoggedLine;
+    expect(parsed.event).toBe("worker.unhandled");
+    expect(parsed.error).toBe("boom");
+    expect(typeof parsed.stack).toBe("string");
+    expect(parsed.path).toBe("/api/x");
+    expect(typeof parsed.t).toBe("number");
+  });
+
+  it("stringifies non-Error values into `error`", () => {
+    const err = captureStderr();
+    logError("sweep.failed", "something went wrong");
+    const parsed = JSON.parse(err.lines[0]!) as LoggedLine;
+    expect(parsed.error).toBe("something went wrong");
+    expect(parsed.stack).toBeUndefined();
+  });
+
+  it("handles null/undefined/object inputs without throwing", () => {
+    const err = captureStderr();
+    logError("a", null);
+    logError("b", undefined);
+    logError("c", { oops: true });
+    expect(err.lines).toHaveLength(3);
+    const a = JSON.parse(err.lines[0]!) as LoggedLine;
+    const b = JSON.parse(err.lines[1]!) as LoggedLine;
+    const c = JSON.parse(err.lines[2]!) as LoggedLine;
+    expect(a.error).toBe("null");
+    expect(b.error).toBe("undefined");
+    expect(typeof c.error).toBe("string");
+    expect(c.error).toContain("oops");
+  });
+
+  it("doesn't let extras overwrite event/t/error/stack", () => {
+    const err = captureStderr();
+    logError("e", new Error("boom"), {
+      event: "nope",
+      t: "nope",
+      error: "nope",
+      stack: "nope",
+    });
+    const parsed = JSON.parse(err.lines[0]!) as LoggedLine;
+    expect(parsed.event).toBe("e");
+    expect(typeof parsed.t).toBe("number");
+    expect(parsed.error).toBe("boom");
+    expect(typeof parsed.stack).toBe("string");
+    expect(parsed.stack === "nope").toBe(false);
+  });
+});

--- a/worker/log.ts
+++ b/worker/log.ts
@@ -1,0 +1,47 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/**
+ * Tiny structured logger for the Worker. Each call emits a single-line
+ * JSON object via `console.log` / `console.error` — Cloudflare's
+ * observability feed records the string and lets us filter / aggregate by
+ * `event` field without regex-scraping.
+ *
+ * Usage:
+ *   logEvent("sweep.completed", { magicLinks: n, sessions: m });
+ *   logError("worker.unhandled", err, { path, method });
+ *
+ * The dev-only console stubs in `worker/email.ts` stay as plain-string
+ * `console.log` — they exist for humans grepping `wrangler tail`, not for
+ * the observability pipeline.
+ */
+
+export function logEvent(event: string, fields?: Record<string, unknown>): void {
+  const line = { ...(fields ?? {}), event, t: Date.now() };
+  // eslint-disable-next-line no-console
+  console.log(JSON.stringify(line));
+}
+
+export function logError(event: string, err: unknown, fields?: Record<string, unknown>): void {
+  const message = err instanceof Error ? err.message : safeString(err);
+  const stack = err instanceof Error ? err.stack : undefined;
+  const line: Record<string, unknown> = {
+    ...(fields ?? {}),
+    event,
+    t: Date.now(),
+    error: message,
+  };
+  if (stack !== undefined) line["stack"] = stack;
+  // eslint-disable-next-line no-console
+  console.error(JSON.stringify(line));
+}
+
+function safeString(value: unknown): string {
+  if (value === null) return "null";
+  if (value === undefined) return "undefined";
+  if (typeof value === "string") return value;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return Object.prototype.toString.call(value);
+  }
+}


### PR DESCRIPTION
Closes #246.

## Summary

Adds `worker/log.ts` — a ~45-line structured-logging helper that emits single-line JSON to console, so Cloudflare's observability feed can aggregate by `event` field without regex-scraping:

```ts
logEvent("sweep.completed", { magicLinks, sessions });
// → console.log('{"magicLinks":3,"sessions":7,"event":"sweep.completed","t":1712345678901}')

logError("worker.unhandled", err, { path, method });
// → console.error('{"path":"…","method":"POST","event":"worker.unhandled","t":…,"error":"boom","stack":"Error: boom\n  at …"}')
```

## Migrated call sites

Three operational sites in `worker/index.ts`:

| Before | After |
|--------|-------|
| `console.error("[worker] unhandled error", err)` | `logError("worker.unhandled", err, { path, method })` |
| `console.log(`[sweep] magic_links=${links} sessions=${sessions}`)` | `logEvent("sweep.completed", { magicLinks, sessions })` |
| `console.error("[sweep] failed", err)` | `logError("sweep.failed", err)` |

## What's intentionally unchanged

- `ConsoleEmailSender` in `worker/email.ts` — its whole purpose is human-readable `wrangler tail` output for local dev. Stays as plain string.
- SPA-side `console.warn` calls — browser-only diagnostics, no telemetry pipeline yet.

## TDD

7 new tests in `worker/log.test.ts`:

- JSON shape: `event`, numeric `t`, extras merged
- Error vs non-Error vs null/undefined/object input shapes
- Extras can't overwrite core fields (event / t / error / stack)

75 worker tests total (+7); 1205 SPA tests unchanged.

## Test plan

- [x] `pnpm typecheck && pnpm lint && pnpm format:check && pnpm test:cov && pnpm build` green locally
- [x] `pnpm test:worker` green
- [ ] After merge + redeploy, confirm `wrangler tail` shows one-line JSON for the sweep / unhandled-error events

https://claude.ai/code/session_014DzXBVSCw5T2nnQvQjJtzS