### PR TITLE
docs(app): align onboarding tour copy with refreshed user guide

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1331,13 +1331,13 @@ export async function bootstrap(
     },
     {
       title: "Drag the time bar to move through time",
-      body: "The bottom bar shows the current time. Drag it left or right to scrub, or use the ← / → arrow keys.",
+      body: "The bottom bar shows the current time. Drag it left or right to scrub, or use ← / → for one-minute steps — hold Shift for hours, Alt for days. Space plays real-time.",
       selector: "[data-testid='hud-scrub']",
       position: "top",
     },
     {
       title: "Explore with the top-right icons",
-      body: "Tap \u2699 for layer settings, \u{1F4C5} for upcoming events, \u2640 for tonight's planets, and ? for help.",
+      body: "Tap \u2699 for layer settings, \u{1F4C5} for upcoming events, \u2640 for tonight's planets, ? for help, and \u{1F303}/\u{1F4D3} to switch to Notebook mode (Pro). \u{1F534} toggles night vision.",
       selector: "[data-testid='panel-header']",
       position: "left",
     },


### PR DESCRIPTION
## Summary

Follow-up to #289 / #293. The refreshed user guide now documents:

- `Shift` / `Alt` modifiers on the time arrow keys, and `Space` to toggle real-time animation.
- The 🌃/📓 Notebook-mode toggle and 🔴 night-vision button in the top-right icon rail.

The first-load onboarding tour described neither. This PR patches step 2 ("Drag the time bar…") and step 3 ("Explore with the top-right icons…") so new users see the same story whether they skim the tour or open the Help modal.

Copy-only change — same 5 steps, same selectors, same positions. Existing onboarding tests assert structure (step count, selectors), not prose.

## Test plan

- [x] \`pnpm typecheck\`
- [x] \`pnpm lint\`
- [x] \`pnpm format:check\`
- [x] \`pnpm test:cov\` — 1235/1235 pass
- [x] \`pnpm build\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)