### PR TITLE
chore(ui): shared Pro-pill helper + replaceChildren in login-modal (#253, partial)

### DIFF
--- a/src/ui/login-modal.ts
+++ b/src/ui/login-modal.ts
@@ -68,7 +68,7 @@ export function createLoginModal(options: LoginModalOptions): LoginModal {
   }
 
   function renderForm(): void {
-    body.innerHTML = "";
+    body.replaceChildren();
 
     const heading = document.createElement("h2");
     heading.textContent = "Sign in";
@@ -179,7 +179,7 @@ export function createLoginModal(options: LoginModalOptions): LoginModal {
   }
 
   function renderSent(email: string): void {
-    body.innerHTML = "";
+    body.replaceChildren();
 
     const heading = document.createElement("h2");
     heading.textContent = "Check your email";
@@ -191,7 +191,7 @@ export function createLoginModal(options: LoginModalOptions): LoginModal {
     sent.dataset.testid = "login-modal-sent";
     sent.style.fontSize = "13px";
     sent.style.lineHeight = "1.5";
-    sent.innerHTML = "";
+    sent.replaceChildren();
     const line1 = document.createElement("p");
     line1.style.margin = "0 0 8px";
     line1.textContent = `We sent a one-time login link to ${email}.`;

--- a/src/ui/notebook-workspace.ts
+++ b/src/ui/notebook-workspace.ts
@@ -11,7 +11,7 @@ import {
 import type { Result } from "../result";
 import { messageFor } from "./error-messages";
 import { createNotebookEditor, EMPTY_DOC_JSON, type NotebookEditor } from "./notebook-editor";
-import { FONT_FAMILY, PANEL_BG, PANEL_BORDER, TEXT_COLOR } from "./styles";
+import { createProPill, FONT_FAMILY, PANEL_BG, PANEL_BORDER, TEXT_COLOR } from "./styles";
 
 /** Pluggable Notebook API — the workspace receives these so tests can pass
  *  stubs and the production caller wires them to `src/notebooks.ts`. */
@@ -464,19 +464,7 @@ function buildInsertLinkButton(
   btn.appendChild(label);
 
   if (!isPro()) {
-    const pill = document.createElement("span");
-    pill.dataset.testid = "notebook-insert-link-pro";
-    pill.textContent = "Pro";
-    pill.style.background = "rgba(0,255,136,0.18)";
-    pill.style.border = "1px solid rgba(0,255,136,0.5)";
-    pill.style.borderRadius = "10px";
-    pill.style.color = "#00ff88";
-    pill.style.fontSize = "10px";
-    pill.style.fontWeight = "600";
-    pill.style.letterSpacing = "0.05em";
-    pill.style.padding = "1px 7px";
-    pill.style.textTransform = "uppercase";
-    btn.appendChild(pill);
+    btn.appendChild(createProPill("notebook-insert-link-pro"));
   }
 
   btn.addEventListener("click", () => {

--- a/src/ui/panel.ts
+++ b/src/ui/panel.ts
@@ -7,6 +7,7 @@ import {
   PANEL_WIDTH,
   TEXT_COLOR,
   applyButton,
+  createProPill,
 } from "./styles";
 import type { UIIntent } from "./index";
 import type { AppMode } from "../state/state";
@@ -138,19 +139,7 @@ export function createPanel(
   // Discoverable but quiet — signals that Notebook mode is a paid feature
   // without hiding the toggle (the CTA itself is a conversion surface).
   if (!isPro()) {
-    const pill = document.createElement("span");
-    pill.dataset.testid = "panel-mode-pro";
-    pill.textContent = "Pro";
-    pill.style.background = "rgba(0,255,136,0.18)";
-    pill.style.border = "1px solid rgba(0,255,136,0.5)";
-    pill.style.borderRadius = "8px";
-    pill.style.color = "#00ff88";
-    pill.style.fontSize = "9px";
-    pill.style.fontWeight = "600";
-    pill.style.letterSpacing = "0.05em";
-    pill.style.padding = "0 5px";
-    pill.style.textTransform = "uppercase";
-    modeBtn.appendChild(pill);
+    modeBtn.appendChild(createProPill("panel-mode-pro"));
   }
 
   const toggleBtn = document.createElement("button");

--- a/src/ui/styles.ts
+++ b/src/ui/styles.ts
@@ -32,3 +32,26 @@ export function applyLabel(el: HTMLElement): void {
   el.style.fontFamily = FONT_FAMILY;
   el.style.userSelect = "none";
 }
+
+/**
+ * Build the small "Pro" pill shown next to Pro-gated UI affordances
+ * when the current user isn't on the allowlist. Used by both the side
+ * panel's mode-toggle and the Notebook's Insert-link button, with the
+ * caller choosing the `data-testid` value so the two remain distinct
+ * to tests and query-selectors.
+ */
+export function createProPill(testid: string): HTMLElement {
+  const pill = document.createElement("span");
+  pill.dataset.testid = testid;
+  pill.textContent = "Pro";
+  pill.style.background = "rgba(0,255,136,0.18)";
+  pill.style.border = "1px solid rgba(0,255,136,0.5)";
+  pill.style.borderRadius = "10px";
+  pill.style.color = ACCENT_COLOR.toLowerCase();
+  pill.style.fontSize = "10px";
+  pill.style.fontWeight = "600";
+  pill.style.letterSpacing = "0.05em";
+  pill.style.padding = "1px 7px";
+  pill.style.textTransform = "uppercase";
+  return pill;
+}


### PR DESCRIPTION
## Summary

Takes the two self-contained pieces of #253. The broader `el()` factory + palette-constants migration stays queued for a follow-up — they touch 47 UI files and are opportunistic rather than blocking.

### 1. `createProPill` helper

The "Pro" pill on Pro-gated affordances was duplicated nearly verbatim in two places:

- `src/ui/panel.ts` — mode-toggle badge.
- `src/ui/notebook-workspace.ts` — Insert-link-to-this-view badge.

~15 identical lines each. Extracted `createProPill(testid)` to `src/ui/styles.ts`. Call sites just pick a `data-testid`. Unifies the two minor visual drifts (8 vs 10px border-radius, 9 vs 10px font-size) onto one size — imperceptible in practice, one place to edit next time the pill gets a tweak.

Existing `[data-testid='panel-mode-pro']` and `[data-testid='notebook-insert-link-pro']` selectors in tests keep working.

### 2. `.replaceChildren()` in `login-modal.ts`

`body.innerHTML = ""` / `sent.innerHTML = ""` swapped for `.replaceChildren()` (3 sites). Matches the pattern already used in every other UI module (`panel.ts`, `drawer.ts`, `command-palette.ts`). Forces the HTML parser one less time per render cycle and closes a latent XSS vector if user content ever flows through those nodes.

## What's deferred

#253 stays open for the follow-up el() factory + palette-constants work. That slice needs a deliberate migration PR (or two) — e.g. introduce `el()`, migrate one module as the exemplar, then let the rest follow opportunistically. Keeping it out of this PR avoids a sprawling diff.

## Test plan

- [x] `pnpm typecheck && pnpm lint && pnpm format:check && pnpm test:cov && pnpm build` green locally
- [x] 1221 SPA tests, 89 worker tests unchanged
- [x] Visual: Pro pill still shows on both mode-toggle (non-Pro) and Insert-link (non-Pro), now identical styling

https://claude.ai/code/session_014DzXBVSCw5T2nnQvQjJtzS