### PR TITLE
exp(scene): scroll wheel pans alt/az (Cmd+wheel keeps zoom)

### DIFF
--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -674,7 +674,7 @@ describe("bootstrap", () => {
     document.body.removeChild(root);
   });
 
-  it("wheel gesture re-renders the reticle layer via onZoom", async () => {
+  it("wheel + double-click gestures bootstrap without throwing (exercises onZoom + resolveObjectAt)", async () => {
     capturedDispatch = null;
     const root = document.createElement("main");
     root.id = "app";
@@ -687,38 +687,49 @@ describe("bootstrap", () => {
     document.body.appendChild(root);
 
     const cesium = await import("cesium");
+    const viewerCtor = vi.mocked(cesium.Viewer);
     const handlerCtor = vi.mocked(cesium.ScreenSpaceEventHandler);
+    viewerCtor.mockClear();
     handlerCtor.mockClear();
 
     await bootstrap(root, new URLSearchParams({ fov: "naked-eye" }));
 
-    // Collect WHEEL handler across all ScreenSpaceEventHandler instances
+    // Wheel listener now lives on the canvas DOM element (no longer routed
+    // through Cesium's ScreenSpaceEventHandler). Dispatch a real WheelEvent
+    // on the viewer's canvas to exercise the pan + zoom paths.
+    const viewer = viewerCtor.mock.results[0]!.value as { scene: { canvas: HTMLCanvasElement } };
+    const canvas = viewer.scene.canvas;
+    expect(() =>
+      canvas.dispatchEvent(
+        new WheelEvent("wheel", { deltaX: 0, deltaY: -100, ctrlKey: true, cancelable: true }),
+      ),
+    ).not.toThrow();
+    expect(() =>
+      canvas.dispatchEvent(
+        new WheelEvent("wheel", { deltaX: 5, deltaY: 5, ctrlKey: false, cancelable: true }),
+      ),
+    ).not.toThrow();
+
+    // LEFT_DOUBLE_CLICK is still wired through Cesium's ScreenSpaceEventHandler.
     const handlers = handlerCtor.mock.results.map(
       (r) => r.value as { setInputAction: ReturnType<typeof vi.fn> },
     );
-    let wheelFn: ((delta: number) => void) | null = null;
     let doubleClickFn: ((ev: { position: { x: number; y: number } }) => void) | null = null;
     for (const h of handlers) {
       for (const call of h.setInputAction.mock.calls) {
         const [fn, type] = call as [unknown, unknown];
-        if (type === cesium.ScreenSpaceEventType.WHEEL) {
-          wheelFn = fn as (delta: number) => void;
-        }
         if (type === cesium.ScreenSpaceEventType.LEFT_DOUBLE_CLICK) {
           doubleClickFn = fn as (ev: { position: { x: number; y: number } }) => void;
         }
       }
     }
-    expect(wheelFn).not.toBeNull();
     expect(doubleClickFn).not.toBeNull();
-    // Fire them — exercises resolveObjectAt, getObserver, onZoom callbacks in app.ts
-    expect(() => wheelFn!(-100)).not.toThrow();
     expect(() => doubleClickFn!({ position: { x: 100, y: 100 } })).not.toThrow();
 
     document.body.removeChild(root);
   });
 
-  it("registers gesture handlers (WHEEL, LEFT_DOUBLE_CLICK) on bootstrap", async () => {
+  it("registers gesture handlers (canvas wheel + LEFT_DOUBLE_CLICK) on bootstrap", async () => {
     capturedDispatch = null;
     const root = document.createElement("main");
     root.id = "app";
@@ -731,19 +742,29 @@ describe("bootstrap", () => {
     document.body.appendChild(root);
 
     const cesium = await import("cesium");
+    const viewerCtor = vi.mocked(cesium.Viewer);
     const handlerCtor = vi.mocked(cesium.ScreenSpaceEventHandler);
+    viewerCtor.mockClear();
     handlerCtor.mockClear();
 
     await bootstrap(root);
 
-    // Collect every event type registered across all ScreenSpaceEventHandler instances
+    // Wheel handler lives on the canvas now — spy on addEventListener via
+    // dispatching an event and asserting cancelable behavior implies a
+    // listener handled it. Cleaner: verify by dispatching a plain wheel event
+    // and confirming preventDefault was honored.
+    const viewer = viewerCtor.mock.results[0]!.value as { scene: { canvas: HTMLCanvasElement } };
+    const wheelEvent = new WheelEvent("wheel", { deltaY: 1, cancelable: true });
+    viewer.scene.canvas.dispatchEvent(wheelEvent);
+    expect(wheelEvent.defaultPrevented).toBe(true);
+
+    // LEFT_DOUBLE_CLICK still goes through ScreenSpaceEventHandler.
     const handlers = handlerCtor.mock.results.map(
       (r) => r.value as { setInputAction: ReturnType<typeof vi.fn> },
     );
     const allEvents: unknown[] = handlers.flatMap((h) =>
       h.setInputAction.mock.calls.map((c: unknown[]) => c[1]),
     );
-    expect(allEvents).toContain(cesium.ScreenSpaceEventType.WHEEL);
     expect(allEvents).toContain(cesium.ScreenSpaceEventType.LEFT_DOUBLE_CLICK);
     document.body.removeChild(root);
   });

--- a/src/scene/camera.test.ts
+++ b/src/scene/camera.test.ts
@@ -88,7 +88,13 @@ function makeViewer(fovy = Math.PI / 3): Viewer {
   return {
     scene: {
       screenSpaceCameraController: controller,
-      canvas: { clientWidth: 800, clientHeight: 600 } as unknown as HTMLCanvasElement,
+      canvas: {
+        clientWidth: 800,
+        clientHeight: 600,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      } as unknown as HTMLCanvasElement,
       camera,
       pick: vi.fn().mockReturnValue(undefined),
     },
@@ -236,14 +242,17 @@ describe("setupGestures", () => {
     vi.useRealTimers();
   });
 
-  it("registers a WHEEL handler for scroll-wheel zoom", () => {
+  it("registers a wheel listener on the canvas (alt/az pan with Cmd-zoom)", () => {
     const viewer = makeViewer();
     setupGestures(viewer, {
       getObserver: () => ({ lat: 0, lon: 0 }),
       resolveObjectAt: () => null,
     });
-    const registeredEvents = mockSetInputAction.mock.calls.map((call: unknown[]) => call[1]);
-    expect(registeredEvents).toContain("WHEEL");
+    const addEventListener = (
+      viewer.scene.canvas as unknown as { addEventListener: { mock: { calls: unknown[][] } } }
+    ).addEventListener;
+    const wheelCalls = addEventListener.mock.calls.filter((c: unknown[]) => c[0] === "wheel");
+    expect(wheelCalls).toHaveLength(1);
   });
 
   it("registers a LEFT_DOUBLE_CLICK handler", () => {
@@ -256,27 +265,98 @@ describe("setupGestures", () => {
     expect(registeredEvents).toContain("LEFT_DOUBLE_CLICK");
   });
 
-  it("wheel zoom clamps FOV within [FOV_MIN_DEG, FOV_MAX_DEG]", () => {
+  it("Cmd/Ctrl+wheel zoom clamps FOV within [FOV_MIN_DEG, FOV_MAX_DEG]", () => {
     const viewer = makeViewer(Math.PI / 3); // 60 deg
     setupGestures(viewer, {
       getObserver: () => ({ lat: 0, lon: 0 }),
       resolveObjectAt: () => null,
     });
-    // Find the wheel handler
-    const wheelCall = mockSetInputAction.mock.calls.find((c: unknown[]) => c[1] === "WHEEL") as
-      | [(delta: number) => void, string]
+    const addEventListener = (
+      viewer.scene.canvas as unknown as { addEventListener: { mock: { calls: unknown[][] } } }
+    ).addEventListener;
+    const wheelCall = addEventListener.mock.calls.find((c: unknown[]) => c[0] === "wheel") as
+      | [string, (e: WheelEvent) => void, AddEventListenerOptions]
       | undefined;
     expect(wheelCall).toBeDefined();
-    const wheelHandler = wheelCall![0];
-    // Huge negative delta (user scrolls up, zoom in) — clamp at min
-    for (let i = 0; i < 1000; i++) wheelHandler(-1000);
+    const wheelHandler = wheelCall![1];
+    const make = (deltaY: number) =>
+      ({
+        deltaX: 0,
+        deltaY,
+        ctrlKey: true,
+        metaKey: false,
+        preventDefault: () => undefined,
+      }) as unknown as WheelEvent;
+    // Huge negative delta — clamp at min
+    for (let i = 0; i < 1000; i++) wheelHandler(make(-1000));
     const frustum = viewer.camera.frustum as { fovy: number };
     const fovDeg = (frustum.fovy * 180) / Math.PI;
     expect(fovDeg).toBeGreaterThanOrEqual(1 - 1e-6);
-    // Huge positive delta (scroll down, zoom out) — clamp at max
-    for (let i = 0; i < 1000; i++) wheelHandler(1000);
+    // Huge positive delta — clamp at max
+    for (let i = 0; i < 1000; i++) wheelHandler(make(1000));
     const fovDeg2 = ((viewer.camera.frustum as { fovy: number }).fovy * 180) / Math.PI;
     expect(fovDeg2).toBeLessThanOrEqual(120 + 1e-6);
+  });
+
+  it("plain wheel pans alt/az (no FOV change)", () => {
+    const viewer = makeViewer(Math.PI / 3);
+    setupGestures(viewer, {
+      getObserver: () => ({ lat: 40, lon: -74 }),
+      resolveObjectAt: () => null,
+    });
+    const addEventListener = (
+      viewer.scene.canvas as unknown as { addEventListener: { mock: { calls: unknown[][] } } }
+    ).addEventListener;
+    const wheelCall = addEventListener.mock.calls.find((c: unknown[]) => c[0] === "wheel") as
+      | [string, (e: WheelEvent) => void, AddEventListenerOptions]
+      | undefined;
+    const wheelHandler = wheelCall![1];
+    const setView = (viewer.camera as unknown as { setView: ReturnType<typeof vi.fn> }).setView;
+    setView.mockClear();
+    const fovBefore = (viewer.camera.frustum as { fovy: number }).fovy;
+    wheelHandler({
+      deltaX: 0,
+      deltaY: 100,
+      ctrlKey: false,
+      metaKey: false,
+      preventDefault: () => undefined,
+    } as unknown as WheelEvent);
+    expect(setView).toHaveBeenCalled();
+    expect((viewer.camera.frustum as { fovy: number }).fovy).toBe(fovBefore);
+  });
+
+  it("plain wheel altitude is clamped to [-89.9, 89.9]", () => {
+    const viewer = makeViewer();
+    // Camera "looks up" near zenith so big negative deltaY would push past 90.
+    (viewer.camera as unknown as { pitch: number; heading: number }).pitch = (89.5 * Math.PI) / 180;
+    (viewer.camera as unknown as { heading: number }).heading = 0;
+    setupGestures(viewer, {
+      getObserver: () => ({ lat: 0, lon: 0 }),
+      resolveObjectAt: () => null,
+    });
+    const addEventListener = (
+      viewer.scene.canvas as unknown as { addEventListener: { mock: { calls: unknown[][] } } }
+    ).addEventListener;
+    const wheelHandler = (
+      addEventListener.mock.calls.find((c: unknown[]) => c[0] === "wheel") as [
+        string,
+        (e: WheelEvent) => void,
+      ]
+    )[1];
+    const setView = (viewer.camera as unknown as { setView: ReturnType<typeof vi.fn> }).setView;
+    setView.mockClear();
+    // Big negative deltaY (drag world up = look up) tries to push alt past 90
+    wheelHandler({
+      deltaX: 0,
+      deltaY: -10_000,
+      ctrlKey: false,
+      metaKey: false,
+      preventDefault: () => undefined,
+    } as unknown as WheelEvent);
+    const lastCall = setView.mock.calls[setView.mock.calls.length - 1] as [
+      { orientation: { pitch: number } },
+    ];
+    expect(lastCall[0].orientation.pitch).toBeLessThanOrEqual((89.9 * Math.PI) / 180 + 1e-6);
   });
 
   it("double-tap with no picked object resets view toward zenith", () => {
@@ -330,7 +410,7 @@ describe("setupGestures", () => {
     expect(mockHandlerDestroy).toHaveBeenCalled();
   });
 
-  it("invokes onZoom callback after a wheel event (so caller can re-render reticle)", () => {
+  it("invokes onZoom callback after a Cmd/Ctrl+wheel event (so caller can re-render reticle)", () => {
     const viewer = makeViewer();
     const onZoom = vi.fn();
     setupGestures(viewer, {
@@ -338,11 +418,50 @@ describe("setupGestures", () => {
       resolveObjectAt: () => null,
       onZoom,
     });
-    const wheelCall = mockSetInputAction.mock.calls.find((c: unknown[]) => c[1] === "WHEEL") as
-      | [(delta: number) => void, string]
-      | undefined;
-    wheelCall![0](-100);
+    const addEventListener = (
+      viewer.scene.canvas as unknown as { addEventListener: { mock: { calls: unknown[][] } } }
+    ).addEventListener;
+    const wheelHandler = (
+      addEventListener.mock.calls.find((c: unknown[]) => c[0] === "wheel") as [
+        string,
+        (e: WheelEvent) => void,
+      ]
+    )[1];
+    wheelHandler({
+      deltaX: 0,
+      deltaY: -100,
+      ctrlKey: true,
+      metaKey: false,
+      preventDefault: () => undefined,
+    } as unknown as WheelEvent);
     expect(onZoom).toHaveBeenCalled();
+  });
+
+  it("does NOT invoke onZoom on a plain (no-modifier) wheel event", () => {
+    const viewer = makeViewer();
+    const onZoom = vi.fn();
+    setupGestures(viewer, {
+      getObserver: () => ({ lat: 0, lon: 0 }),
+      resolveObjectAt: () => null,
+      onZoom,
+    });
+    const addEventListener = (
+      viewer.scene.canvas as unknown as { addEventListener: { mock: { calls: unknown[][] } } }
+    ).addEventListener;
+    const wheelHandler = (
+      addEventListener.mock.calls.find((c: unknown[]) => c[0] === "wheel") as [
+        string,
+        (e: WheelEvent) => void,
+      ]
+    )[1];
+    wheelHandler({
+      deltaX: 0,
+      deltaY: -100,
+      ctrlKey: false,
+      metaKey: false,
+      preventDefault: () => undefined,
+    } as unknown as WheelEvent);
+    expect(onZoom).not.toHaveBeenCalled();
   });
 
   it("PINCH_MOVE with fingers apart (bigger distance) zooms in (smaller FOV)", () => {

--- a/src/scene/camera.ts
+++ b/src/scene/camera.ts
@@ -134,6 +134,23 @@ export type GestureHandle = {
 /** Wheel-zoom sensitivity: multiplicative factor per "unit" of wheel delta. */
 const WHEEL_ZOOM_FACTOR = 1.0015;
 
+/** Wheel-pan sensitivity: degrees of altitude/azimuth per pixel of wheel delta. */
+const WHEEL_PAN_DEG_PER_PX = 0.1;
+
+/** Hard altitude clamp — Cesium pitch becomes degenerate at exactly 90°. */
+const ALT_MAX_DEG = 89.9;
+const ALT_MIN_DEG = -89.9;
+
+function getCameraPitchDeg(camera: Camera): number {
+  const p = (camera as { pitch?: unknown }).pitch;
+  if (typeof p !== "number" || !Number.isFinite(p)) return 0;
+  return CesiumMath.toDegrees(p);
+}
+
+function wrapAz(deg: number): number {
+  return ((deg % 360) + 360) % 360;
+}
+
 function getCameraFovDeg(camera: Camera): number {
   const frustum = camera.frustum as { fovy?: number; fov?: number };
   const rad =
@@ -156,18 +173,69 @@ export function setupGestures(viewer: Viewer, options: GestureOptions): GestureH
   const { scene, camera } = viewer;
   const handler = new ScreenSpaceEventHandler(scene.canvas);
 
-  // --- Scroll-wheel / pinch zoom -------------------------------------------
-  function applyWheelDelta(delta: number): void {
+  // --- Scroll-wheel ---------------------------------------------------------
+  // EXPERIMENT (exp/altaz-scroll-controls): scroll now pans the view in alt/az
+  // instead of zooming. Cmd/Ctrl + scroll keeps the old zoom-FOV behavior so
+  // zoom remains reachable while we evaluate the scroll-to-pan UX.
+  function applyWheelZoom(delta: number): void {
     const current = getCameraFovDeg(camera);
-    // Positive delta -> zoom out (bigger FOV); negative -> zoom in.
     const next = clampFov(current * Math.pow(WHEEL_ZOOM_FACTOR, delta));
     setCameraFovDeg(camera, next);
     options.onZoom?.();
   }
 
-  handler.setInputAction((delta: number) => {
-    applyWheelDelta(delta);
-  }, ScreenSpaceEventType.WHEEL);
+  function applyWheelPan(deltaXPx: number, deltaYPx: number): void {
+    const { lat, lon } = options.getObserver();
+    const currentAz = getCameraHeadingDeg(camera);
+    const currentAlt = getCameraPitchDeg(camera);
+    // "Steer the camera" feel:
+    // deltaY positive = scroll down = look down = alt decreases.
+    // deltaX positive = scroll right = look right = az increases.
+    const nextAlt = Math.min(
+      ALT_MAX_DEG,
+      Math.max(ALT_MIN_DEG, currentAlt - deltaYPx * WHEEL_PAN_DEG_PER_PX),
+    );
+    const nextAz = wrapAz(currentAz + deltaXPx * WHEEL_PAN_DEG_PER_PX);
+    setCameraView(camera, lat, lon, nextAz, nextAlt);
+  }
+
+  // Track the last cursor position so we can re-fire a synthetic mousemove
+  // after a scroll-driven camera change. The hover-tooltip subsystem
+  // (scene/tooltip.ts) only re-picks on MOUSE_MOVE — without this the tooltip
+  // becomes stale (or appears broken) as the world slides under a stationary
+  // cursor during scroll.
+  let lastClientX = 0;
+  let lastClientY = 0;
+  function onMouseMoveTrack(e: MouseEvent): void {
+    lastClientX = e.clientX;
+    lastClientY = e.clientY;
+  }
+  scene.canvas.addEventListener("mousemove", onMouseMoveTrack);
+
+  function refireMouseMove(): void {
+    scene.canvas.dispatchEvent(
+      new MouseEvent("mousemove", {
+        clientX: lastClientX,
+        clientY: lastClientY,
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
+  }
+
+  // Bypass Cesium's WHEEL action so we can read both deltaX (trackpad
+  // horizontal scroll) and deltaY off the raw DOM event.
+  function onWheel(e: WheelEvent): void {
+    e.preventDefault();
+    if (e.ctrlKey || e.metaKey) {
+      // Trackpad pinch-zoom and Cmd+wheel arrive as ctrlKey/metaKey + deltaY.
+      applyWheelZoom(e.deltaY);
+      return;
+    }
+    applyWheelPan(e.deltaX, e.deltaY);
+    refireMouseMove();
+  }
+  scene.canvas.addEventListener("wheel", onWheel, { passive: false });
 
   // Pinch zoom: Cesium fires PINCH_START with two finger positions
   // (TwoPointEvent) and PINCH_MOVE with current+previous positions
@@ -214,6 +282,8 @@ export function setupGestures(viewer: Viewer, options: GestureOptions): GestureH
   }, ScreenSpaceEventType.LEFT_DOUBLE_CLICK);
 
   function destroy(): void {
+    scene.canvas.removeEventListener("wheel", onWheel);
+    scene.canvas.removeEventListener("mousemove", onMouseMoveTrack);
     handler.destroy();
   }
 


### PR DESCRIPTION
## Summary

Experiment swapping scroll-wheel behavior on the sky canvas:

- **Plain wheel/trackpad scroll** → pan altitude (vertical) + azimuth (horizontal). Feels like steering a camera around the celestial sphere.
- **Cmd/Ctrl + wheel** (or trackpad pinch) → keeps the prior FOV zoom, so zoom stays reachable.
- Altitude clamps to `[-89.9°, 89.9°]` (option 1 from the offline brainstorm — the simplest "you can't quite reach exact zenith" approach; trade-off is a small dead spot at the pole).
- Sensitivity: `0.1° per wheel-pixel`, tunable via `WHEEL_PAN_DEG_PER_PX`.

Switched from Cesium's `ScreenSpaceEventType.WHEEL` (single scalar) to a raw DOM `wheel` listener on `scene.canvas` so we can read `deltaX` for trackpad horizontal scroll in addition to `deltaY`.

Hover tooltips kept working: after each scroll-driven `setCameraView`, dispatches a synthetic `mousemove` at the last known cursor position so `scene/tooltip.ts` re-picks under the moved sky. Without this, tooltips look frozen during scroll.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm format:check`
- [x] `pnpm test:cov` — 1300/1300 passing; project total **96.61% lines / 87.54% branches**; `src/scene/camera.ts` 98.81% / 93.33%; `src/app.ts` 91.16% / 77.6% (above the 70% gate).
- [x] `pnpm build`
- [x] `pnpm test:worker` — 103/103
- [ ] Manual feel: scroll-pan responsiveness, direction (currently scroll-down → look down), 89.9° pole stop, Cmd/Ctrl+wheel zoom still works on Mac and PC.

## Open questions for the experiment

1. Does the 0.1°/px sensitivity feel right, or should it be tied to current FOV (smaller FOV = finer pan)?
2. Is the "scroll = steer the camera" direction the keeper, or do users expect "scroll = drag the sky" (inverted)?
3. Is the 89.9° pole stop perceptible in real use? If yes, follow-up: option (2) from the brainstorm — auto-rotate-to-prime-meridian as alt → 90°.
4. Drag-pan is unchanged (still works for object-on-screen positioning). Are scroll-pan and drag-pan complementary or redundant?

🤖 Generated with [Claude Code](https://claude.com/claude-code)