### PR TITLE
test: silence jsdom canvas noise via test-setup stub

### DIFF
--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -1,0 +1,55 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/**
+ * Vitest setup file.
+ *
+ * jsdom 25 does not implement `HTMLCanvasElement.getContext` — calling it
+ * logs "Not implemented" to stderr via jsdom's virtual console and returns
+ * `undefined`. That return value is already handled correctly by our
+ * production code (scene layers bail out when `getContext` returns falsy),
+ * but the log spam makes `pnpm test` output unreadable.
+ *
+ * We replace the method with a Proxy-backed no-op 2D context so nothing
+ * logs and calls succeed silently. The stub intentionally does not paint
+ * pixels — any test that actually needs canvas output should mock at the
+ * component boundary, not here.
+ */
+
+function makeMockContext2D(canvas: HTMLCanvasElement): CanvasRenderingContext2D {
+  const gradient = { addColorStop: (): void => {} };
+  const pattern = {};
+  const state: Record<string | symbol, unknown> = { canvas };
+  const defaults: Record<string, unknown> = {
+    createLinearGradient: () => gradient,
+    createRadialGradient: () => gradient,
+    createConicGradient: () => gradient,
+    createPattern: () => pattern,
+    getImageData: () => ({ data: new Uint8ClampedArray() }),
+    measureText: () => ({ width: 0 }),
+    isPointInPath: () => false,
+    isPointInStroke: () => false,
+  };
+  const handler: ProxyHandler<Record<string | symbol, unknown>> = {
+    get(_target, prop) {
+      if (prop in state) return state[prop];
+      if (prop in defaults) return defaults[prop as string];
+      // Any other property read — treat as a no-op method. Returning a
+      // function is safe because method-style calls discard the value
+      // and property reads for things like `fillStyle` are handled by
+      // the setter path (set trap writes to `state`).
+      return (): void => {};
+    },
+    set(_target, prop, value) {
+      state[prop] = value;
+      return true;
+    },
+  };
+  return new Proxy({}, handler) as unknown as CanvasRenderingContext2D;
+}
+
+HTMLCanvasElement.prototype.getContext = function getContext(
+  this: HTMLCanvasElement,
+  contextId: string,
+): RenderingContext | null {
+  if (contextId === "2d") return makeMockContext2D(this);
+  return null;
+} as HTMLCanvasElement["getContext"];

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,12 +12,19 @@ export default defineConfig({
     environment: "jsdom",
     globals: false,
     include: ["src/**/*.test.ts"],
+    setupFiles: ["./src/test-setup.ts"],
     coverage: {
       provider: "v8",
       reporter: ["text", "html", "lcov"],
       reportsDirectory: "./coverage",
       include: ["src/**/*.ts"],
-      exclude: ["src/**/*.test.ts", "src/main.ts", "src/env.d.ts", "src/**/index.ts"],
+      exclude: [
+        "src/**/*.test.ts",
+        "src/main.ts",
+        "src/env.d.ts",
+        "src/**/index.ts",
+        "src/test-setup.ts",
+      ],
       thresholds: {
         // Project-wide floor
         lines: 85,


### PR DESCRIPTION
## Summary

Silences the ~2000 "Not implemented: HTMLCanvasElement.prototype.getContext" log lines that jsdom 25 emits during `pnpm test`. These come from `src/scene/{compass,messier,satellites}.ts` calling `canvas.getContext("2d")` during `app.test.ts` bootstrap — jsdom's unimplemented shim logs to stderr via the virtual console even when the return value is handled correctly by the caller.

The fix is a Proxy-backed no-op 2D context installed via a new `src/test-setup.ts` wired into `vitest.config.ts`' `setupFiles`. Any method call on the context is a no-op; property setters retain their value. Tests that actually need pixel output should continue to mock at the component boundary.

Side benefit: scene-layer draw paths that previously bailed out on a null context now execute under the stub, so coverage went **up**:

- `scene/messier.ts`: 54.38% → 95.9%
- `scene/satellites.ts`: 81.94% → 94.44%
- `scene/compass.ts`: 93.93% → 95.45%

## Test plan

- [x] `pnpm test` produces zero "Not implemented" log lines (was 2230+)
- [x] `pnpm typecheck && pnpm lint && pnpm format:check && pnpm test:cov && pnpm build`
- [x] All 1235 tests pass, coverage thresholds held or exceeded

https://claude.ai/code/session_014DzXBVSCw5T2nnQvQjJtzS