### PR TITLE
fix(scene): stop Cesium credit bar from blocking hover + drag

### DIFF
--- a/src/scene/viewer.test.ts
+++ b/src/scene/viewer.test.ts
@@ -74,6 +74,24 @@ describe("repositionCreditBar", () => {
     expect(creditBar.dataset.testid).toBe("cesium-credit-bar");
   });
 
+  it("shrinks the bar to content width and disables pointer events", () => {
+    // Cesium's default `.cesium-viewer-bottom` is a full-width absolutely-
+    // positioned element. Leaving it full-width at `top: 8px` would lay a
+    // transparent band across the top of the viewer that intercepts every
+    // hover / drag gesture — breaks picker popups and camera drag. The
+    // wrapper must be `pointer-events: none` + `width: auto` so only the
+    // visible logo area shows and nothing there eats mouse events.
+    const container = document.createElement("div");
+    const creditBar = document.createElement("div");
+    creditBar.className = "cesium-viewer-bottom";
+    container.appendChild(creditBar);
+
+    repositionCreditBar(container);
+
+    expect(creditBar.style.pointerEvents).toBe("none");
+    expect(creditBar.style.width).toBe("auto");
+  });
+
   it("is a no-op if the viewer has no .cesium-viewer-bottom child", () => {
     const container = document.createElement("div");
     expect(() => {

--- a/src/scene/viewer.ts
+++ b/src/scene/viewer.ts
@@ -60,8 +60,13 @@ export function createViewer(containerId: string): Result<Viewer, SceneInitError
  * position so it doesn't collide with the bottom-hud (time / observer /
  * scrubber). Exported for testing.
  *
- * Cesium's Apache-2.0 licence expects the credit display to stay visible;
- * we keep it visible and clickable, just out of the hud's way.
+ * `pointer-events: none` on the wrapper is critical: the default
+ * `.cesium-viewer-bottom` is a full-width absolutely-positioned bar, so
+ * without it we'd be laying a transparent full-width band across the top
+ * of the viewer that intercepts every hover / drag gesture (= broken
+ * picker popups and broken camera drag). Cesium's Apache-2.0 requires
+ * the credit stay visible — it does — but doesn't require the link stay
+ * clickable, which it doesn't need to be for attribution.
  */
 export function repositionCreditBar(viewerContainer: HTMLElement): void {
   const creditBar = viewerContainer.querySelector<HTMLElement>(".cesium-viewer-bottom");
@@ -70,6 +75,8 @@ export function repositionCreditBar(viewerContainer: HTMLElement): void {
   creditBar.style.left = "auto";
   creditBar.style.top = "8px";
   creditBar.style.right = "8px";
+  creditBar.style.width = "auto";
+  creditBar.style.pointerEvents = "none";
   creditBar.style.zIndex = "100";
   creditBar.dataset.testid = "cesium-credit-bar";
 }


### PR DESCRIPTION
## Problem

After #256, hover popups and drag-to-reposition were broken in production. Root cause: Cesium's `.cesium-viewer-bottom` element is a **full-width, absolutely-positioned** bar by default. My earlier fix repositioned it to `top: 8px; right: 8px` but kept the default width, which laid a transparent full-width band across the top of the viewer — intercepting every hover / drag gesture in that band.

## Fix

Two additional inline style overrides on the credit bar:

- `width: auto` — the wrapper now shrinks to its visible logo content.
- `pointer-events: none` — even within that content area, mouse events pass through to the canvas below.

Cesium's Apache-2.0 licence requires the credit **stay visible**; it doesn't require the logo link stay clickable. Logo still shows top-right, just inert.

## TDD

One new assertion in `viewer.test.ts` covering the `width: auto` + `pointer-events: none` bits specifically, with the comment explaining *why* (so a future cleanup doesn't accidentally re-introduce the regression).

## Test plan

- [x] `pnpm typecheck && pnpm lint && pnpm format:check && pnpm test:cov && pnpm build` green locally
- [x] 1206 SPA tests (+1), 89 worker tests unchanged
- [ ] On the preview URL: hover a star → popover shows; drag across the sky → camera rotates; logo still visible in top-right

https://claude.ai/code/session_014DzXBVSCw5T2nnQvQjJtzS