### PR TITLE
chore(ui): el() factory + exemplar migration (#253)

### DIFF
--- a/src/ui/dom.test.ts
+++ b/src/ui/dom.test.ts
@@ -1,0 +1,94 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { el } from "./dom";
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("el()", () => {
+  it("creates a plain element of the given tag", () => {
+    const div = el("div");
+    expect(div).toBeInstanceOf(HTMLDivElement);
+    expect(div.tagName).toBe("DIV");
+  });
+
+  it("sets dataset.testid via the `testid` shortcut", () => {
+    const el1 = el("span", { testid: "hello" });
+    expect(el1.dataset.testid).toBe("hello");
+  });
+
+  it("sets textContent via `text`", () => {
+    const p = el("p", { text: "hi" });
+    expect(p.textContent).toBe("hi");
+  });
+
+  it("merges style via Object.assign on node.style", () => {
+    const div = el("div", { style: { color: "red", padding: "4px" } });
+    expect(div.style.color).toBe("red");
+    expect(div.style.padding).toBe("4px");
+  });
+
+  it("sets id + className", () => {
+    const div = el("div", { id: "foo", className: "bar baz" });
+    expect(div.id).toBe("foo");
+    expect(div.className).toBe("bar baz");
+  });
+
+  it("sets `type` on button + input elements", () => {
+    const btn = el("button", { type: "submit" });
+    expect(btn.type).toBe("submit");
+    const input = el("input", { type: "email" });
+    expect(input.type).toBe("email");
+  });
+
+  it("falls back to setAttribute for `type` on other elements", () => {
+    const div = el("div", { type: "application/json" });
+    expect(div.getAttribute("type")).toBe("application/json");
+  });
+
+  it("sets placeholder on input", () => {
+    const input = el("input", { placeholder: "you@example.com" });
+    expect(input.placeholder).toBe("you@example.com");
+  });
+
+  it("sets href on anchor", () => {
+    const a = el("a", { href: "https://example.com" });
+    expect(a.href).toBe("https://example.com/");
+  });
+
+  it("applies extra dataset entries", () => {
+    const div = el("div", { dataset: { foo: "1", bar: "two" } });
+    expect(div.dataset.foo).toBe("1");
+    expect(div.dataset.bar).toBe("two");
+  });
+
+  it("applies arbitrary attributes via `attrs`", () => {
+    const div = el("div", { attrs: { role: "button", "aria-label": "x" } });
+    expect(div.getAttribute("role")).toBe("button");
+    expect(div.getAttribute("aria-label")).toBe("x");
+  });
+
+  it("attaches event handlers via `on`", () => {
+    const handler = vi.fn();
+    const btn = el("button", { on: { click: handler } });
+    btn.click();
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it("appends provided children (nodes + strings) and skips null/false/undefined", () => {
+    const heading = el("h2", { text: "Title" });
+    const root = el("section", {
+      children: [heading, " — ", null, false, undefined, "footer"],
+    });
+    expect(root.children.length).toBe(1);
+    expect(root.childNodes.length).toBe(3);
+    expect(root.textContent).toBe("Title — footer");
+  });
+
+  it("innerHTML via `html` is opt-in for callers that need it", () => {
+    const div = el("div", { html: "<b>bold</b>" });
+    expect(div.innerHTML).toBe("<b>bold</b>");
+    expect(div.querySelector("b")).not.toBeNull();
+  });
+});

--- a/src/ui/dom.ts
+++ b/src/ui/dom.ts
@@ -1,0 +1,105 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/**
+ * Tiny DOM factory that collapses the `createElement` + `.style.*` +
+ * `dataset.testid` + `.appendChild(child)` + `.addEventListener(...)` incantation
+ * that dominates `src/ui/*.ts`. The idea is ergonomics, not a framework — every
+ * returned node is still a plain HTMLElement and every DOM API on it keeps
+ * working. Use the factory when it reads cleaner than hand-rolled DOM; reach
+ * for `document.createElement` directly when you need something the factory
+ * can't express.
+ *
+ * Typical call:
+ *
+ *   const btn = el("button", {
+ *     type: "button",
+ *     text: "+ New",
+ *     testid: "notebook-new",
+ *     style: { padding: "6px 10px", fontSize: "12px" },
+ *     on: { click: () => createFresh() },
+ *   });
+ */
+
+type EventHandlers = {
+  [K in keyof HTMLElementEventMap]?: (event: HTMLElementEventMap[K]) => void;
+};
+
+type ElOptions = {
+  readonly testid?: string;
+  readonly text?: string;
+  readonly html?: string;
+  readonly id?: string;
+  readonly className?: string;
+  readonly type?: string;
+  readonly placeholder?: string;
+  readonly href?: string;
+  readonly style?: Partial<CSSStyleDeclaration>;
+  readonly dataset?: Record<string, string>;
+  readonly attrs?: Record<string, string>;
+  readonly on?: EventHandlers;
+  readonly children?: readonly (Node | string | null | undefined | false)[];
+};
+
+export function el<K extends keyof HTMLElementTagNameMap>(
+  tag: K,
+  opts: ElOptions = {},
+): HTMLElementTagNameMap[K] {
+  const node = document.createElement(tag);
+
+  if (opts.testid !== undefined) node.dataset["testid"] = opts.testid;
+  if (opts.id !== undefined) node.id = opts.id;
+  if (opts.className !== undefined) node.className = opts.className;
+
+  // Tag-specific conveniences — narrow via instanceof so TS is happy.
+  if (opts.type !== undefined) {
+    if (node instanceof HTMLButtonElement || node instanceof HTMLInputElement) {
+      node.type = opts.type;
+    } else {
+      node.setAttribute("type", opts.type);
+    }
+  }
+  if (opts.placeholder !== undefined && node instanceof HTMLInputElement) {
+    node.placeholder = opts.placeholder;
+  }
+  if (opts.href !== undefined && node instanceof HTMLAnchorElement) {
+    node.href = opts.href;
+  }
+
+  if (opts.text !== undefined) node.textContent = opts.text;
+  // Explicit opt-in for raw HTML — callers should almost always prefer `text`
+  // or `children`. Live XSS footgun; flagged so review catches it.
+  if (opts.html !== undefined) node.innerHTML = opts.html;
+
+  if (opts.style !== undefined) {
+    Object.assign(node.style, opts.style);
+  }
+
+  if (opts.dataset !== undefined) {
+    for (const [k, v] of Object.entries(opts.dataset)) {
+      node.dataset[k] = v;
+    }
+  }
+
+  if (opts.attrs !== undefined) {
+    for (const [k, v] of Object.entries(opts.attrs)) {
+      node.setAttribute(k, v);
+    }
+  }
+
+  if (opts.on !== undefined) {
+    for (const [event, handler] of Object.entries(opts.on)) {
+      if (handler !== undefined) {
+        node.addEventListener(event, handler as EventListener);
+      }
+    }
+  }
+
+  if (opts.children !== undefined) {
+    for (const child of opts.children) {
+      if (child === null || child === undefined || child === false) continue;
+      node.append(child);
+    }
+  }
+
+  return node;
+}

--- a/src/ui/notebook-mention-popover.ts
+++ b/src/ui/notebook-mention-popover.ts
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 import type { EntityRecord } from "../astro/entities";
 import { resolveEntityLabel, type EntityKind } from "../astro/entities";
+import { el } from "./dom";
 import { FONT_FAMILY, PANEL_BG, PANEL_BORDER, TEXT_COLOR, TEXT_MUTED } from "./styles";
 
 /**
@@ -33,20 +34,23 @@ export function createMentionPopover(options: MentionPopoverOptions): MentionPop
   let selectedIndex = 0;
   let clientRect: (() => DOMRect | null) | null = options.clientRect;
 
-  const root = document.createElement("div");
-  root.dataset.testid = "notebook-mention-popover";
-  root.style.position = "fixed";
-  root.style.background = PANEL_BG;
-  root.style.border = PANEL_BORDER;
-  root.style.borderRadius = "6px";
-  root.style.color = TEXT_COLOR;
-  root.style.fontFamily = FONT_FAMILY;
-  root.style.fontSize = "13px";
-  root.style.padding = "4px";
-  root.style.minWidth = "200px";
-  root.style.maxWidth = "320px";
-  root.style.boxShadow = "0 6px 20px rgba(0,0,0,0.5)";
-  root.style.zIndex = "1400";
+  const root = el("div", {
+    testid: "notebook-mention-popover",
+    style: {
+      position: "fixed",
+      background: PANEL_BG,
+      border: PANEL_BORDER,
+      borderRadius: "6px",
+      color: TEXT_COLOR,
+      fontFamily: FONT_FAMILY,
+      fontSize: "13px",
+      padding: "4px",
+      minWidth: "200px",
+      maxWidth: "320px",
+      boxShadow: "0 6px 20px rgba(0,0,0,0.5)",
+      zIndex: "1400",
+    },
+  });
   document.body.appendChild(root);
 
   function commit(idx: number): void {
@@ -57,54 +61,57 @@ export function createMentionPopover(options: MentionPopoverOptions): MentionPop
   function render(): void {
     root.textContent = "";
     if (items.length === 0) {
-      const empty = document.createElement("div");
-      empty.dataset.testid = "notebook-mention-empty";
-      empty.textContent = "No matches";
-      empty.style.padding = "8px 10px";
-      empty.style.color = TEXT_MUTED;
-      root.appendChild(empty);
+      root.appendChild(
+        el("div", {
+          testid: "notebook-mention-empty",
+          text: "No matches",
+          style: { padding: "8px 10px", color: TEXT_MUTED },
+        }),
+      );
       return;
     }
     items.forEach((item, idx) => {
-      const row = document.createElement("button");
-      row.type = "button";
-      row.dataset.testid = "notebook-mention-item";
-      row.dataset.index = String(idx);
-      row.dataset.kind = item.kind;
-      row.dataset.entityId = item.id;
-      row.style.display = "flex";
-      row.style.justifyContent = "space-between";
-      row.style.alignItems = "center";
-      row.style.gap = "10px";
-      row.style.width = "100%";
-      row.style.textAlign = "left";
-      row.style.border = "none";
-      row.style.background = idx === selectedIndex ? "rgba(255,255,255,0.12)" : "transparent";
-      row.style.color = TEXT_COLOR;
-      row.style.fontFamily = FONT_FAMILY;
-      row.style.fontSize = "13px";
-      row.style.padding = "6px 10px";
-      row.style.borderRadius = "4px";
-      row.style.cursor = "pointer";
-
-      const label = document.createElement("span");
-      label.textContent = item.label;
-      row.appendChild(label);
-
-      const kindPill = document.createElement("span");
-      kindPill.textContent = item.kind;
-      kindPill.style.fontSize = "10px";
-      kindPill.style.textTransform = "uppercase";
-      kindPill.style.letterSpacing = "0.05em";
-      kindPill.style.color = TEXT_MUTED;
-      row.appendChild(kindPill);
-
-      row.addEventListener("mousedown", (ev) => {
-        // mousedown, not click — click fires after the editor loses
-        // focus, which tears down the suggestion plugin before the
-        // handler runs.
-        ev.preventDefault();
-        commit(idx);
+      const row = el("button", {
+        type: "button",
+        testid: "notebook-mention-item",
+        dataset: { index: String(idx), kind: item.kind, entityId: item.id },
+        style: {
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          gap: "10px",
+          width: "100%",
+          textAlign: "left",
+          border: "none",
+          background: idx === selectedIndex ? "rgba(255,255,255,0.12)" : "transparent",
+          color: TEXT_COLOR,
+          fontFamily: FONT_FAMILY,
+          fontSize: "13px",
+          padding: "6px 10px",
+          borderRadius: "4px",
+          cursor: "pointer",
+        },
+        on: {
+          // mousedown, not click — click fires after the editor loses
+          // focus, which tears down the suggestion plugin before the
+          // handler runs.
+          mousedown: (ev: MouseEvent) => {
+            ev.preventDefault();
+            commit(idx);
+          },
+        },
+        children: [
+          el("span", { text: item.label }),
+          el("span", {
+            text: item.kind,
+            style: {
+              fontSize: "10px",
+              textTransform: "uppercase",
+              letterSpacing: "0.05em",
+              color: TEXT_MUTED,
+            },
+          }),
+        ],
       });
       root.appendChild(row);
     });


### PR DESCRIPTION
## Summary

Third pass on #253. Adds the `el()` factory the audit called for and migrates one module as the reference shape.

## New `src/ui/dom.ts`

```ts
el("button", {
  type: "button",
  testid: "notebook-new",
  text: "+ New",
  style: { padding: "6px 10px", fontSize: "12px" },
  on: { click: () => createFresh() },
  children: [icon, label],
});
```

Covers the ~80% of `document.createElement` call sites in the UI layer: tag, text content, testid + arbitrary dataset, arbitrary attributes, inline styles, typed event handlers (`HTMLElementEventMap`), and a children list that tolerates `null | false | undefined | string | Node` for conditional children. Callers that need something outside that vocabulary keep using `document.createElement` directly — not a framework, just ergonomics.

## Exemplar migration — `notebook-mention-popover.ts`

Went from ~44 hand-rolled DOM lines (popover root + empty-state + per-row button + label + kind-pill) to ~50 `el()` calls that read as one tree. Behaviour unchanged — all 11 existing popover tests pass without modification.

## Follow-up work

Factory is ready; the remaining modules migrate opportunistically next time they're touched. #253 stays open for:

- **Palette-constant migrations** in `login-modal`, `bottom-hud`, `events-panel`, `command-palette`, `search`, `object-card`, `planet-info`, `onboarding-overlay`, `location-picker-overlay`, `help-modal`.
- **`el()` migration** of larger modules (`notebook-workspace`, `panel`, `drawer`-family, `settings-drawer`).

## TDD

14 new tests in `src/ui/dom.test.ts` covering every option: tag type, testid, text, html (opt-in XSS surface), id, className, type (button/input-specialised vs fallback attribute), placeholder, href, dataset, attrs, typed event handlers, and the mixed-children list.

## Test plan

- [x] `pnpm typecheck && pnpm lint && pnpm format:check && pnpm test:cov && pnpm build` green locally
- [x] 1235 SPA tests (+14), 89 worker tests unchanged

https://claude.ai/code/session_014DzXBVSCw5T2nnQvQjJtzS