### PR TITLE
chore(scene): centralise Cesium collection casts (#252)

### DIFF
--- a/src/scene/bodies.ts
+++ b/src/scene/bodies.ts
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 import { BillboardCollection, HorizontalOrigin, VerticalOrigin } from "cesium";
 import type { Scene } from "cesium";
+import { setCollectionVisible } from "./cesium-collections";
 import type { CelestialBody } from "../astro";
 import { altAzToCartesian } from "./stars";
 
@@ -115,7 +116,7 @@ export function createBodyLayer(scene: Scene): BodyLayer {
   }
 
   function setVisible(visible: boolean): void {
-    (billboards as unknown as { show: boolean }).show = visible;
+    setCollectionVisible(billboards, visible);
   }
 
   return { update, setVisible };

--- a/src/scene/boundaries.ts
+++ b/src/scene/boundaries.ts
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 import { PolylineCollection, Color, Material } from "cesium";
 import type { Scene } from "cesium";
+import { setCollectionVisible } from "./cesium-collections";
 import type { VisibleBoundary } from "../astro";
 import { raDecToAltAz } from "../astro/coords";
 import { altAzToCartesian } from "./stars";
@@ -57,7 +58,7 @@ export function createBoundaryLayer(scene: Scene): BoundaryLayer {
   }
 
   function setVisible(visible: boolean): void {
-    (polylines as unknown as { show: boolean }).show = visible;
+    setCollectionVisible(polylines, visible);
   }
 
   function setOpacity(opacity: number): void {

--- a/src/scene/cesium-collections.test.ts
+++ b/src/scene/cesium-collections.test.ts
@@ -1,0 +1,38 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { describe, expect, it } from "vitest";
+import { collectionAt, collectionLength, setCollectionVisible } from "./cesium-collections";
+
+describe("setCollectionVisible", () => {
+  it("sets `.show` on the collection object", () => {
+    const c: { show: boolean } = { show: false };
+    setCollectionVisible(c, true);
+    expect(c.show).toBe(true);
+    setCollectionVisible(c, false);
+    expect(c.show).toBe(false);
+  });
+});
+
+describe("collectionLength", () => {
+  it("returns the numeric `.length`", () => {
+    expect(collectionLength({ length: 7 })).toBe(7);
+    expect(collectionLength({ length: 0 })).toBe(0);
+  });
+
+  it("returns 0 when `.length` is missing or non-numeric", () => {
+    expect(collectionLength({})).toBe(0);
+    expect(collectionLength({ length: "x" })).toBe(0);
+  });
+});
+
+describe("collectionAt", () => {
+  it("delegates to the collection's `.get(i)` and returns the typed shape", () => {
+    const c = {
+      get(i: number): { id: number; color: { alpha: number } } {
+        return { id: i, color: { alpha: i * 0.1 } };
+      },
+    };
+    const row = collectionAt<{ id: number; color: { alpha: number } }>(c, 3);
+    expect(row.id).toBe(3);
+    expect(row.color.alpha).toBeCloseTo(0.3);
+  });
+});

--- a/src/scene/cesium-collections.ts
+++ b/src/scene/cesium-collections.ts
@@ -1,0 +1,32 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/**
+ * Typed helpers for Cesium's `BillboardCollection` / `PolylineCollection`
+ * / `LabelCollection`. The collections expose `.show`, `.length`, and
+ * `.get(i)` at runtime, but Cesium's bundled type definitions don't
+ * surface those members — so every caller otherwise needs to reach
+ * through `as unknown as { show: boolean }` etc. That cast is repeated
+ * 15+ times across `src/scene/*`.
+ *
+ * Concentrating the cast here means individual layer files read as
+ * plain function calls, and the day Cesium's types grow these members
+ * (or we switch to module augmentation) we flip this one file instead
+ * of 11.
+ */
+
+type ShowTarget = { show: boolean };
+type LengthTarget = { length: unknown };
+type IndexedCollection<T> = { get(i: number): T };
+
+export function setCollectionVisible(collection: unknown, visible: boolean): void {
+  (collection as ShowTarget).show = visible;
+}
+
+export function collectionLength(collection: unknown): number {
+  const raw = (collection as LengthTarget).length;
+  return typeof raw === "number" ? raw : 0;
+}
+
+export function collectionAt<T>(collection: unknown, index: number): T {
+  return (collection as IndexedCollection<T>).get(index);
+}

--- a/src/scene/constellations.ts
+++ b/src/scene/constellations.ts
@@ -10,6 +10,7 @@ import {
 } from "cesium";
 import type { Scene } from "cesium";
 import type { VisibleConstellation } from "../astro";
+import { setCollectionVisible } from "./cesium-collections";
 import { altAzToCartesian } from "./stars";
 
 export type ConstellationNameOverrides = Readonly<Record<string, string>> | null;
@@ -80,8 +81,8 @@ export function createConstellationLayer(scene: Scene): ConstellationLayer {
   }
 
   function setVisible(visible: boolean): void {
-    (polylines as unknown as { show: boolean }).show = visible;
-    (labels as unknown as { show: boolean }).show = visible;
+    setCollectionVisible(polylines, visible);
+    setCollectionVisible(labels, visible);
   }
 
   function setOpacity(opacity: number): void {

--- a/src/scene/ecliptic.ts
+++ b/src/scene/ecliptic.ts
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 import { PolylineCollection, Color, Material } from "cesium";
 import type { Scene } from "cesium";
+import { setCollectionVisible } from "./cesium-collections";
 import type { HorizontalCoord } from "../astro/coords";
 import { altAzToCartesian } from "./stars";
 
@@ -39,7 +40,7 @@ export function createEclipticLayer(scene: Scene): EclipticLayer {
   function setOpacity(opacity: number): void {
     currentOpacity = opacity;
     const show = opacity > 0;
-    (polylines as unknown as { show: boolean }).show = show;
+    setCollectionVisible(polylines, show);
     for (const pl of addedPolylines) {
       if (pl?.material?.uniforms?.color !== undefined) {
         pl.material.uniforms.color.alpha = opacity;

--- a/src/scene/grid.ts
+++ b/src/scene/grid.ts
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 import { PolylineCollection, Color, Material } from "cesium";
 import type { Scene } from "cesium";
+import { setCollectionVisible } from "./cesium-collections";
 import type { GridData } from "../astro/grid";
 import { altAzToCartesian } from "./stars";
 
@@ -40,7 +41,7 @@ export function createGridLayer(scene: Scene): GridLayer {
   function setOpacity(opacity: number): void {
     currentOpacity = opacity;
     const show = opacity > 0;
-    (polylines as unknown as { show: boolean }).show = show;
+    setCollectionVisible(polylines, show);
     for (const pl of addedPolylines) {
       if (pl?.material?.uniforms?.color !== undefined) {
         pl.material.uniforms.color.alpha = opacity;

--- a/src/scene/messier.ts
+++ b/src/scene/messier.ts
@@ -2,6 +2,7 @@
 import { BillboardCollection, Color, HorizontalOrigin, VerticalOrigin } from "cesium";
 import type { Scene } from "cesium";
 import type { VisibleMessier } from "../astro/messier";
+import { collectionAt, collectionLength, setCollectionVisible } from "./cesium-collections";
 import { altAzToCartesian } from "./stars";
 
 export type MessierLayer = {
@@ -184,16 +185,14 @@ export function createMessierLayer(scene: Scene): MessierLayer {
   }
 
   function setVisible(visible: boolean): void {
-    (billboards as unknown as { show: boolean }).show = visible;
+    setCollectionVisible(billboards, visible);
   }
 
   function setOpacity(opacity: number): void {
     // Billboard alpha is set per-billboard at add time; update all existing billboards
-    const count = (billboards as unknown as { length: number }).length ?? 0;
+    const count = collectionLength(billboards);
     for (let i = 0; i < count; i++) {
-      const bb = (
-        billboards as unknown as { get: (i: number) => { color: { alpha: number } } }
-      ).get(i);
+      const bb = collectionAt<{ color: { alpha: number } }>(billboards, i);
       if (bb?.color !== undefined) {
         bb.color.alpha = opacity;
       }

--- a/src/scene/satellites.ts
+++ b/src/scene/satellites.ts
@@ -9,6 +9,7 @@ import {
 } from "cesium";
 import type { Scene } from "cesium";
 import type { VisibleSatellite } from "../sat";
+import { setCollectionVisible } from "./cesium-collections";
 import { altAzToCartesian } from "./stars";
 
 const SAT_COLOR = "#00FF88";
@@ -84,8 +85,8 @@ export function createSatelliteLayer(scene: Scene): SatelliteLayer {
   }
 
   function setVisible(visible: boolean): void {
-    (billboards as unknown as { show: boolean }).show = visible;
-    (polylines as unknown as { show: boolean }).show = visible;
+    setCollectionVisible(billboards, visible);
+    setCollectionVisible(polylines, visible);
   }
 
   function setOpacity(opacity: number): void {

--- a/src/scene/stars.ts
+++ b/src/scene/stars.ts
@@ -12,6 +12,7 @@ import {
 import type { Scene } from "cesium";
 import type { AltAzStar } from "../astro";
 import { bvToRgb } from "../astro/star-color";
+import { setCollectionVisible } from "./cesium-collections";
 
 const SKY_RADIUS = 1e5;
 
@@ -86,7 +87,7 @@ export function createStarLayer(scene: Scene): StarLayer {
   }
 
   function setVisible(visible: boolean): void {
-    (billboards as unknown as { show: boolean }).show = visible;
+    setCollectionVisible(billboards, visible);
   }
 
   return { update, setVisible };

--- a/src/scene/trail-layer.ts
+++ b/src/scene/trail-layer.ts
@@ -2,6 +2,7 @@
 import { PolylineCollection, Color, Material } from "cesium";
 import type { Scene } from "cesium";
 import type { HorizontalCoord } from "../astro/coords";
+import { setCollectionVisible } from "./cesium-collections";
 import { altAzToCartesian } from "./stars";
 
 export type TrailLayer = {
@@ -37,15 +38,15 @@ export function createTrailLayer(scene: Scene): TrailLayer {
         dashLength: 16,
       }),
     });
-    (polylines as unknown as { show: boolean }).show = true;
+    setCollectionVisible(polylines, true);
   }
 
   function show(): void {
-    (polylines as unknown as { show: boolean }).show = true;
+    setCollectionVisible(polylines, true);
   }
 
   function hide(): void {
-    (polylines as unknown as { show: boolean }).show = false;
+    setCollectionVisible(polylines, false);
   }
 
   return { setPoints, show, hide };


### PR DESCRIPTION
## Summary

Closes #252.

Cesium's `BillboardCollection` / `PolylineCollection` / `LabelCollection` expose `.show`, `.length`, and `.get(i)` at runtime, but their bundled type definitions don't surface those members. 15 callers across 9 scene layers were reaching through `as unknown as { show: boolean }` or similar — same cast copy-pasted everywhere.

New `src/scene/cesium-collections.ts` with three thin typed helpers:

```ts
setCollectionVisible(coll, visible)
collectionLength(coll): number
collectionAt<T>(coll, index): T
```

Concentrates the cast in one place. Layer files now read as plain function calls. If Cesium ever grows the missing type members (or we switch to module-augmentation), this becomes a one-file flip instead of 9.

## Migrated

- `src/scene/{bodies,boundaries,constellations,ecliptic,grid,messier,satellites,stars,trail-layer}.ts` — 15 cast sites replaced; one `setCollectionVisible` / `collectionLength` / `collectionAt` import per file.
- Camera's `camera as unknown as { heading?, pitch? }` cast left alone — different shape, single site, not the same pattern.

## TDD

4 new tests in `src/scene/cesium-collections.test.ts`:
- `setCollectionVisible` flips `.show`.
- `collectionLength` reads `.length` + falls back to 0 when missing / non-numeric.
- `collectionAt<T>` passes the typed shape through `.get(i)`.

## Test plan

- [x] `pnpm typecheck && pnpm lint && pnpm format:check && pnpm test:cov && pnpm build` green locally
- [x] 1221 SPA tests (+4), 89 worker tests unchanged

https://claude.ai/code/session_014DzXBVSCw5T2nnQvQjJtzS