### PR TITLE
chore(ui): migrate drawer.ts to el() factory (#253)

### DIFF
--- a/src/ui/drawer.ts
+++ b/src/ui/drawer.ts
@@ -1,4 +1,5 @@
 /* SPDX-License-Identifier: Apache-2.0 */
+import { el } from "./dom";
 import { PANEL_BG, PANEL_BORDER, TEXT_COLOR } from "./styles";
 
 export type DrawerSide = "left" | "right";
@@ -40,76 +41,83 @@ export type Drawer = {
 export function createDrawer(options: DrawerOptions): Drawer {
   const { side, width, onClose, initialContent } = options;
 
-  const root = document.createElement("div");
-  root.dataset.testid = "drawer";
-  root.style.display = "none";
-  root.style.position = "fixed";
-  root.style.inset = "0";
-  root.style.zIndex = "2000";
-
-  const backdrop = document.createElement("div");
-  backdrop.dataset.testid = "drawer-backdrop";
-  backdrop.style.position = "absolute";
-  backdrop.style.inset = "0";
-  backdrop.style.background = "rgba(0,0,0,0.5)";
-
-  const panel = document.createElement("div");
-  panel.dataset.testid = "drawer-panel";
-  panel.style.position = "absolute";
-  panel.style.top = "0";
-  panel.style.bottom = "0";
-  panel.style.width = typeof width === "number" ? `${String(width)}px` : width;
-  panel.style.maxWidth = "100vw";
-  panel.style.background = PANEL_BG;
-  panel.style.boxSizing = "border-box";
-  panel.style.display = "flex";
-  panel.style.flexDirection = "column";
-  if (side === "right") {
-    panel.style.right = "0";
-    panel.style.borderLeft = PANEL_BORDER;
-  } else {
-    panel.style.left = "0";
-    panel.style.borderRight = PANEL_BORDER;
-  }
-
-  // Header with close button. Consumers render their own title inside the body.
-  const header = document.createElement("div");
-  header.dataset.testid = "drawer-header";
-  header.style.display = "flex";
-  header.style.justifyContent = "flex-end";
-  header.style.alignItems = "center";
-  header.style.padding = "8px 12px";
-  header.style.borderBottom = "1px solid rgba(255,255,255,0.15)";
-  header.style.flexShrink = "0";
-
-  const closeBtn = document.createElement("button");
-  closeBtn.dataset.testid = "drawer-close";
-  closeBtn.textContent = "×";
-  closeBtn.title = "Close (Esc)";
-  closeBtn.style.background = "rgba(255,255,255,0.1)";
-  closeBtn.style.border = "1px solid rgba(255,255,255,0.3)";
-  closeBtn.style.borderRadius = "4px";
-  closeBtn.style.color = TEXT_COLOR;
-  closeBtn.style.cursor = "pointer";
-  closeBtn.style.fontSize = "18px";
-  closeBtn.style.lineHeight = "1";
-  closeBtn.style.padding = "2px 10px";
-  header.appendChild(closeBtn);
-
-  const body = document.createElement("div");
-  body.dataset.testid = "drawer-body";
-  body.style.overflowY = "auto";
-  body.style.padding = "12px 14px";
-  body.style.flex = "1 1 auto";
-
-  panel.appendChild(header);
-  panel.appendChild(body);
-  root.appendChild(backdrop);
-  root.appendChild(panel);
+  const body = el("div", {
+    testid: "drawer-body",
+    style: { overflowY: "auto", padding: "12px 14px", flex: "1 1 auto" },
+  });
 
   if (initialContent !== undefined) {
     body.replaceChildren(initialContent);
   }
+
+  const closeBtn = el("button", {
+    testid: "drawer-close",
+    text: "×",
+    attrs: { title: "Close (Esc)" },
+    style: {
+      background: "rgba(255,255,255,0.1)",
+      border: "1px solid rgba(255,255,255,0.3)",
+      borderRadius: "4px",
+      color: TEXT_COLOR,
+      cursor: "pointer",
+      fontSize: "18px",
+      lineHeight: "1",
+      padding: "2px 10px",
+    },
+  });
+
+  const panel = el("div", {
+    testid: "drawer-panel",
+    style: {
+      position: "absolute",
+      top: "0",
+      bottom: "0",
+      width: typeof width === "number" ? `${String(width)}px` : width,
+      maxWidth: "100vw",
+      background: PANEL_BG,
+      boxSizing: "border-box",
+      display: "flex",
+      flexDirection: "column",
+      ...(side === "right"
+        ? { right: "0", borderLeft: PANEL_BORDER }
+        : { left: "0", borderRight: PANEL_BORDER }),
+    },
+    children: [
+      el("div", {
+        testid: "drawer-header",
+        style: {
+          display: "flex",
+          justifyContent: "flex-end",
+          alignItems: "center",
+          padding: "8px 12px",
+          borderBottom: "1px solid rgba(255,255,255,0.15)",
+          flexShrink: "0",
+        },
+        children: [closeBtn],
+      }),
+      body,
+    ],
+  });
+
+  const backdrop = el("div", {
+    testid: "drawer-backdrop",
+    style: {
+      position: "absolute",
+      inset: "0",
+      background: "rgba(0,0,0,0.5)",
+    },
+  });
+
+  const root = el("div", {
+    testid: "drawer",
+    style: {
+      display: "none",
+      position: "fixed",
+      inset: "0",
+      zIndex: "2000",
+    },
+    children: [backdrop, panel],
+  });
 
   let open = false;
 


### PR DESCRIPTION
## Summary

Eighth pass on #253. Rewrites `src/ui/drawer.ts` — the shared slide-in primitive used by settings-drawer / tonight-drawer / events-drawer — against the el() factory. One declarative tree replaces ~40 lines of imperative DOM.

Nice moment in the migration: the left/right side-anchoring stays honest with a spread conditional inside the panel's style object:

```ts
...(side === "right"
  ? { right: "0", borderLeft: PANEL_BORDER }
  : { left: "0", borderRight: PANEL_BORDER }),
```

## What stayed the same

- Public API (`createDrawer`, `Drawer`, `DrawerOptions`, `DrawerSide`).
- DOM structure (`element > [backdrop, panel]` with `panel > [header, body]`).
- Keyboard handling (Escape closes while open), backdrop click, close button.

## Test plan

- [x] `pnpm typecheck && pnpm lint && pnpm format:check && pnpm test:cov && pnpm build` green locally
- [x] All 62 drawer-family tests pass without modification (drawer + settings-drawer + tonight-drawer + events-drawer)
- [x] 1235 SPA tests, 89 worker tests unchanged

## #253 progress

- ✅ Pro-pill helper (#266)
- ✅ Palette constants + Notebook migrations (#267)
- ✅ `el()` factory + `notebook-mention-popover.ts` exemplar (#268)
- ✅ `login-modal.ts` migration (#269)
- ✅ 6 more palette migrations (#270)
- ✅ `notebook-workspace.ts` migration (#271)
- ✅ `panel.ts` migration (#272)
- ✅ **This PR**: `drawer.ts` migration
- Remaining: settings-drawer, tonight-drawer, events-drawer, help-modal, command-palette, search; plus `cssText`-embedded palette literals.

https://claude.ai/code/session_014DzXBVSCw5T2nnQvQjJtzS