### PR TITLE
chore(ui): migrate final createElement sites to el() factory (#253)

### DIFF
--- a/src/ui/notebook-editor.ts
+++ b/src/ui/notebook-editor.ts
@@ -2,6 +2,7 @@
 import { Editor, type Content } from "@tiptap/core";
 import StarterKit from "@tiptap/starter-kit";
 import { createNotebookMentionExtension } from "./notebook-mention";
+import { el } from "./dom";
 import { BORDER_SUBTLE, FONT_FAMILY, SURFACE_LOW, TEXT_COLOR } from "./styles";
 
 /**
@@ -53,20 +54,23 @@ function parseOrNull(s: string | undefined): Content {
 export function createNotebookEditor(options: NotebookEditorOptions): NotebookEditor {
   const { container, initialContent, onChange } = options;
 
-  const host = document.createElement("div");
-  host.dataset.testid = "notebook-editor";
-  host.style.flex = "1 1 auto";
-  host.style.minHeight = "200px";
-  host.style.background = SURFACE_LOW;
-  host.style.border = BORDER_SUBTLE;
-  host.style.borderRadius = "6px";
-  host.style.color = TEXT_COLOR;
-  host.style.fontFamily = FONT_FAMILY;
-  host.style.fontSize = "13px";
-  host.style.padding = "10px 12px";
-  host.style.boxSizing = "border-box";
-  host.style.overflowY = "auto";
-  container.appendChild(host);
+  const host = el("div", {
+    testid: "notebook-editor",
+    style: {
+      flex: "1 1 auto",
+      minHeight: "200px",
+      background: SURFACE_LOW,
+      border: BORDER_SUBTLE,
+      borderRadius: "6px",
+      color: TEXT_COLOR,
+      fontFamily: FONT_FAMILY,
+      fontSize: "13px",
+      padding: "10px 12px",
+      boxSizing: "border-box",
+      overflowY: "auto",
+    },
+  });
+  container.append(host);
 
   const initialDoc: Content = parseOrNull(initialContent) ?? parseOrNull(EMPTY_DOC_JSON);
 

--- a/src/ui/panel.ts
+++ b/src/ui/panel.ts
@@ -184,14 +184,14 @@ export function createPanel(
         void navigator.clipboard.writeText(text);
       } else {
         // Fallback for older browsers
-        const textarea = document.createElement("textarea");
+        const textarea = el("textarea", {
+          style: { position: "fixed", opacity: "0" },
+        });
         textarea.value = text;
-        textarea.style.position = "fixed";
-        textarea.style.opacity = "0";
-        document.body.appendChild(textarea);
+        document.body.append(textarea);
         textarea.select();
         document.execCommand("copy");
-        document.body.removeChild(textarea);
+        textarea.remove();
       }
     };
     copy(url);


### PR DESCRIPTION
## Summary

Mop-up pass for #253 — the last two production files under `src/ui/` still using `document.createElement` after the object-card migration landed.

- **`src/ui/notebook-editor.ts`** — the tiptap host `<div>` is now built via `el()`, with the existing `BORDER_SUBTLE` / `SURFACE_LOW` / `TEXT_COLOR` / `FONT_FAMILY` palette imports consolidated into a single `style` object.
- **`src/ui/panel.ts`** — the `<textarea>` created inside the clipboard fallback (used when `navigator.clipboard` is unavailable) is built via `el()`, and the detach uses `.remove()` instead of `document.body.removeChild`.

After this, every production file under `src/ui/` (excluding `dom.ts` and `styles.ts`, which *define* the factory and palette) is free of `document.createElement`. DOM shape, testids, and behaviour are unchanged.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm format:check` — clean
- [x] `pnpm test:cov` — 1235/1235 pass, coverage thresholds hold
- [x] `pnpm build` — succeeds

https://claude.ai/code/session_planisphere-open-issues-QFuWY

---
_Generated by [Claude Code](https://claude.ai/code/session_01VKmj4YQnxN8sydc7X6v2ra)_