### PR TITLE
chore(ui): migrate tonight-drawer + events-drawer to el() factory (#253)

### DIFF
--- a/src/ui/events-drawer.ts
+++ b/src/ui/events-drawer.ts
@@ -1,5 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 import { createDrawer } from "./drawer";
+import { el } from "./dom";
 import { createEventsPanel } from "./events-panel";
 import { TEXT_COLOR } from "./styles";
 import type { CelestialEvent } from "../astro/events";
@@ -28,23 +29,26 @@ export type EventsDrawerOptions = {
 export function createEventsDrawer(options: EventsDrawerOptions): EventsDrawer {
   const { dispatch } = options;
 
+  const panelHost = el("div", { testid: "events-drawer-panel-host" });
+
   // Stable content host. We rebuild its children when setEvents is called so
   // updates propagate whether the drawer is open or closed.
-  const content = document.createElement("div");
-  content.dataset.testid = "events-drawer-content";
-
-  const title = document.createElement("div");
-  title.textContent = "Upcoming Events";
-  title.style.color = TEXT_COLOR;
-  title.style.fontSize = "14px";
-  title.style.fontWeight = "bold";
-  title.style.fontFamily = "sans-serif";
-  title.style.marginBottom = "8px";
-  content.appendChild(title);
-
-  const panelHost = document.createElement("div");
-  panelHost.dataset.testid = "events-drawer-panel-host";
-  content.appendChild(panelHost);
+  const content = el("div", {
+    testid: "events-drawer-content",
+    children: [
+      el("div", {
+        text: "Upcoming Events",
+        style: {
+          color: TEXT_COLOR,
+          fontSize: "14px",
+          fontWeight: "bold",
+          fontFamily: "sans-serif",
+          marginBottom: "8px",
+        },
+      }),
+      panelHost,
+    ],
+  });
 
   let currentEvents: readonly CelestialEvent[] = [];
 
@@ -60,9 +64,9 @@ export function createEventsDrawer(options: EventsDrawerOptions): EventsDrawer {
   // Internal drawer structure test ids also get an events-drawer prefix so the
   // existing events-drawer-backdrop / events-drawer-close / events-drawer-body
   // queries continue to match after swapping in the canonical primitive.
-  drawer.element.querySelectorAll<HTMLElement>("[data-testid^='drawer']").forEach((el) => {
-    const current = el.dataset.testid!;
-    el.dataset.testid = `events-${current}`;
+  drawer.element.querySelectorAll<HTMLElement>("[data-testid^='drawer']").forEach((node) => {
+    const prevId = node.dataset.testid!;
+    node.dataset.testid = `events-${prevId}`;
   });
 
   return {

--- a/src/ui/tonight-drawer.ts
+++ b/src/ui/tonight-drawer.ts
@@ -1,5 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 import { createDrawer } from "./drawer";
+import { el } from "./dom";
 import { createPlanetInfo } from "./planet-info";
 import { TEXT_COLOR } from "./styles";
 import type { CelestialBody } from "../astro/bodies";
@@ -36,24 +37,27 @@ export type TonightDrawerOptions = {
 export function createTonightDrawer(options: TonightDrawerOptions): TonightDrawer {
   const { dispatch } = options;
 
+  const panelHost = el("div", { testid: "tonight-drawer-panel-host" });
+
   // Stable content host. Children are rebuilt when setBodies is called so
   // updates propagate whether the drawer is open or closed.
-  const content = document.createElement("div");
-  content.dataset.testid = "tonight-drawer-content";
-
-  const title = document.createElement("div");
-  title.dataset.testid = "tonight-drawer-title";
-  title.textContent = "Tonight's sky";
-  title.style.color = TEXT_COLOR;
-  title.style.fontSize = "14px";
-  title.style.fontWeight = "bold";
-  title.style.fontFamily = "sans-serif";
-  title.style.marginBottom = "8px";
-  content.appendChild(title);
-
-  const panelHost = document.createElement("div");
-  panelHost.dataset.testid = "tonight-drawer-panel-host";
-  content.appendChild(panelHost);
+  const content = el("div", {
+    testid: "tonight-drawer-content",
+    children: [
+      el("div", {
+        testid: "tonight-drawer-title",
+        text: "Tonight's sky",
+        style: {
+          color: TEXT_COLOR,
+          fontSize: "14px",
+          fontWeight: "bold",
+          fontFamily: "sans-serif",
+          marginBottom: "8px",
+        },
+      }),
+      panelHost,
+    ],
+  });
 
   type Snapshot = {
     bodies: CelestialBody[];
@@ -94,9 +98,9 @@ export function createTonightDrawer(options: TonightDrawerOptions): TonightDrawe
   drawer.element.dataset.testid = "tonight-drawer";
   // Prefix the inner drawer-* test ids so the tonight-drawer-{close,backdrop,body,header,panel}
   // selectors are unique (events + settings drawers have the same pattern on the page).
-  drawer.element.querySelectorAll<HTMLElement>("[data-testid^='drawer']").forEach((el) => {
-    const prev = el.dataset.testid!;
-    el.dataset.testid = `tonight-${prev}`;
+  drawer.element.querySelectorAll<HTMLElement>("[data-testid^='drawer']").forEach((node) => {
+    const prev = node.dataset.testid!;
+    node.dataset.testid = `tonight-${prev}`;
   });
 
   return {


### PR DESCRIPTION
## Summary

- Migrates `src/ui/tonight-drawer.ts` and `src/ui/events-drawer.ts` from imperative `createElement` + style setters to the declarative `el()` factory.
- DOM shape, testids, and styles are unchanged — the outer `div[data-testid="…-drawer-content"]` hosts a titled header plus a stable `panelHost` that `setBodies` / `setEvents` rebuild in place.
- Ninth/tenth module migrated under #253.

Refs #253.

## Test plan

- [x] `pnpm typecheck && pnpm lint && pnpm format:check && pnpm test:cov && pnpm build`
- [x] Coverage: `events-drawer.ts` 100/100, `tonight-drawer.ts` 95.31/90.9 — unchanged vs. pre-migration.
- [x] All 1235 SPA tests pass, including the 11 events-drawer + 14 tonight-drawer specs that pin the testid contract.

https://claude.ai/code/session_014DzXBVSCw5T2nnQvQjJtzS