### PR TITLE
chore(ui): palette constants + Notebook migrations (#253 follow-up)

### DIFF
--- a/src/ui/notebook-editor.ts
+++ b/src/ui/notebook-editor.ts
@@ -2,7 +2,7 @@
 import { Editor, type Content } from "@tiptap/core";
 import StarterKit from "@tiptap/starter-kit";
 import { createNotebookMentionExtension } from "./notebook-mention";
-import { FONT_FAMILY, TEXT_COLOR } from "./styles";
+import { BORDER_SUBTLE, FONT_FAMILY, SURFACE_LOW, TEXT_COLOR } from "./styles";
 
 /**
  * Thin wrapper around a tiptap `Editor` that exposes only the surface the
@@ -57,8 +57,8 @@ export function createNotebookEditor(options: NotebookEditorOptions): NotebookEd
   host.dataset.testid = "notebook-editor";
   host.style.flex = "1 1 auto";
   host.style.minHeight = "200px";
-  host.style.background = "rgba(255,255,255,0.06)";
-  host.style.border = "1px solid rgba(255,255,255,0.18)";
+  host.style.background = SURFACE_LOW;
+  host.style.border = BORDER_SUBTLE;
   host.style.borderRadius = "6px";
   host.style.color = TEXT_COLOR;
   host.style.fontFamily = FONT_FAMILY;

--- a/src/ui/notebook-mention-popover.ts
+++ b/src/ui/notebook-mention-popover.ts
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 import type { EntityRecord } from "../astro/entities";
 import { resolveEntityLabel, type EntityKind } from "../astro/entities";
-import { FONT_FAMILY, PANEL_BG, PANEL_BORDER, TEXT_COLOR } from "./styles";
+import { FONT_FAMILY, PANEL_BG, PANEL_BORDER, TEXT_COLOR, TEXT_MUTED } from "./styles";
 
 /**
  * Suggestion popover for the Notebook's @-mention feature (ADR 013).
@@ -61,7 +61,7 @@ export function createMentionPopover(options: MentionPopoverOptions): MentionPop
       empty.dataset.testid = "notebook-mention-empty";
       empty.textContent = "No matches";
       empty.style.padding = "8px 10px";
-      empty.style.color = "rgba(255,255,255,0.55)";
+      empty.style.color = TEXT_MUTED;
       root.appendChild(empty);
       return;
     }
@@ -96,7 +96,7 @@ export function createMentionPopover(options: MentionPopoverOptions): MentionPop
       kindPill.style.fontSize = "10px";
       kindPill.style.textTransform = "uppercase";
       kindPill.style.letterSpacing = "0.05em";
-      kindPill.style.color = "rgba(255,255,255,0.55)";
+      kindPill.style.color = TEXT_MUTED;
       row.appendChild(kindPill);
 
       row.addEventListener("mousedown", (ev) => {

--- a/src/ui/notebook-workspace.ts
+++ b/src/ui/notebook-workspace.ts
@@ -11,7 +11,18 @@ import {
 import type { Result } from "../result";
 import { messageFor } from "./error-messages";
 import { createNotebookEditor, EMPTY_DOC_JSON, type NotebookEditor } from "./notebook-editor";
-import { createProPill, FONT_FAMILY, PANEL_BG, PANEL_BORDER, TEXT_COLOR } from "./styles";
+import {
+  BORDER_SUBTLE,
+  createProPill,
+  FONT_FAMILY,
+  PANEL_BG,
+  PANEL_BORDER,
+  SURFACE,
+  SURFACE_ACTIVE,
+  SURFACE_LOW,
+  TEXT_COLOR,
+  TEXT_MUTED,
+} from "./styles";
 
 /** Pluggable Notebook API — the workspace receives these so tests can pass
  *  stubs and the production caller wires them to `src/notebooks.ts`. */
@@ -92,8 +103,8 @@ export function createNotebookWorkspace(options: NotebookWorkspaceOptions = {}):
   titleInput.dataset.testid = "notebook-title";
   titleInput.placeholder = "Untitled notebook";
   titleInput.style.flex = "1 1 auto";
-  titleInput.style.background = "rgba(255,255,255,0.06)";
-  titleInput.style.border = "1px solid rgba(255,255,255,0.18)";
+  titleInput.style.background = SURFACE_LOW;
+  titleInput.style.border = BORDER_SUBTLE;
   titleInput.style.borderRadius = "4px";
   titleInput.style.color = TEXT_COLOR;
   titleInput.style.fontFamily = FONT_FAMILY;
@@ -128,7 +139,7 @@ export function createNotebookWorkspace(options: NotebookWorkspaceOptions = {}):
   const statusLine = document.createElement("div");
   statusLine.dataset.testid = "notebook-status";
   statusLine.style.fontSize = "11px";
-  statusLine.style.color = "rgba(255,255,255,0.55)";
+  statusLine.style.color = TEXT_MUTED;
   statusLine.style.minHeight = "14px";
   root.appendChild(statusLine);
 
@@ -177,9 +188,8 @@ export function createNotebookWorkspace(options: NotebookWorkspaceOptions = {}):
       tab.dataset.notebookId = String(s.id);
       tab.dataset.active = s.id === currentId ? "true" : "false";
       tab.textContent = s.title;
-      tab.style.background =
-        s.id === currentId ? "rgba(255,255,255,0.18)" : "rgba(255,255,255,0.06)";
-      tab.style.border = "1px solid rgba(255,255,255,0.2)";
+      tab.style.background = s.id === currentId ? SURFACE_ACTIVE : SURFACE_LOW;
+      tab.style.border = PANEL_BORDER;
       tab.style.borderRadius = "999px";
       tab.style.color = TEXT_COLOR;
       tab.style.cursor = "pointer";
@@ -428,8 +438,8 @@ function applyShellStyles(root: HTMLElement): void {
 }
 
 function styleActionButton(btn: HTMLButtonElement): void {
-  btn.style.background = "rgba(255,255,255,0.08)";
-  btn.style.border = "1px solid rgba(255,255,255,0.2)";
+  btn.style.background = SURFACE;
+  btn.style.border = PANEL_BORDER;
   btn.style.borderRadius = "4px";
   btn.style.color = TEXT_COLOR;
   btn.style.cursor = "pointer";
@@ -446,8 +456,8 @@ function buildInsertLinkButton(
   const btn = document.createElement("button");
   btn.type = "button";
   btn.dataset.testid = "notebook-insert-link";
-  btn.style.background = "rgba(255,255,255,0.08)";
-  btn.style.border = "1px solid rgba(255,255,255,0.2)";
+  btn.style.background = SURFACE;
+  btn.style.border = PANEL_BORDER;
   btn.style.borderRadius = "4px";
   btn.style.color = TEXT_COLOR;
   btn.style.cursor = "pointer";

--- a/src/ui/styles.ts
+++ b/src/ui/styles.ts
@@ -10,6 +10,15 @@ export const FONT_SIZE = "13px";
 export const FONT_FAMILY = "sans-serif";
 export const GAP = "8px";
 
+/** Translucent "raised surface" backgrounds used for buttons, tabs, inputs. */
+export const SURFACE_LOW = "rgba(255, 255, 255, 0.06)";
+export const SURFACE = "rgba(255, 255, 255, 0.08)";
+export const SURFACE_ACTIVE = "rgba(255, 255, 255, 0.18)";
+/** Thin border that pairs with SURFACE / SURFACE_LOW. */
+export const BORDER_SUBTLE = "1px solid rgba(255, 255, 255, 0.18)";
+/** Muted caption-text colour for labels and secondary information. */
+export const TEXT_MUTED = "rgba(255, 255, 255, 0.55)";
+
 export function applyBaseText(el: HTMLElement): void {
   el.style.color = TEXT_COLOR;
   el.style.fontSize = FONT_SIZE;


### PR DESCRIPTION
## Summary

Second pass on #253. Adds the palette constants the audit called for, and migrates the Notebook-family files that had the most repeated literals so the new constants aren't dead code.

### New in `src/ui/styles.ts`

- `SURFACE_LOW` (`rgba(255,255,255,0.06)`) — translucent raised background.
- `SURFACE` (`rgba(255,255,255,0.08)`) — slightly brighter surface.
- `SURFACE_ACTIVE` (`rgba(255,255,255,0.18)`) — highlighted state.
- `BORDER_SUBTLE` (`1px solid rgba(255,255,255,0.18)`) — matching thin border.
- `TEXT_MUTED` (`rgba(255,255,255,0.55)`) — muted caption-text colour.

### Migrated

- `src/ui/notebook-workspace.ts` — 5 literals → constants (title input, status line, tab active / idle, action-button background + border).
- `src/ui/notebook-editor.ts` — editor host background + border.
- `src/ui/notebook-mention-popover.ts` — empty-state + kind-pill muted text.

### Not migrated in this PR

Same constants, more files to touch: `login-modal`, `bottom-hud`, `events-panel`, `command-palette`, `search`, `object-card`, `planet-info`, `onboarding-overlay`, `location-picker-overlay`, `help-modal`. Each becomes a one-line diff opportunistically next time the file is touched. #253 stays open for the `el()` factory piece plus these remaining palette migrations.

## Test plan

- [x] `pnpm typecheck && pnpm lint && pnpm format:check && pnpm test:cov && pnpm build` green locally
- [x] 1221 SPA tests, 89 worker tests unchanged
- [x] Visual: Notebook surfaces look unchanged (same hex values, just named)

https://claude.ai/code/session_014DzXBVSCw5T2nnQvQjJtzS