### PR TITLE
chore(ui): palette migrations across 6 more UI modules (#253)

### DIFF
--- a/src/ui/bottom-hud.ts
+++ b/src/ui/bottom-hud.ts
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: Apache-2.0 */
-import { PANEL_BORDER, TEXT_COLOR, FONT_FAMILY } from "./styles";
+import { FONT_FAMILY, PANEL_BORDER, SURFACE, TEXT_COLOR } from "./styles";
 import type { UIIntent } from "./index";
 
 const IDLE_FADE_MS = 2000;
@@ -118,7 +118,7 @@ export function createBottomHud(
   const locationChip = document.createElement("button");
   locationChip.dataset.testid = "hud-location";
   locationChip.type = "button";
-  locationChip.style.background = "rgba(255,255,255,0.08)";
+  locationChip.style.background = SURFACE;
   locationChip.style.border = "1px solid rgba(255,255,255,0.25)";
   locationChip.style.borderRadius = "999px";
   locationChip.style.padding = "6px 12px";
@@ -168,7 +168,7 @@ export function createBottomHud(
   // Right chip — compass
   const compassChip = document.createElement("div");
   compassChip.dataset.testid = "hud-compass";
-  compassChip.style.background = "rgba(255,255,255,0.08)";
+  compassChip.style.background = SURFACE;
   compassChip.style.border = "1px solid rgba(255,255,255,0.25)";
   compassChip.style.borderRadius = "999px";
   compassChip.style.padding = "6px 12px";

--- a/src/ui/events-panel.ts
+++ b/src/ui/events-panel.ts
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: Apache-2.0 */
-import { applyBaseText, GAP, TEXT_COLOR } from "./styles";
+import { applyBaseText, GAP, SURFACE, TEXT_COLOR, TEXT_MUTED } from "./styles";
 import type { CelestialEvent } from "../astro/events";
 import type { UIIntent } from "./index";
 
@@ -138,7 +138,7 @@ export function createEventsPanel(
       gotoBtn.style.padding = "2px 6px";
       gotoBtn.style.fontSize = "11px";
       gotoBtn.style.fontFamily = "sans-serif";
-      gotoBtn.style.background = "rgba(255,255,255,0.08)";
+      gotoBtn.style.background = SURFACE;
       gotoBtn.style.color = TEXT_COLOR;
       gotoBtn.style.border = "1px solid rgba(255,255,255,0.2)";
       gotoBtn.style.borderRadius = "3px";
@@ -168,7 +168,7 @@ export function createEventsPanel(
       const descEl = document.createElement("div");
       descEl.dataset.testid = "event-description";
       descEl.textContent = event.description;
-      descEl.style.color = "rgba(255,255,255,0.55)";
+      descEl.style.color = TEXT_MUTED;
       descEl.style.fontSize = "11px";
       descEl.style.fontFamily = "sans-serif";
       descEl.style.marginTop = "2px";

--- a/src/ui/location-picker-overlay.ts
+++ b/src/ui/location-picker-overlay.ts
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 import citiesJson from "../../data/cities.json";
-import { ACCENT_COLOR, FONT_FAMILY, PANEL_BG, PANEL_BORDER, TEXT_COLOR } from "./styles";
+import { ACCENT_COLOR, FONT_FAMILY, PANEL_BG, PANEL_BORDER, SURFACE, TEXT_COLOR } from "./styles";
 import type { UIIntent } from "./index";
 
 export type LocationPickerOverlay = {
@@ -246,7 +246,7 @@ export function createLocationPickerOverlay(
     pill.type = "button";
     pill.textContent = city.name;
     pill.title = `${city.name}, ${city.country}`;
-    pill.style.background = "rgba(255,255,255,0.08)";
+    pill.style.background = SURFACE;
     pill.style.border = "1px solid rgba(255,255,255,0.25)";
     pill.style.borderRadius = "999px";
     pill.style.color = TEXT_COLOR;

--- a/src/ui/object-card.ts
+++ b/src/ui/object-card.ts
@@ -3,6 +3,7 @@ import type { AltAzStar, CelestialBody, VisibleMessier, VisibleConstellation } f
 import type { VisibleSatellite } from "../sat";
 import type { UIIntent } from "./index";
 import { computeRiseSet } from "../astro/rise-set";
+import { TEXT_MUTED } from "./styles";
 
 export type ObjectCardData =
   | { readonly kind: "star"; readonly star: AltAzStar }
@@ -163,7 +164,7 @@ function appendAttrRow(container: HTMLElement, label: string, value: string): vo
   row.style.marginTop = "2px";
   const l = document.createElement("span");
   l.textContent = label;
-  l.style.color = "rgba(255,255,255,0.55)";
+  l.style.color = TEXT_MUTED;
   const v = document.createElement("span");
   v.textContent = value;
   row.appendChild(l);
@@ -345,7 +346,7 @@ export function createObjectCard(props: ObjectCardProps): ObjectCard {
   subtitleEl.dataset.testid = "object-card-subtitle";
   subtitleEl.textContent = subtitle;
   subtitleEl.style.fontSize = "10px";
-  subtitleEl.style.color = "rgba(255,255,255,0.55)";
+  subtitleEl.style.color = TEXT_MUTED;
   subtitleEl.style.marginTop = "1px";
   headerText.appendChild(subtitleEl);
 

--- a/src/ui/onboarding-overlay.ts
+++ b/src/ui/onboarding-overlay.ts
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: Apache-2.0 */
-import { ACCENT_COLOR, FONT_FAMILY, PANEL_BG, PANEL_BORDER, TEXT_COLOR } from "./styles";
+import { ACCENT_COLOR, FONT_FAMILY, PANEL_BG, PANEL_BORDER, SURFACE, TEXT_COLOR } from "./styles";
 
 export const ONBOARDING_STORAGE_KEY = "planisphere.onboarding.v1";
 
@@ -176,7 +176,7 @@ export function createOnboardingOverlay(opts: OnboardingOverlayOptions): Onboard
   backBtn.dataset.testid = "onboarding-back";
   backBtn.type = "button";
   backBtn.textContent = "Back";
-  backBtn.style.background = "rgba(255,255,255,0.08)";
+  backBtn.style.background = SURFACE;
   backBtn.style.border = "1px solid rgba(255,255,255,0.25)";
   backBtn.style.color = TEXT_COLOR;
   backBtn.style.borderRadius = "6px";

--- a/src/ui/planet-info.ts
+++ b/src/ui/planet-info.ts
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: Apache-2.0 */
-import { applyBaseText, GAP, ACCENT_COLOR, TEXT_COLOR } from "./styles";
+import { ACCENT_COLOR, applyBaseText, GAP, SURFACE, TEXT_COLOR } from "./styles";
 import type { CelestialBody } from "../astro/bodies";
 import { computeRiseSet } from "../astro/rise-set";
 
@@ -166,7 +166,7 @@ export function createPlanetInfo(
       trailBtn.style.padding = "2px 6px";
       trailBtn.style.fontSize = "11px";
       trailBtn.style.fontFamily = "sans-serif";
-      trailBtn.style.background = active ? "rgba(100,160,255,0.25)" : "rgba(255,255,255,0.08)";
+      trailBtn.style.background = active ? "rgba(100,160,255,0.25)" : SURFACE;
       trailBtn.style.color = TEXT_COLOR;
       trailBtn.style.border = "1px solid rgba(255,255,255,0.2)";
       trailBtn.style.borderRadius = "3px";


### PR DESCRIPTION
## Summary

Fifth pass on #253. Mechanical swap of `SURFACE` / `TEXT_MUTED` at every `.style.x = "rgba(255,255,255,0.08)"` / `"…0.55)"` direct-assignment site in the UI modules not yet migrated.

## Migrated

| File | Swap |
|------|------|
| `bottom-hud.ts` | `locationChip` + `compassChip` backgrounds → `SURFACE` |
| `events-panel.ts` | `gotoBtn` background → `SURFACE`; `descEl` color → `TEXT_MUTED` |
| `planet-info.ts` | `trailBtn` inactive background → `SURFACE` |
| `onboarding-overlay.ts` | `backBtn` background → `SURFACE` |
| `location-picker-overlay.ts` | `pill` background → `SURFACE` |
| `object-card.ts` | attribute-label + subtitle colors → `TEXT_MUTED` |

## Skipped

Every site where the colour is inside a `cssText` template literal — `command-palette.ts`, `search.ts`, `help-modal.ts`, parts of `command-palette`. Those want a bigger refactor than a one-line swap; leaving for opportunistic pickup when those modules are next touched.

## Test plan

- [x] `pnpm typecheck && pnpm lint && pnpm format:check && pnpm test:cov && pnpm build` green locally
- [x] 1235 SPA tests, 89 worker tests unchanged
- [x] Visual: same rgba values behind the constants, zero perceptible change

## #253 status

Still open for:
- `cssText`-embedded palette migrations (above).
- Broader `el()` factory adoption (`panel.ts`, `notebook-workspace.ts`, drawer-family, settings-drawer).

https://claude.ai/code/session_014DzXBVSCw5T2nnQvQjJtzS