### PR TITLE
chore(ui): migrate layer-controls + planet-info to el() factory (#253)

### DIFF
--- a/src/ui/layer-controls.ts
+++ b/src/ui/layer-controls.ts
@@ -1,4 +1,5 @@
 /* SPDX-License-Identifier: Apache-2.0 */
+import { el } from "./dom";
 import { applyBaseText, ACCENT_COLOR } from "./styles";
 import type { UIIntent } from "./index";
 import type { LayerVisibility, LayerOpacity } from "../state/state";
@@ -38,7 +39,7 @@ const TOGGLE_LAYERS: LayerDef[] = [
   { key: "planets", label: "Planets ☾" },
   { key: "satellites", label: "Satellites 🛰" },
   { key: "compass", label: "Compass ◎" },
-  { key: "deepSky", label: "Deep Sky \u2726" },
+  { key: "deepSky", label: "Deep Sky ✦" },
 ];
 
 const LINE_LAYERS: LineDef[] = [
@@ -50,77 +51,74 @@ const LINE_LAYERS: LineDef[] = [
   { key: "milkyWay", label: "Milky Way", defaultPct: 30 },
 ];
 
-function appendToggleRow(
-  section: HTMLElement,
+const SLIDER_LABEL_STYLE: Partial<CSSStyleDeclaration> = {
+  fontSize: "12px",
+  marginBottom: "2px",
+};
+
+const SLIDER_STYLE: Partial<CSSStyleDeclaration> = {
+  width: "100%",
+  accentColor: ACCENT_COLOR,
+};
+
+function buildToggleRow(
   layer: LayerDef,
   initialChecked: boolean,
   dispatch: (intent: UIIntent) => void,
-): void {
-  const row = document.createElement("div");
-  row.style.display = "flex";
-  row.style.alignItems = "center";
-  row.style.justifyContent = "space-between";
-  row.style.marginBottom = "6px";
-
-  const lbl = document.createElement("label");
-  lbl.style.display = "flex";
-  lbl.style.alignItems = "center";
-  lbl.style.gap = "6px";
-  lbl.style.cursor = "pointer";
-  applyBaseText(lbl);
-
-  const checkbox = document.createElement("input");
-  checkbox.type = "checkbox";
-  checkbox.dataset.layer = layer.key;
+): HTMLElement {
+  const checkbox = el("input", {
+    type: "checkbox",
+    dataset: { layer: layer.key },
+    style: { accentColor: ACCENT_COLOR, width: "16px", height: "16px" },
+  });
   checkbox.checked = initialChecked;
-  checkbox.style.accentColor = ACCENT_COLOR;
-  checkbox.style.width = "16px";
-  checkbox.style.height = "16px";
-
-  lbl.appendChild(checkbox);
-  lbl.appendChild(document.createTextNode(layer.label));
-  row.appendChild(lbl);
-  section.appendChild(row);
-
   checkbox.addEventListener("change", () => {
     dispatch({ type: "toggle-layer", layer: layer.key });
   });
+
+  const lbl = el("label", {
+    style: { display: "flex", alignItems: "center", gap: "6px", cursor: "pointer" },
+    children: [checkbox, document.createTextNode(layer.label)],
+  });
+  applyBaseText(lbl);
+
+  return el("div", {
+    style: {
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "space-between",
+      marginBottom: "6px",
+    },
+    children: [lbl],
+  });
 }
 
-function appendOpacityRow(
-  section: HTMLElement,
+function buildOpacityRow(
   ld: LineDef,
   initialValue: number,
   dispatch: (intent: UIIntent) => void,
-): void {
-  const row = document.createElement("div");
-  row.dataset.opacityRow = ld.key;
-  row.style.marginBottom = "6px";
-
-  const lbl = document.createElement("div");
-  lbl.textContent = ld.label;
+): HTMLElement {
+  const lbl = el("div", { text: ld.label, style: SLIDER_LABEL_STYLE });
   applyBaseText(lbl);
-  lbl.style.fontSize = "12px";
-  lbl.style.marginBottom = "2px";
 
-  const slider = document.createElement("input");
-  slider.type = "range";
-  slider.dataset.opacity = ld.key;
+  const slider = el("input", {
+    type: "range",
+    dataset: { opacity: ld.key },
+    style: SLIDER_STYLE,
+  });
   slider.min = "0";
   slider.max = "100";
   slider.step = "1";
   slider.value = String(Math.round(initialValue * 100));
-  slider.style.width = "100%";
-  slider.style.accentColor = ACCENT_COLOR;
-
   slider.addEventListener("input", () => {
-    const value = Number(slider.value) / 100;
-    dispatch({ type: "set-opacity", layer: ld.key, value });
+    dispatch({ type: "set-opacity", layer: ld.key, value: Number(slider.value) / 100 });
   });
 
-  row.appendChild(lbl);
-  row.appendChild(slider);
-  section.appendChild(row);
+  return el("div", {
+    dataset: { opacityRow: ld.key },
+    style: { marginBottom: "6px" },
+    children: [lbl, slider],
+  });
 }
 
 /**
@@ -131,11 +129,9 @@ export function createVisibilitySection(
   visibility: LayerVisibility,
   dispatch: (intent: UIIntent) => void,
 ): HTMLElement {
-  const section = document.createElement("div");
-  for (const layer of TOGGLE_LAYERS) {
-    appendToggleRow(section, layer, visibility[layer.key], dispatch);
-  }
-  return section;
+  return el("div", {
+    children: TOGGLE_LAYERS.map((layer) => buildToggleRow(layer, visibility[layer.key], dispatch)),
+  });
 }
 
 /**
@@ -146,11 +142,9 @@ export function createOpacitySection(
   opacity: LayerOpacity,
   dispatch: (intent: UIIntent) => void,
 ): HTMLElement {
-  const section = document.createElement("div");
-  for (const ld of LINE_LAYERS) {
-    appendOpacityRow(section, ld, opacity[ld.key], dispatch);
-  }
-  return section;
+  return el("div", {
+    children: LINE_LAYERS.map((ld) => buildOpacityRow(ld, opacity[ld.key], dispatch)),
+  });
 }
 
 /**
@@ -160,37 +154,58 @@ export function createMagnitudeFilterSection(
   initialMagLimit: number,
   dispatch: (intent: UIIntent) => void,
 ): HTMLElement {
-  const section = document.createElement("div");
-  const magRow = document.createElement("div");
-  magRow.style.marginBottom = "6px";
-
-  const magLabel = document.createElement("div");
-  magLabel.dataset.magLabel = "";
-  magLabel.textContent = `Mag \u2264 ${initialMagLimit.toFixed(1)}`;
+  const magLabel = el("div", {
+    dataset: { magLabel: "" },
+    text: `Mag ≤ ${initialMagLimit.toFixed(1)}`,
+    style: SLIDER_LABEL_STYLE,
+  });
   applyBaseText(magLabel);
-  magLabel.style.fontSize = "12px";
-  magLabel.style.marginBottom = "2px";
 
-  const magSlider = document.createElement("input");
-  magSlider.type = "range";
-  magSlider.dataset.mag = "limit";
+  const magSlider = el("input", {
+    type: "range",
+    dataset: { mag: "limit" },
+    style: SLIDER_STYLE,
+  });
   magSlider.min = "1";
   magSlider.max = "6";
   magSlider.step = "0.5";
   magSlider.value = String(initialMagLimit);
-  magSlider.style.width = "100%";
-  magSlider.style.accentColor = ACCENT_COLOR;
-
   magSlider.addEventListener("input", () => {
     const value = Number(magSlider.value);
-    magLabel.textContent = `Mag \u2264 ${value.toFixed(1)}`;
+    magLabel.textContent = `Mag ≤ ${value.toFixed(1)}`;
     dispatch({ type: "set-mag-limit", value });
   });
 
-  magRow.appendChild(magLabel);
-  magRow.appendChild(magSlider);
-  section.appendChild(magRow);
-  return section;
+  return el("div", {
+    children: [el("div", { style: { marginBottom: "6px" }, children: [magLabel, magSlider] })],
+  });
+}
+
+function buildSelectRow<T extends string>(
+  ids: readonly T[],
+  labels: Record<T, string>,
+  initial: T,
+  datasetKey: "language" | "skyculture",
+  onChange: (value: T) => void,
+): HTMLElement {
+  const select = el("select", {
+    dataset: { [datasetKey]: "" },
+    style: { width: "100%", fontSize: "12px" },
+    children: ids.map((id) => {
+      const option = el("option", { text: labels[id] });
+      option.value = id;
+      if (id === initial) option.selected = true;
+      return option;
+    }),
+  });
+  applyBaseText(select);
+  select.addEventListener("change", () => {
+    onChange(select.value as T);
+  });
+
+  return el("div", {
+    children: [el("div", { style: { marginBottom: "6px" }, children: [select] })],
+  });
 }
 
 /**
@@ -200,32 +215,9 @@ export function createLanguageSection(
   initialLanguage: Language,
   dispatch: (intent: UIIntent) => void,
 ): HTMLElement {
-  const section = document.createElement("div");
-  const row = document.createElement("div");
-  row.style.marginBottom = "6px";
-
-  const select = document.createElement("select");
-  select.dataset.language = "";
-  select.style.width = "100%";
-  applyBaseText(select);
-  select.style.fontSize = "12px";
-
-  for (const code of LANGUAGES) {
-    const option = document.createElement("option");
-    option.value = code;
-    option.textContent = LANGUAGE_LABELS[code];
-    if (code === initialLanguage) option.selected = true;
-    select.appendChild(option);
-  }
-
-  select.addEventListener("change", () => {
-    const value = select.value as Language;
-    dispatch({ type: "set-language", language: value });
+  return buildSelectRow(LANGUAGES, LANGUAGE_LABELS, initialLanguage, "language", (language) => {
+    dispatch({ type: "set-language", language });
   });
-
-  row.appendChild(select);
-  section.appendChild(row);
-  return section;
 }
 
 /**
@@ -235,30 +227,7 @@ export function createSkycultureSection(
   initialSkyculture: SkycultureId,
   dispatch: (intent: UIIntent) => void,
 ): HTMLElement {
-  const section = document.createElement("div");
-  const row = document.createElement("div");
-  row.style.marginBottom = "6px";
-
-  const select = document.createElement("select");
-  select.dataset.skyculture = "";
-  select.style.width = "100%";
-  applyBaseText(select);
-  select.style.fontSize = "12px";
-
-  for (const id of SKYCULTURES) {
-    const option = document.createElement("option");
-    option.value = id;
-    option.textContent = SKYCULTURE_LABELS[id];
-    if (id === initialSkyculture) option.selected = true;
-    select.appendChild(option);
-  }
-
-  select.addEventListener("change", () => {
-    const value = select.value as SkycultureId;
-    dispatch({ type: "set-skyculture", id: value });
+  return buildSelectRow(SKYCULTURES, SKYCULTURE_LABELS, initialSkyculture, "skyculture", (id) => {
+    dispatch({ type: "set-skyculture", id });
   });
-
-  row.appendChild(select);
-  section.appendChild(row);
-  return section;
 }

--- a/src/ui/planet-info.ts
+++ b/src/ui/planet-info.ts
@@ -1,4 +1,5 @@
 /* SPDX-License-Identifier: Apache-2.0 */
+import { el } from "./dom";
 import { ACCENT_COLOR, applyBaseText, GAP, SURFACE, TEXT_COLOR } from "./styles";
 import type { CelestialBody } from "../astro/bodies";
 import { computeRiseSet } from "../astro/rise-set";
@@ -14,6 +15,123 @@ function formatHHMM(d: Date | null): string {
 /** Format altitude and azimuth as a compact string. */
 function formatAltAz(alt: number, az: number): string {
   return `Alt ${alt.toFixed(1)}° Az ${az.toFixed(1)}°`;
+}
+
+const ALT_AZ_STYLE: Partial<CSSStyleDeclaration> = {
+  color: "rgba(255,255,255,0.65)",
+  fontSize: "11px",
+  fontFamily: "sans-serif",
+  marginTop: "2px",
+};
+
+const RISE_SET_STYLE: Partial<CSSStyleDeclaration> = {
+  fontSize: "11px",
+  fontFamily: "sans-serif",
+};
+
+const BELOW_HORIZON_STYLE: Partial<CSSStyleDeclaration> = {
+  color: "rgba(255,255,255,0.4)",
+  fontSize: "10px",
+  fontFamily: "sans-serif",
+};
+
+function buildRow(
+  celestialBody: CelestialBody,
+  lat: number,
+  lon: number,
+  time: Date,
+  onSelect?: (az: number, alt: number) => void,
+  onShowTrail?: (id: string) => void,
+  trailBodyId?: string | null,
+): HTMLElement {
+  const riseSet = computeRiseSet(celestialBody.id, lat, lon, time);
+
+  const nameEl = el("span", {
+    testid: "planet-name",
+    text: celestialBody.id,
+    style: {
+      color: celestialBody.color,
+      fontWeight: "bold",
+      fontSize: "12px",
+      fontFamily: "sans-serif",
+    },
+  });
+  if (celestialBody.alt > 0 && onSelect) {
+    nameEl.style.cursor = "pointer";
+    nameEl.style.textDecoration = "underline";
+    nameEl.addEventListener("click", () => {
+      onSelect(celestialBody.az, celestialBody.alt);
+    });
+  }
+
+  const nameRow = el("div", {
+    style: { display: "flex", justifyContent: "space-between", alignItems: "center" },
+    children: [
+      nameEl,
+      celestialBody.alt <= 0
+        ? el("span", {
+            testid: "planet-below-horizon",
+            text: "↓ below",
+            style: BELOW_HORIZON_STYLE,
+          })
+        : null,
+    ],
+  });
+
+  const altAzEl = el("div", {
+    testid: "planet-altaz",
+    text: formatAltAz(celestialBody.alt, celestialBody.az),
+    style: ALT_AZ_STYLE,
+  });
+
+  const riseSetRow = el("div", {
+    style: { display: "flex", gap: "8px", marginTop: "2px" },
+    children: [
+      el("span", {
+        testid: "planet-rise",
+        text: `↑ ${formatHHMM(riseSet.rise)}`,
+        style: { ...RISE_SET_STYLE, color: ACCENT_COLOR },
+      }),
+      el("span", {
+        testid: "planet-set",
+        text: `↓ ${formatHHMM(riseSet.set)}`,
+        style: { ...RISE_SET_STYLE, color: "rgba(255,180,100,0.85)" },
+      }),
+    ],
+  });
+
+  let trailBtn: HTMLElement | null = null;
+  if (celestialBody.alt > 0 && onShowTrail) {
+    const active = trailBodyId === celestialBody.id;
+    trailBtn = el("button", {
+      testid: "planet-show-trail",
+      text: active ? "Hide path" : "Show path",
+      style: {
+        marginTop: "4px",
+        padding: "2px 6px",
+        fontSize: "11px",
+        fontFamily: "sans-serif",
+        background: active ? "rgba(100,160,255,0.25)" : SURFACE,
+        color: TEXT_COLOR,
+        border: "1px solid rgba(255,255,255,0.2)",
+        borderRadius: "3px",
+        cursor: "pointer",
+      },
+    });
+    trailBtn.addEventListener("click", () => {
+      onShowTrail(celestialBody.id);
+    });
+  }
+
+  return el("div", {
+    testid: "planet-info-row",
+    style: {
+      marginBottom: "6px",
+      paddingBottom: "6px",
+      borderBottom: "1px solid rgba(255,255,255,0.08)",
+    },
+    children: [nameRow, altAzEl, riseSetRow, trailBtn],
+  });
 }
 
 /**
@@ -35,39 +153,30 @@ export function createPlanetInfo(
   onShowTrail?: (id: string) => void,
   trailBodyId?: string | null,
 ): HTMLElement {
-  const section = document.createElement("div");
-  section.style.marginBottom = GAP;
-
-  // Header row with heading and collapse toggle
-  const header = document.createElement("div");
-  header.style.display = "flex";
-  header.style.justifyContent = "space-between";
-  header.style.alignItems = "center";
-  header.style.marginBottom = "4px";
-
-  const heading = document.createElement("div");
-  heading.dataset.testid = "planet-info-heading";
-  heading.textContent = "Planet Info";
-  heading.style.fontWeight = "bold";
+  const heading = el("div", {
+    testid: "planet-info-heading",
+    text: "Planet Info",
+    style: { fontWeight: "bold" },
+  });
   applyBaseText(heading);
-  header.appendChild(heading);
 
-  const toggleBtn = document.createElement("button");
-  toggleBtn.dataset.testid = "planet-info-toggle";
-  toggleBtn.textContent = "▾";
-  toggleBtn.style.background = "none";
-  toggleBtn.style.border = "none";
-  toggleBtn.style.color = TEXT_COLOR;
-  toggleBtn.style.cursor = "pointer";
-  toggleBtn.style.fontSize = "14px";
-  toggleBtn.style.padding = "0 2px";
-  header.appendChild(toggleBtn);
+  const toggleBtn = el("button", {
+    testid: "planet-info-toggle",
+    text: "▾",
+    style: {
+      background: "none",
+      border: "none",
+      color: TEXT_COLOR,
+      cursor: "pointer",
+      fontSize: "14px",
+      padding: "0 2px",
+    },
+  });
 
-  section.appendChild(header);
-
-  // Collapsible body
-  const body = document.createElement("div");
-  body.dataset.testid = "planet-info-body";
+  const body = el("div", {
+    testid: "planet-info-body",
+    children: bodies.map((b) => buildRow(b, lat, lon, time, onSelect, onShowTrail, trailBodyId)),
+  });
 
   let collapsed = false;
   toggleBtn.addEventListener("click", () => {
@@ -76,110 +185,19 @@ export function createPlanetInfo(
     toggleBtn.textContent = collapsed ? "▸" : "▾";
   });
 
-  // Build a row for each body
-  for (const celestialBody of bodies) {
-    const riseSet = computeRiseSet(celestialBody.id, lat, lon, time);
-
-    const row = document.createElement("div");
-    row.dataset.testid = "planet-info-row";
-    row.style.marginBottom = "6px";
-    row.style.paddingBottom = "6px";
-    row.style.borderBottom = "1px solid rgba(255,255,255,0.08)";
-
-    // Name row
-    const nameRow = document.createElement("div");
-    nameRow.style.display = "flex";
-    nameRow.style.justifyContent = "space-between";
-    nameRow.style.alignItems = "center";
-
-    const nameEl = document.createElement("span");
-    nameEl.dataset.testid = "planet-name";
-    nameEl.textContent = celestialBody.id;
-    nameEl.style.color = celestialBody.color;
-    nameEl.style.fontWeight = "bold";
-    nameEl.style.fontSize = "12px";
-    nameEl.style.fontFamily = "sans-serif";
-
-    if (celestialBody.alt > 0 && onSelect) {
-      nameEl.style.cursor = "pointer";
-      nameEl.style.textDecoration = "underline";
-      nameEl.addEventListener("click", () => {
-        onSelect(celestialBody.az, celestialBody.alt);
-      });
-    }
-
-    nameRow.appendChild(nameEl);
-
-    // Below-horizon indicator
-    if (celestialBody.alt <= 0) {
-      const indicator = document.createElement("span");
-      indicator.dataset.testid = "planet-below-horizon";
-      indicator.textContent = "↓ below";
-      indicator.style.color = "rgba(255,255,255,0.4)";
-      indicator.style.fontSize = "10px";
-      indicator.style.fontFamily = "sans-serif";
-      nameRow.appendChild(indicator);
-    }
-
-    row.appendChild(nameRow);
-
-    // Alt/Az row
-    const altAzEl = document.createElement("div");
-    altAzEl.dataset.testid = "planet-altaz";
-    altAzEl.textContent = formatAltAz(celestialBody.alt, celestialBody.az);
-    altAzEl.style.color = "rgba(255,255,255,0.65)";
-    altAzEl.style.fontSize = "11px";
-    altAzEl.style.fontFamily = "sans-serif";
-    altAzEl.style.marginTop = "2px";
-    row.appendChild(altAzEl);
-
-    // Rise/Set row
-    const riseSetRow = document.createElement("div");
-    riseSetRow.style.display = "flex";
-    riseSetRow.style.gap = "8px";
-    riseSetRow.style.marginTop = "2px";
-
-    const riseEl = document.createElement("span");
-    riseEl.dataset.testid = "planet-rise";
-    riseEl.textContent = `↑ ${formatHHMM(riseSet.rise)}`;
-    riseEl.style.color = ACCENT_COLOR;
-    riseEl.style.fontSize = "11px";
-    riseEl.style.fontFamily = "sans-serif";
-    riseSetRow.appendChild(riseEl);
-
-    const setEl = document.createElement("span");
-    setEl.dataset.testid = "planet-set";
-    setEl.textContent = `↓ ${formatHHMM(riseSet.set)}`;
-    setEl.style.color = "rgba(255,180,100,0.85)";
-    setEl.style.fontSize = "11px";
-    setEl.style.fontFamily = "sans-serif";
-    riseSetRow.appendChild(setEl);
-
-    row.appendChild(riseSetRow);
-
-    if (celestialBody.alt > 0 && onShowTrail) {
-      const trailBtn = document.createElement("button");
-      trailBtn.dataset.testid = "planet-show-trail";
-      const active = trailBodyId === celestialBody.id;
-      trailBtn.textContent = active ? "Hide path" : "Show path";
-      trailBtn.style.marginTop = "4px";
-      trailBtn.style.padding = "2px 6px";
-      trailBtn.style.fontSize = "11px";
-      trailBtn.style.fontFamily = "sans-serif";
-      trailBtn.style.background = active ? "rgba(100,160,255,0.25)" : SURFACE;
-      trailBtn.style.color = TEXT_COLOR;
-      trailBtn.style.border = "1px solid rgba(255,255,255,0.2)";
-      trailBtn.style.borderRadius = "3px";
-      trailBtn.style.cursor = "pointer";
-      trailBtn.addEventListener("click", () => {
-        onShowTrail(celestialBody.id);
-      });
-      row.appendChild(trailBtn);
-    }
-
-    body.appendChild(row);
-  }
-
-  section.appendChild(body);
-  return section;
+  return el("div", {
+    style: { marginBottom: GAP },
+    children: [
+      el("div", {
+        style: {
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          marginBottom: "4px",
+        },
+        children: [heading, toggleBtn],
+      }),
+      body,
+    ],
+  });
 }


### PR DESCRIPTION
## Summary

Two el() factory migrations bundled into one PR:

**`src/ui/layer-controls.ts`**
- Replaces imperative `createElement` + style setters with the `el()` factory.
- `appendToggleRow` / `appendOpacityRow` mutate-and-append helpers become pure `buildToggleRow` / `buildOpacityRow` builders.
- Language and skyculture `<select>` section builders collapse into a shared generic `buildSelectRow<T>` since their shapes are identical bar the dataset key + intent type.
- Dataset markers preserved: `data-layer`, `data-opacity`, `data-opacity-row`, `data-mag-label`, `data-mag`, `data-language`, `data-skyculture`.

**`src/ui/planet-info.ts`**
- Per-body row construction (name, below-horizon indicator, alt/az, rise/set times, show-path toggle) moves to a pure `buildRow` helper.
- Repeated style strings lifted to module-level `Partial<CSSStyleDeclaration>` constants.
- Testids preserved: `planet-info-heading`, `-toggle`, `-body`, `-row`, `planet-name`, `planet-below-horizon`, `planet-altaz`, `planet-rise`, `planet-set`, `planet-show-trail`.

Nineteenth and twentieth modules migrated under #253.

## Test plan

- [x] `pnpm typecheck && pnpm lint && pnpm format:check && pnpm test:cov && pnpm build`
- [x] Coverage: `layer-controls.ts` 100/100 (unchanged), `planet-info.ts` 100/95.65 (held)
- [x] All 54 affected specs pass (31 layer-controls + 23 planet-info).

https://claude.ai/code/session_014DzXBVSCw5T2nnQvQjJtzS