### PR TITLE
chore(ui): migrate view-controls.ts to el() factory (#253)

### DIFF
--- a/src/ui/view-controls.ts
+++ b/src/ui/view-controls.ts
@@ -1,4 +1,5 @@
 /* SPDX-License-Identifier: Apache-2.0 */
+import { el } from "./dom";
 import type { UIIntent } from "./index";
 
 type ViewPreset = { label: string; az: number; alt: number };
@@ -11,69 +12,55 @@ const PRESETS: ViewPreset[] = [
   { label: "W", az: 270, alt: 30 },
 ];
 
+const PRESET_BTN_STYLE: Partial<CSSStyleDeclaration> = {
+  background: "rgba(255,255,255,0.1)",
+  color: "#fff",
+  border: "1px solid rgba(255,255,255,0.2)",
+  borderRadius: "4px",
+  padding: "4px 8px",
+  cursor: "pointer",
+  font: "12px sans-serif",
+};
+
+const INPUT_STYLE: Partial<CSSStyleDeclaration> = {
+  width: "60px",
+  background: "rgba(255,255,255,0.1)",
+  color: "#fff",
+  border: "1px solid rgba(255,255,255,0.2)",
+  borderRadius: "4px",
+  padding: "4px",
+  font: "12px sans-serif",
+};
+
+const LABEL_STYLE: Partial<CSSStyleDeclaration> = {
+  color: "rgba(255,255,255,0.6)",
+  font: "12px sans-serif",
+};
+
 export function createViewControls(
   initialAz: number,
   initialAlt: number,
   onIntent: (intent: UIIntent) => void,
 ): HTMLElement {
-  const section = document.createElement("div");
-  section.style.cssText = "padding:8px 0;border-top:1px solid rgba(255,255,255,0.1)";
-
-  const heading = document.createElement("div");
-  heading.textContent = "View Direction";
-  heading.style.cssText = "color:#fff;font:bold 12px sans-serif;margin-bottom:6px";
-  section.appendChild(heading);
-
-  // Preset buttons
-  const btnRow = document.createElement("div");
-  btnRow.style.cssText = "display:flex;gap:4px;margin-bottom:8px;flex-wrap:wrap";
-  for (const preset of PRESETS) {
-    const btn = document.createElement("button");
-    btn.textContent = preset.label;
-    btn.dataset.testid = `view-${preset.label.toLowerCase()}`;
-    btn.style.cssText =
-      "background:rgba(255,255,255,0.1);color:#fff;border:1px solid rgba(255,255,255,0.2);" +
-      "border-radius:4px;padding:4px 8px;cursor:pointer;font:12px sans-serif";
-    btn.addEventListener("click", () => {
-      azInput.value = String(preset.az);
-      altInput.value = String(preset.alt);
-      onIntent({ type: "set-view", az: preset.az, alt: preset.alt });
-    });
-    btnRow.appendChild(btn);
-  }
-  section.appendChild(btnRow);
-
-  // Az/Alt inputs
-  const inputRow = document.createElement("div");
-  inputRow.style.cssText = "display:flex;gap:8px;align-items:center";
-
-  const azLabel = document.createElement("label");
-  azLabel.textContent = "Az";
-  azLabel.style.cssText = "color:rgba(255,255,255,0.6);font:12px sans-serif";
-  const azInput = document.createElement("input");
-  azInput.type = "number";
+  const azInput = el("input", {
+    testid: "view-az",
+    type: "number",
+    style: INPUT_STYLE,
+  });
   azInput.min = "0";
   azInput.max = "360";
   azInput.step = "1";
   azInput.value = String(initialAz);
-  azInput.dataset.testid = "view-az";
-  azInput.style.cssText =
-    "width:60px;background:rgba(255,255,255,0.1);color:#fff;border:1px solid rgba(255,255,255,0.2);" +
-    "border-radius:4px;padding:4px;font:12px sans-serif";
 
-  const altLabel = document.createElement("label");
-  altLabel.textContent = "Alt";
-  altLabel.style.cssText = "color:rgba(255,255,255,0.6);font:12px sans-serif";
-  const altInput = document.createElement("input");
-  altInput.type = "number";
+  const altInput = el("input", {
+    testid: "view-alt",
+    type: "number",
+    style: INPUT_STYLE,
+  });
   altInput.min = "0";
   altInput.max = "90";
   altInput.step = "1";
   altInput.value = String(initialAlt);
-  altInput.dataset.testid = "view-alt";
-  altInput.style.cssText =
-    "width:60px;background:rgba(255,255,255,0.1);color:#fff;border:1px solid rgba(255,255,255,0.2);" +
-    "border-radius:4px;padding:4px;font:12px sans-serif";
 
   function onInputChange(): void {
     const az = Number(azInput.value);
@@ -82,15 +69,43 @@ export function createViewControls(
       onIntent({ type: "set-view", az, alt });
     }
   }
-
   azInput.addEventListener("change", onInputChange);
   altInput.addEventListener("change", onInputChange);
 
-  inputRow.appendChild(azLabel);
-  inputRow.appendChild(azInput);
-  inputRow.appendChild(altLabel);
-  inputRow.appendChild(altInput);
-  section.appendChild(inputRow);
+  const presetButtons = PRESETS.map((preset) => {
+    const btn = el("button", {
+      testid: `view-${preset.label.toLowerCase()}`,
+      text: preset.label,
+      style: PRESET_BTN_STYLE,
+    });
+    btn.addEventListener("click", () => {
+      azInput.value = String(preset.az);
+      altInput.value = String(preset.alt);
+      onIntent({ type: "set-view", az: preset.az, alt: preset.alt });
+    });
+    return btn;
+  });
 
-  return section;
+  return el("div", {
+    style: { padding: "8px 0", borderTop: "1px solid rgba(255,255,255,0.1)" },
+    children: [
+      el("div", {
+        text: "View Direction",
+        style: { color: "#fff", font: "bold 12px sans-serif", marginBottom: "6px" },
+      }),
+      el("div", {
+        style: { display: "flex", gap: "4px", marginBottom: "8px", flexWrap: "wrap" },
+        children: presetButtons,
+      }),
+      el("div", {
+        style: { display: "flex", gap: "8px", alignItems: "center" },
+        children: [
+          el("label", { text: "Az", style: LABEL_STYLE }),
+          azInput,
+          el("label", { text: "Alt", style: LABEL_STYLE }),
+          altInput,
+        ],
+      }),
+    ],
+  });
 }


### PR DESCRIPTION
## Summary

- Migrates `src/ui/view-controls.ts` from imperative `createElement` + `cssText` setters to the declarative `el()` factory.
- Shared style snippets (preset button, number input, label) lifted to named `Partial<CSSStyleDeclaration>` constants.
- DOM shape, testids (`view-zenith`, `view-n`, `view-e`, `view-s`, `view-w`, `view-az`, `view-alt`), and event handlers are unchanged.
- Seventeenth module migrated under #253.

## Test plan

- [x] `pnpm typecheck && pnpm lint && pnpm format:check && pnpm test:cov && pnpm build`
- [x] `view-controls.ts` coverage: 100/100 (unchanged)
- [x] All 1235 SPA tests pass

https://claude.ai/code/session_014DzXBVSCw5T2nnQvQjJtzS