### PR TITLE
chore(ui): migrate empty-sky-popover.ts to el() factory (#253)

### DIFF
--- a/src/ui/empty-sky-popover.ts
+++ b/src/ui/empty-sky-popover.ts
@@ -1,4 +1,5 @@
 /* SPDX-License-Identifier: Apache-2.0 */
+import { el } from "./dom";
 import { FOV_PRESETS, type FovPresetId, isFovPresetId } from "../astro/fov-presets";
 import type { UIIntent } from "./index";
 
@@ -19,36 +20,85 @@ const CARD_OFFSET_PX = 16;
 const ESTIMATED_HEIGHT_PX = 160;
 const RETICLE_SIZE_PX = 28;
 
-const ROOT_STYLE =
-  "position:absolute;top:0;left:0;width:0;height:0;pointer-events:none;z-index:1200";
+const ROOT_STYLE: Partial<CSSStyleDeclaration> = {
+  position: "absolute",
+  top: "0",
+  left: "0",
+  width: "0",
+  height: "0",
+  pointerEvents: "none",
+  zIndex: "1200",
+  display: "none",
+};
 
-const CARD_STYLE =
-  "position:absolute;width:240px;background:rgba(10,20,40,0.96);color:#fff;" +
-  "font:12px/1.45 sans-serif;padding:10px 12px;border-radius:6px;" +
-  "border:1px solid rgba(100,160,255,0.8);pointer-events:auto;" +
-  "box-shadow:0 4px 16px rgba(0,0,0,0.5);box-sizing:border-box";
+const CARD_STYLE: Partial<CSSStyleDeclaration> = {
+  position: "absolute",
+  width: `${String(CARD_WIDTH_PX)}px`,
+  background: "rgba(10,20,40,0.96)",
+  color: "#fff",
+  font: "12px/1.45 sans-serif",
+  padding: "10px 12px",
+  borderRadius: "6px",
+  border: "1px solid rgba(100,160,255,0.8)",
+  pointerEvents: "auto",
+  boxShadow: "0 4px 16px rgba(0,0,0,0.5)",
+  boxSizing: "border-box",
+};
 
-const RETICLE_STYLE =
-  `position:absolute;width:${String(RETICLE_SIZE_PX)}px;height:${String(RETICLE_SIZE_PX)}px;` +
-  "transform:translate(-50%,-50%);border:1.5px solid rgba(255,200,80,0.9);" +
-  "border-radius:50%;pointer-events:none;box-shadow:0 0 8px rgba(255,200,80,0.35)";
+const RETICLE_STYLE: Partial<CSSStyleDeclaration> = {
+  position: "absolute",
+  width: `${String(RETICLE_SIZE_PX)}px`,
+  height: `${String(RETICLE_SIZE_PX)}px`,
+  transform: "translate(-50%,-50%)",
+  border: "1.5px solid rgba(255,200,80,0.9)",
+  borderRadius: "50%",
+  pointerEvents: "none",
+  boxShadow: "0 0 8px rgba(255,200,80,0.35)",
+};
 
-const CLOSE_BTN_STYLE =
-  "background:none;border:none;color:rgba(255,255,255,0.7);cursor:pointer;" +
-  "font:16px/1 sans-serif;padding:0;margin:0 0 0 8px;line-height:1";
+const CLOSE_BTN_STYLE: Partial<CSSStyleDeclaration> = {
+  background: "none",
+  border: "none",
+  color: "rgba(255,255,255,0.7)",
+  cursor: "pointer",
+  font: "16px/1 sans-serif",
+  padding: "0",
+  margin: "0 0 0 8px",
+  lineHeight: "1",
+};
 
-const LOOK_HERE_BTN_STYLE =
-  "background:rgba(100,160,255,0.2);border:1px solid rgba(100,160,255,0.7);" +
-  "border-radius:3px;color:#fff;cursor:pointer;font:11px/1.3 sans-serif;" +
-  "padding:4px 10px;margin:0";
+const LOOK_HERE_BTN_STYLE: Partial<CSSStyleDeclaration> = {
+  background: "rgba(100,160,255,0.2)",
+  border: "1px solid rgba(100,160,255,0.7)",
+  borderRadius: "3px",
+  color: "#fff",
+  cursor: "pointer",
+  font: "11px/1.3 sans-serif",
+  padding: "4px 10px",
+  margin: "0",
+};
 
-const FOV_ROW_STYLE = "display:flex;align-items:center;gap:6px;margin-top:8px";
+const FOV_ROW_STYLE: Partial<CSSStyleDeclaration> = {
+  display: "flex",
+  alignItems: "center",
+  gap: "6px",
+  marginTop: "8px",
+};
 
-const FOV_LABEL_STYLE = "color:rgba(255,255,255,0.6);font:11px sans-serif";
+const FOV_LABEL_STYLE: Partial<CSSStyleDeclaration> = {
+  color: "rgba(255,255,255,0.6)",
+  font: "11px sans-serif",
+};
 
-const FOV_SELECT_STYLE =
-  "flex:1;background:rgba(255,255,255,0.1);color:#fff;border:1px solid rgba(255,255,255,0.2);" +
-  "border-radius:4px;padding:3px;font:11px sans-serif";
+const FOV_SELECT_STYLE: Partial<CSSStyleDeclaration> = {
+  flex: "1",
+  background: "rgba(255,255,255,0.1)",
+  color: "#fff",
+  border: "1px solid rgba(255,255,255,0.2)",
+  borderRadius: "4px",
+  padding: "3px",
+  font: "11px sans-serif",
+};
 
 /** Smart edge-flip placement matching the object-card idiom. */
 function smartPosition(
@@ -80,83 +130,82 @@ function viewport(): { width: number; height: number } {
 }
 
 export function createEmptySkyPopover(opts: EmptySkyPopoverOptions): EmptySkyPopover {
-  const root = document.createElement("div");
-  root.dataset.testid = "empty-sky-popover-root";
-  root.style.cssText = ROOT_STYLE;
-  root.style.display = "none";
-
   // Reticle — tiny crosshair circle at the click point.
-  const reticle = document.createElement("div");
-  reticle.dataset.testid = "empty-sky-popover-reticle";
-  reticle.style.cssText = RETICLE_STYLE;
-  root.appendChild(reticle);
-
-  // Card — floating panel with readout, "Look here", FOV select, and close button.
-  const card = document.createElement("div");
-  card.dataset.testid = "empty-sky-popover-card";
-  card.style.cssText = CARD_STYLE;
-  root.appendChild(card);
+  const reticle = el("div", {
+    testid: "empty-sky-popover-reticle",
+    style: RETICLE_STYLE,
+  });
 
   // Header: title + close button
-  const header = document.createElement("div");
-  header.style.cssText = "display:flex;justify-content:space-between;align-items:flex-start";
+  const closeBtn = el("button", {
+    testid: "empty-sky-popover-close",
+    type: "button",
+    text: "×",
+    attrs: { title: "Close" },
+    style: CLOSE_BTN_STYLE,
+  });
 
-  const title = document.createElement("div");
-  title.textContent = "Empty sky";
-  title.style.cssText = "font-weight:bold;font-size:13px";
-  header.appendChild(title);
-
-  const closeBtn = document.createElement("button");
-  closeBtn.dataset.testid = "empty-sky-popover-close";
-  closeBtn.type = "button";
-  closeBtn.textContent = "\u00D7";
-  closeBtn.title = "Close";
-  closeBtn.style.cssText = CLOSE_BTN_STYLE;
-  header.appendChild(closeBtn);
-
-  card.appendChild(header);
+  const header = el("div", {
+    style: { display: "flex", justifyContent: "space-between", alignItems: "flex-start" },
+    children: [
+      el("div", { text: "Empty sky", style: { fontWeight: "bold", fontSize: "13px" } }),
+      closeBtn,
+    ],
+  });
 
   // Readout — live alt/az text.
-  const readout = document.createElement("div");
-  readout.dataset.testid = "empty-sky-popover-readout";
-  readout.style.cssText =
-    "margin-top:4px;color:rgba(255,255,255,0.85);font:11px monospace;font-family:monospace";
-  card.appendChild(readout);
+  const readout = el("div", {
+    testid: "empty-sky-popover-readout",
+    style: {
+      marginTop: "4px",
+      color: "rgba(255,255,255,0.85)",
+      font: "11px monospace",
+      fontFamily: "monospace",
+    },
+  });
 
   // "Look here" action row.
-  const actionRow = document.createElement("div");
-  actionRow.style.cssText = "margin-top:8px;display:flex;gap:6px";
+  const lookHereBtn = el("button", {
+    testid: "empty-sky-popover-look-here",
+    type: "button",
+    text: "Look here",
+    style: LOOK_HERE_BTN_STYLE,
+  });
 
-  const lookHereBtn = document.createElement("button");
-  lookHereBtn.dataset.testid = "empty-sky-popover-look-here";
-  lookHereBtn.type = "button";
-  lookHereBtn.textContent = "Look here";
-  lookHereBtn.style.cssText = LOOK_HERE_BTN_STYLE;
-  actionRow.appendChild(lookHereBtn);
-
-  card.appendChild(actionRow);
+  const actionRow = el("div", {
+    style: { marginTop: "8px", display: "flex", gap: "6px" },
+    children: [lookHereBtn],
+  });
 
   // FOV preset selector — same options as the settings-drawer dropdown.
-  const fovRow = document.createElement("div");
-  fovRow.style.cssText = FOV_ROW_STYLE;
-
-  const fovLabel = document.createElement("label");
-  fovLabel.textContent = "FOV";
-  fovLabel.style.cssText = FOV_LABEL_STYLE;
-  fovRow.appendChild(fovLabel);
-
-  const fovSelect = document.createElement("select");
-  fovSelect.dataset.fov = "preset";
-  fovSelect.style.cssText = FOV_SELECT_STYLE;
-  for (const preset of FOV_PRESETS) {
-    const option = document.createElement("option");
-    option.value = preset.id;
-    option.textContent = preset.label;
-    fovSelect.appendChild(option);
-  }
+  const fovSelect = el("select", {
+    dataset: { fov: "preset" },
+    style: FOV_SELECT_STYLE,
+    children: FOV_PRESETS.map((preset) => {
+      const option = el("option", { text: preset.label });
+      option.value = preset.id;
+      return option;
+    }),
+  });
   fovSelect.value = opts.initialFov;
-  fovRow.appendChild(fovSelect);
-  card.appendChild(fovRow);
+
+  const fovRow = el("div", {
+    style: FOV_ROW_STYLE,
+    children: [el("label", { text: "FOV", style: FOV_LABEL_STYLE }), fovSelect],
+  });
+
+  // Card — floating panel with readout, "Look here", FOV select, and close button.
+  const card = el("div", {
+    testid: "empty-sky-popover-card",
+    style: CARD_STYLE,
+    children: [header, readout, actionRow, fovRow],
+  });
+
+  const root = el("div", {
+    testid: "empty-sky-popover-root",
+    style: ROOT_STYLE,
+    children: [reticle, card],
+  });
 
   // Internal state — track the latest click so "Look here" knows where to aim.
   let open = false;
@@ -164,7 +213,7 @@ export function createEmptySkyPopover(opts: EmptySkyPopoverOptions): EmptySkyPop
   let currentAz = 0;
 
   function setReadout(alt: number, az: number): void {
-    readout.textContent = `Alt ${alt.toFixed(1)}\u00B0  Az ${az.toFixed(1)}\u00B0`;
+    readout.textContent = `Alt ${alt.toFixed(1)}°  Az ${az.toFixed(1)}°`;
   }
 
   function placeReticle(x: number, y: number): void {
@@ -212,9 +261,8 @@ export function createEmptySkyPopover(opts: EmptySkyPopoverOptions): EmptySkyPop
   });
 
   fovSelect.addEventListener("change", () => {
-    const value = fovSelect.value;
-    if (!isFovPresetId(value)) return;
-    opts.dispatch({ type: "set-fov", preset: value });
+    if (!isFovPresetId(fovSelect.value)) return;
+    opts.dispatch({ type: "set-fov", preset: fovSelect.value });
   });
 
   document.addEventListener("keydown", (e) => {


### PR DESCRIPTION
## Summary

- Migrates `src/ui/empty-sky-popover.ts` from imperative `createElement` + `cssText` setters to the declarative `el()` factory.
- Each `cssText` string converted to a `Partial<CSSStyleDeclaration>` constant per role (root, card, reticle, close btn, look-here btn, FOV row/label/select).
- DOM shape, testids (`empty-sky-popover-root`, `-reticle`, `-card`, `-close`, `-readout`, `-look-here`), the `[data-fov="preset"]` marker, and all behaviour (smart-position card placement with edge flip, Escape-to-close, Look-here dispatches `set-view`, FOV change dispatches `set-fov`) are unchanged.
- Twenty-fourth module migrated under #253.

## Test plan

- [x] `pnpm typecheck && pnpm lint && pnpm format:check && pnpm test:cov && pnpm build`
- [x] `empty-sky-popover.ts` coverage: 99.09 / 73.07 (lines ticked up slightly from 98.75).
- [x] All 14 `empty-sky-popover` specs pass.

https://claude.ai/code/session_014DzXBVSCw5T2nnQvQjJtzS