### PR TITLE
chore(ui): migrate fov/time/location controls to el() factory (#253)

### DIFF
--- a/src/ui/fov-controls.ts
+++ b/src/ui/fov-controls.ts
@@ -1,4 +1,5 @@
 /* SPDX-License-Identifier: Apache-2.0 */
+import { el } from "./dom";
 import { FOV_PRESETS, type FovPresetId, isFovPresetId } from "../astro/fov-presets";
 import type { UIIntent } from "./index";
 
@@ -6,45 +7,46 @@ export function createFovControls(
   initialPreset: FovPresetId,
   onIntent: (intent: UIIntent) => void,
 ): HTMLElement {
-  const section = document.createElement("div");
-  section.style.cssText = "padding:8px 0;border-top:1px solid rgba(255,255,255,0.1)";
-
-  const heading = document.createElement("div");
-  heading.textContent = "Telescope FOV";
-  heading.style.cssText = "color:#fff;font:bold 12px sans-serif;margin-bottom:6px";
-  section.appendChild(heading);
-
-  const row = document.createElement("div");
-  row.style.cssText = "display:flex;align-items:center;gap:8px";
-
-  const label = document.createElement("label");
-  label.textContent = "Reticle";
-  label.style.cssText = "color:rgba(255,255,255,0.6);font:12px sans-serif";
-  row.appendChild(label);
-
-  const select = document.createElement("select");
-  select.dataset.fov = "preset";
-  select.style.cssText =
-    "flex:1;background:rgba(255,255,255,0.1);color:#fff;border:1px solid rgba(255,255,255,0.2);" +
-    "border-radius:4px;padding:4px;font:12px sans-serif";
-
-  for (const preset of FOV_PRESETS) {
-    const option = document.createElement("option");
-    option.value = preset.id;
-    option.textContent = preset.label;
-    select.appendChild(option);
-  }
-
+  const select = el("select", {
+    dataset: { fov: "preset" },
+    style: {
+      flex: "1",
+      background: "rgba(255,255,255,0.1)",
+      color: "#fff",
+      border: "1px solid rgba(255,255,255,0.2)",
+      borderRadius: "4px",
+      padding: "4px",
+      font: "12px sans-serif",
+    },
+    children: FOV_PRESETS.map((preset) => {
+      const opt = el("option", { text: preset.label });
+      opt.value = preset.id;
+      return opt;
+    }),
+  });
   select.value = initialPreset;
-
   select.addEventListener("change", () => {
-    const value = select.value;
-    if (!isFovPresetId(value)) return;
-    onIntent({ type: "set-fov", preset: value });
+    if (!isFovPresetId(select.value)) return;
+    onIntent({ type: "set-fov", preset: select.value });
   });
 
-  row.appendChild(select);
-  section.appendChild(row);
-
-  return section;
+  return el("div", {
+    style: { padding: "8px 0", borderTop: "1px solid rgba(255,255,255,0.1)" },
+    children: [
+      el("div", {
+        text: "Telescope FOV",
+        style: { color: "#fff", font: "bold 12px sans-serif", marginBottom: "6px" },
+      }),
+      el("div", {
+        style: { display: "flex", alignItems: "center", gap: "8px" },
+        children: [
+          el("label", {
+            text: "Reticle",
+            style: { color: "rgba(255,255,255,0.6)", font: "12px sans-serif" },
+          }),
+          select,
+        ],
+      }),
+    ],
+  });
 }

--- a/src/ui/location-controls.ts
+++ b/src/ui/location-controls.ts
@@ -1,4 +1,5 @@
 /* SPDX-License-Identifier: Apache-2.0 */
+import { el } from "./dom";
 import { applyBaseText, GAP } from "./styles";
 import type { UIIntent } from "./index";
 
@@ -22,6 +23,41 @@ const PRESET_CITIES: City[] = [
   { name: "Deerfield", lat: 42.54, lon: -72.61 },
 ];
 
+const NUMBER_INPUT_STYLE: Partial<CSSStyleDeclaration> = {
+  flex: "1",
+  background: "rgba(255,255,255,0.1)",
+  border: "1px solid rgba(255,255,255,0.3)",
+  borderRadius: "4px",
+  color: "#fff",
+  fontSize: "12px",
+  padding: "4px",
+};
+
+const SELECT_STYLE: Partial<CSSStyleDeclaration> = {
+  width: "100%",
+  background: "rgba(255,255,255,0.1)",
+  border: "1px solid rgba(255,255,255,0.3)",
+  borderRadius: "4px",
+  color: "#fff",
+  fontSize: "12px",
+  padding: "4px",
+};
+
+const LABEL_STYLE: Partial<CSSStyleDeclaration> = {
+  color: "#fff",
+  fontSize: "12px",
+  width: "30px",
+  fontFamily: "sans-serif",
+};
+
+const PRESET_LABEL_STYLE: Partial<CSSStyleDeclaration> = {
+  color: "#fff",
+  fontSize: "12px",
+  marginTop: "6px",
+  marginBottom: "4px",
+  fontFamily: "sans-serif",
+};
+
 export function createLocationControls(
   initialLat: number,
   initialLon: number,
@@ -30,16 +66,6 @@ export function createLocationControls(
   let currentLat = initialLat;
   let currentLon = initialLon;
 
-  const section = document.createElement("div");
-  section.style.marginBottom = GAP;
-
-  const heading = document.createElement("div");
-  heading.textContent = "Location";
-  heading.style.fontWeight = "bold";
-  heading.style.marginBottom = GAP;
-  applyBaseText(heading);
-  section.appendChild(heading);
-
   function makeNumberInput(
     label: string,
     field: "lat" | "lon",
@@ -47,34 +73,15 @@ export function createLocationControls(
     min: number,
     max: number,
   ): HTMLElement {
-    const row = document.createElement("div");
-    row.style.display = "flex";
-    row.style.alignItems = "center";
-    row.style.gap = "6px";
-    row.style.marginBottom = "4px";
-
-    const lbl = document.createElement("label");
-    lbl.textContent = label;
-    lbl.style.color = "#fff";
-    lbl.style.fontSize = "12px";
-    lbl.style.width = "30px";
-    lbl.style.fontFamily = "sans-serif";
-
-    const input = document.createElement("input");
-    input.type = "number";
-    input.dataset.field = field;
+    const input = el("input", {
+      type: "number",
+      dataset: { field },
+      style: NUMBER_INPUT_STYLE,
+    });
     input.value = String(value);
     input.min = String(min);
     input.max = String(max);
     input.step = "0.01";
-    input.style.flex = "1";
-    input.style.background = "rgba(255,255,255,0.1)";
-    input.style.border = "1px solid rgba(255,255,255,0.3)";
-    input.style.borderRadius = "4px";
-    input.style.color = "#fff";
-    input.style.fontSize = "12px";
-    input.style.padding = "4px";
-
     input.addEventListener("change", () => {
       if (input.value === "") return;
       const n = Number(input.value);
@@ -84,44 +91,42 @@ export function createLocationControls(
       dispatch({ type: "set-observer", lat: currentLat, lon: currentLon });
     });
 
-    row.appendChild(lbl);
-    row.appendChild(input);
-    return row;
+    return el("div", {
+      style: { display: "flex", alignItems: "center", gap: "6px", marginBottom: "4px" },
+      children: [el("label", { text: label, style: LABEL_STYLE }), input],
+    });
   }
 
-  section.appendChild(makeNumberInput("Lat", "lat", initialLat, -90, 90));
-  section.appendChild(makeNumberInput("Lon", "lon", initialLon, -180, 180));
-
-  // Preset dropdown
-  const presetLabel = document.createElement("div");
-  presetLabel.textContent = "City preset";
-  presetLabel.style.color = "#fff";
-  presetLabel.style.fontSize = "12px";
-  presetLabel.style.marginTop = "6px";
-  presetLabel.style.marginBottom = "4px";
-  presetLabel.style.fontFamily = "sans-serif";
-  section.appendChild(presetLabel);
-
-  const select = document.createElement("select");
-  select.style.width = "100%";
-  select.style.background = "rgba(255,255,255,0.1)";
-  select.style.border = "1px solid rgba(255,255,255,0.3)";
-  select.style.borderRadius = "4px";
-  select.style.color = "#fff";
-  select.style.fontSize = "12px";
-  select.style.padding = "4px";
-
-  const placeholder = document.createElement("option");
+  const placeholder = el("option", { text: "— Select city —" });
   placeholder.value = "";
-  placeholder.textContent = "— Select city —";
-  select.appendChild(placeholder);
 
-  for (const city of PRESET_CITIES) {
-    const opt = document.createElement("option");
+  const cityOptions = PRESET_CITIES.map((city) => {
+    const opt = el("option", { text: city.name });
     opt.value = JSON.stringify({ lat: city.lat, lon: city.lon });
-    opt.textContent = city.name;
-    select.appendChild(opt);
-  }
+    return opt;
+  });
+
+  const select = el("select", {
+    style: SELECT_STYLE,
+    children: [placeholder, ...cityOptions],
+  });
+
+  const heading = el("div", {
+    text: "Location",
+    style: { fontWeight: "bold", marginBottom: GAP },
+  });
+  applyBaseText(heading);
+
+  const section = el("div", {
+    style: { marginBottom: GAP },
+    children: [
+      heading,
+      makeNumberInput("Lat", "lat", initialLat, -90, 90),
+      makeNumberInput("Lon", "lon", initialLon, -180, 180),
+      el("div", { text: "City preset", style: PRESET_LABEL_STYLE }),
+      select,
+    ],
+  });
 
   select.addEventListener("change", () => {
     if (!select.value) return;
@@ -129,7 +134,6 @@ export function createLocationControls(
       const { lat, lon } = JSON.parse(select.value) as { lat: number; lon: number };
       currentLat = lat;
       currentLon = lon;
-      // Update inputs
       const latInput = section.querySelector<HTMLInputElement>("input[data-field='lat']");
       const lonInput = section.querySelector<HTMLInputElement>("input[data-field='lon']");
       if (latInput) latInput.value = String(lat);
@@ -139,8 +143,6 @@ export function createLocationControls(
       // ignore malformed value
     }
   });
-
-  section.appendChild(select);
 
   return section;
 }

--- a/src/ui/time-controls.ts
+++ b/src/ui/time-controls.ts
@@ -1,4 +1,5 @@
 /* SPDX-License-Identifier: Apache-2.0 */
+import { el } from "./dom";
 import { applyButton, applyBaseText, GAP } from "./styles";
 import type { UIIntent } from "./index";
 
@@ -13,9 +14,9 @@ const STEPS: Array<{ label: string; deltaMs: number }> = [
 
 /** Format a Date to a value suitable for <input type="datetime-local"> (local time, no Z). */
 function toDatetimeLocal(d: Date): string {
-  const pad = (n: number) => String(n).padStart(2, "0");
+  const pad = (n: number): string => String(n).padStart(2, "0");
   return (
-    `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}` +
+    `${String(d.getFullYear())}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}` +
     `T${pad(d.getHours())}:${pad(d.getMinutes())}`
   );
 }
@@ -31,30 +32,21 @@ export function createTimeControls(
 ): TimeControls {
   let current = new Date(initial);
 
-  const section = document.createElement("div");
-  section.style.marginBottom = GAP;
-
-  const heading = document.createElement("div");
-  heading.textContent = "Time";
-  heading.style.fontWeight = "bold";
-  heading.style.marginBottom = GAP;
-  applyBaseText(heading);
-  section.appendChild(heading);
-
-  const input = document.createElement("input");
-  input.type = "datetime-local";
+  const input = el("input", {
+    type: "datetime-local",
+    style: {
+      width: "100%",
+      background: "rgba(255,255,255,0.1)",
+      border: "1px solid rgba(255,255,255,0.3)",
+      borderRadius: "4px",
+      color: "#fff",
+      fontSize: "12px",
+      padding: "4px",
+      boxSizing: "border-box",
+      marginBottom: GAP,
+    },
+  });
   input.value = toDatetimeLocal(current);
-  input.style.width = "100%";
-  input.style.background = "rgba(255,255,255,0.1)";
-  input.style.border = "1px solid rgba(255,255,255,0.3)";
-  input.style.borderRadius = "4px";
-  input.style.color = "#fff";
-  input.style.fontSize = "12px";
-  input.style.padding = "4px";
-  input.style.boxSizing = "border-box";
-  input.style.marginBottom = GAP;
-  section.appendChild(input);
-
   input.addEventListener("change", () => {
     const d = new Date(input.value);
     if (!Number.isNaN(d.getTime())) {
@@ -63,33 +55,23 @@ export function createTimeControls(
     }
   });
 
-  // Step buttons row
-  const buttonsRow = document.createElement("div");
-  buttonsRow.style.display = "flex";
-  buttonsRow.style.gap = "4px";
-  buttonsRow.style.flexWrap = "wrap";
-  buttonsRow.style.marginBottom = GAP;
-
-  for (const step of STEPS) {
-    const btn = document.createElement("button");
-    btn.textContent = step.label;
+  const stepButtons = STEPS.map((step) => {
+    const btn = el("button", { text: step.label });
     applyButton(btn);
     btn.addEventListener("click", () => {
       current = new Date(current.getTime() + step.deltaMs);
       input.value = toDatetimeLocal(current);
       dispatch({ type: "set-time", time: new Date(current) });
     });
-    buttonsRow.appendChild(btn);
-  }
-  section.appendChild(buttonsRow);
+    return btn;
+  });
 
-  // Now button row: "Now" + "📍 Now" (with geolocation)
-  const nowRow = document.createElement("div");
-  nowRow.style.display = "flex";
-  nowRow.style.gap = "4px";
+  const buttonsRow = el("div", {
+    style: { display: "flex", gap: "4px", flexWrap: "wrap", marginBottom: GAP },
+    children: stepButtons,
+  });
 
-  const nowBtn = document.createElement("button");
-  nowBtn.textContent = "Now";
+  const nowBtn = el("button", { text: "Now" });
   applyButton(nowBtn);
   nowBtn.style.flex = "1";
   nowBtn.addEventListener("click", () => {
@@ -98,36 +80,43 @@ export function createTimeControls(
     input.value = toDatetimeLocal(now);
     dispatch({ type: "set-time", time: new Date(now) });
   });
-  nowRow.appendChild(nowBtn);
 
-  const liveBtn = document.createElement("button");
-  liveBtn.textContent = "📍 Now";
-  liveBtn.title = "Snap to current time and GPS location";
+  const liveBtn = el("button", {
+    text: "📍 Now",
+    attrs: { title: "Snap to current time and GPS location" },
+  });
   applyButton(liveBtn);
   liveBtn.style.flex = "1";
   liveBtn.addEventListener("click", () => {
     liveBtn.textContent = "Locating…";
     liveBtn.disabled = true;
     dispatch({ type: "now" });
-    if (navigator.geolocation) {
-      navigator.geolocation.getCurrentPosition(
-        () => {
-          liveBtn.textContent = "📍 Now";
-          liveBtn.disabled = false;
-        },
-        () => {
-          liveBtn.textContent = "📍 Now";
-          liveBtn.disabled = false;
-        },
-      );
-    } else {
+    const restore = (): void => {
       liveBtn.textContent = "📍 Now";
       liveBtn.disabled = false;
+    };
+    if (navigator.geolocation) {
+      navigator.geolocation.getCurrentPosition(restore, restore);
+    } else {
+      restore();
     }
   });
-  nowRow.appendChild(liveBtn);
 
-  section.appendChild(nowRow);
+  const nowRow = el("div", {
+    style: { display: "flex", gap: "4px" },
+    children: [nowBtn, liveBtn],
+  });
+
+  const heading = el("div", {
+    text: "Time",
+    style: { fontWeight: "bold", marginBottom: GAP },
+  });
+  applyBaseText(heading);
+
+  const section = el("div", {
+    style: { marginBottom: GAP },
+    children: [heading, input, buttonsRow, nowRow],
+  });
 
   return {
     element: section,


### PR DESCRIPTION
## Summary

Migrates three sibling control widgets from imperative `document.createElement` + style setters to the declarative `el()` factory:

- `src/ui/fov-controls.ts` — telescope FOV preset dropdown
- `src/ui/time-controls.ts` — datetime-local input + step buttons + Now / 📍 Now
- `src/ui/location-controls.ts` — lat/lon number inputs + city preset dropdown

DOM shape, testids, dataset markers (e.g. `[data-field="lat"]` which `location-controls` uses to update its own inputs after a preset pick), and all event handlers are unchanged.

Bundled as one PR because the three files are all small control widgets with the same migration pattern; reviewing them together should be faster than three near-identical PRs. Fourteenth-through-sixteenth modules migrated under #253.

## Test plan

- [x] `pnpm typecheck && pnpm lint && pnpm format:check && pnpm test:cov && pnpm build`
- [x] All 1235 SPA tests pass
- [x] Per-file coverage held: fov-controls 100/100, time-controls 95.28/100, location-controls 100/100

https://claude.ai/code/session_014DzXBVSCw5T2nnQvQjJtzS