### PR TITLE
chore(worker): extract shared test helpers (BASE, fetchWorker, login, authed) (#247)

### DIFF
--- a/worker/routes/auth.test.ts
+++ b/worker/routes/auth.test.ts
@@ -1,20 +1,19 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import worker from "../index";
-import { testEnv, resetDb, extractSessionCookie } from "../test-helpers";
+import {
+  TEST_BASE as BASE,
+  extractSessionCookie,
+  fetchWorker,
+  login,
+  resetDb,
+  testEnv,
+} from "../test-helpers";
 import type { EmailSender } from "../email";
 
 /**
  * End-to-end auth-route tests. Runs inside a real workerd isolate via
  * `@cloudflare/vitest-pool-workers` with an in-memory D1 binding.
  */
-
-async function fetchWorker(req: Request): Promise<Response> {
-  if (!worker.fetch) throw new Error("worker has no fetch handler");
-  return worker.fetch(req, testEnv, {} as unknown as ExecutionContext);
-}
-
-const BASE = "http://localhost";
 
 beforeEach(async () => {
   await resetDb();
@@ -158,23 +157,6 @@ describe("GET /api/auth/callback", () => {
 });
 
 describe("GET /api/auth/me", () => {
-  async function login(email: string): Promise<string> {
-    await fetchWorker(
-      new Request(`${BASE}/api/auth/request-link`, {
-        method: "POST",
-        body: JSON.stringify({ email }),
-      }),
-    );
-    const pending = await testEnv.DB.prepare(
-      "SELECT token FROM magic_links WHERE email = ? ORDER BY created_at DESC LIMIT 1",
-    )
-      .bind(email)
-      .first<{ token: string }>();
-    const res = await fetchWorker(new Request(`${BASE}/api/auth/callback?token=${pending!.token}`));
-    const cookie = extractSessionCookie(res);
-    return cookie!;
-  }
-
   it("returns 401 without a cookie", async () => {
     const res = await fetchWorker(new Request(`${BASE}/api/auth/me`));
     expect(res.status).toBe(401);

--- a/worker/routes/notebooks.test.ts
+++ b/worker/routes/notebooks.test.ts
@@ -1,20 +1,12 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 import { beforeEach, describe, expect, it } from "vitest";
-import worker from "../index";
-import { testEnv, resetDb, extractSessionCookie } from "../test-helpers";
+import { TEST_BASE as BASE, authed, fetchWorker, login, resetDb } from "../test-helpers";
 
 /**
  * End-to-end tests for /api/notebooks routes. Runs inside workerd via
  * @cloudflare/vitest-pool-workers with an in-memory D1 binding that has
  * both the auth tables and the notebooks table created by resetDb().
  */
-
-async function fetchWorker(req: Request): Promise<Response> {
-  if (!worker.fetch) throw new Error("worker has no fetch handler");
-  return worker.fetch(req, testEnv, {} as unknown as ExecutionContext);
-}
-
-const BASE = "http://localhost";
 
 type NotebookRow = {
   readonly id: number;
@@ -28,29 +20,6 @@ type NotebookRow = {
 type NotebookSummary = Omit<NotebookRow, "content_json" | "user_id">;
 
 type NotebookResponse = Omit<NotebookRow, "user_id">;
-
-async function login(email: string): Promise<string> {
-  await fetchWorker(
-    new Request(`${BASE}/api/auth/request-link`, {
-      method: "POST",
-      body: JSON.stringify({ email }),
-    }),
-  );
-  const pending = await testEnv.DB.prepare(
-    "SELECT token FROM magic_links WHERE email = ? ORDER BY created_at DESC LIMIT 1",
-  )
-    .bind(email)
-    .first<{ token: string }>();
-  const res = await fetchWorker(new Request(`${BASE}/api/auth/callback?token=${pending!.token}`));
-  return extractSessionCookie(res)!;
-}
-
-function authed(path: string, cookie: string, init?: RequestInit): Request {
-  return new Request(`${BASE}${path}`, {
-    ...init,
-    headers: { cookie: `ps_session=${cookie}`, ...(init?.headers ?? {}) },
-  });
-}
 
 function sampleDoc(marker = "hello"): string {
   return JSON.stringify({

--- a/worker/sweep.test.ts
+++ b/worker/sweep.test.ts
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 import { beforeEach, describe, expect, it } from "vitest";
 import worker from "./index";
-import { testEnv, resetDb } from "./test-helpers";
+import { resetDb, testEnv } from "./test-helpers";
 import { deleteExpiredMagicLinks, deleteExpiredSessions } from "./db";
 
 /**

--- a/worker/test-helpers.ts
+++ b/worker/test-helpers.ts
@@ -1,19 +1,24 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /**
- * Small helpers used only by Worker tests — creates the schema on the
- * in-memory D1 binding before each test and extracts the signed session
- * cookie from a `Set-Cookie` header.
+ * Helpers shared across Worker tests — schema bootstrap, a `fetchWorker`
+ * wrapper over the entry point, and the `login(email)` / `authed(...)`
+ * helpers that every authenticated route test needs.
  *
- * The schema DDL is kept identical to `migrations/0001_init.sql`; the
- * migration file is the source of truth for production, and this helper
- * mirrors it for tests. Keep them in sync by hand — small cost, no extra
- * tooling.
+ * The schema DDL mirrors `migrations/0001_init.sql` + `0002_notebooks.sql`
+ * + `0003_magic_link_ttl.sql` — the migration files remain the source of
+ * truth for production; we keep this in sync by hand (small cost, no
+ * extra tooling).
  */
 import { env } from "cloudflare:test";
+import worker from "./index";
 import type { Env } from "./types";
 
 // Re-export the bound env so test files get narrow types.
 export const testEnv = env as unknown as Env;
+
+/** Origin used by every worker-test request. Arbitrary, but shared so the
+ *  redirect Location + CORS assertions all line up. */
+export const TEST_BASE = "http://localhost";
 
 const SCHEMA_STATEMENTS = [
   `CREATE TABLE users (
@@ -66,4 +71,43 @@ export function extractSessionCookie(res: Response): string | null {
   if (!header) return null;
   const match = header.match(/ps_session=([^;]+)/);
   return match ? match[1]! : null;
+}
+
+/** Invoke the worker's `fetch` handler with the bound `testEnv`. */
+export async function fetchWorker(req: Request): Promise<Response> {
+  if (!worker.fetch) throw new Error("worker has no fetch handler");
+  return worker.fetch(req, testEnv, {} as unknown as ExecutionContext);
+}
+
+/** Request a magic link for `email`, claim it via the callback, and
+ *  return the signed `ps_session` cookie value. Throws if the login
+ *  flow didn't end with a Set-Cookie (signals a broken test fixture
+ *  or a real regression in the auth routes). */
+export async function login(email: string): Promise<string> {
+  await fetchWorker(
+    new Request(`${TEST_BASE}/api/auth/request-link`, {
+      method: "POST",
+      body: JSON.stringify({ email }),
+    }),
+  );
+  const pending = await testEnv.DB.prepare(
+    "SELECT token FROM magic_links WHERE email = ? ORDER BY created_at DESC LIMIT 1",
+  )
+    .bind(email)
+    .first<{ token: string }>();
+  const res = await fetchWorker(
+    new Request(`${TEST_BASE}/api/auth/callback?token=${pending!.token}`),
+  );
+  const cookie = extractSessionCookie(res);
+  if (cookie === null) throw new Error(`login(${email}) did not yield a session cookie`);
+  return cookie;
+}
+
+/** Build an authenticated `Request` to `path` with the given session
+ *  cookie. Pass `init` for method / body / headers. */
+export function authed(path: string, cookie: string, init?: RequestInit): Request {
+  return new Request(`${TEST_BASE}${path}`, {
+    ...init,
+    headers: { cookie: `ps_session=${cookie}`, ...(init?.headers ?? {}) },
+  });
 }


### PR DESCRIPTION
Closes #247.

## Summary

`worker/routes/auth.test.ts` and `worker/routes/notebooks.test.ts` each re-declared the same plumbing at the top of the file — `BASE`, `fetchWorker`, `login(email)`, `authed(...)`. Moves all four into `worker/test-helpers.ts` alongside the existing `resetDb` / `extractSessionCookie` / `testEnv`. The two test files shrink by 25–50 lines each without any behaviour changes.

## New exports

```ts
// worker/test-helpers.ts
export const TEST_BASE = "http://localhost";
export async function fetchWorker(req: Request): Promise<Response>;
export async function login(email: string): Promise<string>;   // returns cookie
export function authed(path: string, cookie: string, init?: RequestInit): Request;
```

`login` now throws if the login flow doesn't end with a Set-Cookie — previously the tests all used `cookie!` to silence the null. If the auth flow regresses the tests will now fail with a clear message at the fixture instead of tripping over a `null` cookie 40 lines later.

## Scope

Pure refactor. 75 worker tests pass unchanged.

## Test plan

- [x] `pnpm typecheck && pnpm lint && pnpm format:check && pnpm test:cov && pnpm build` green locally
- [x] `pnpm test:worker` green

https://claude.ai/code/session_014DzXBVSCw5T2nnQvQjJtzS