### PR TITLE
fix(scene): restore hover popups (revert post-scroll synthetic mousemove)

### DIFF
--- a/src/scene/camera.ts
+++ b/src/scene/camera.ts
@@ -199,32 +199,17 @@ export function setupGestures(viewer: Viewer, options: GestureOptions): GestureH
     setCameraView(camera, lat, lon, nextAz, nextAlt);
   }
 
-  // Track the last cursor position so we can re-fire a synthetic mousemove
-  // after a scroll-driven camera change. The hover-tooltip subsystem
-  // (scene/tooltip.ts) only re-picks on MOUSE_MOVE — without this the tooltip
-  // becomes stale (or appears broken) as the world slides under a stationary
-  // cursor during scroll.
-  let lastClientX = 0;
-  let lastClientY = 0;
-  function onMouseMoveTrack(e: MouseEvent): void {
-    lastClientX = e.clientX;
-    lastClientY = e.clientY;
-  }
-  scene.canvas.addEventListener("mousemove", onMouseMoveTrack);
-
-  function refireMouseMove(): void {
-    scene.canvas.dispatchEvent(
-      new MouseEvent("mousemove", {
-        clientX: lastClientX,
-        clientY: lastClientY,
-        bubbles: true,
-        cancelable: true,
-      }),
-    );
-  }
-
   // Bypass Cesium's WHEEL action so we can read both deltaX (trackpad
   // horizontal scroll) and deltaY off the raw DOM event.
+  //
+  // NOTE: an earlier version of this handler also added a `mousemove` tracker
+  // and dispatched a synthetic mousemove after each scroll-driven camera
+  // change to keep the hover tooltip in sync with the moved sky. That
+  // synthetic event poisoned Cesium's MOUSE_MOVE pipeline (offsetX/offsetY
+  // aren't settable via MouseEvent init, so picks landed at (0,0) and
+  // subsequent hover tracking broke for planets/stars/satellites). Hover
+  // is now allowed to stay briefly stale during active scroll; it refreshes
+  // naturally on the next real cursor motion.
   function onWheel(e: WheelEvent): void {
     e.preventDefault();
     if (e.ctrlKey || e.metaKey) {
@@ -233,7 +218,6 @@ export function setupGestures(viewer: Viewer, options: GestureOptions): GestureH
       return;
     }
     applyWheelPan(e.deltaX, e.deltaY);
-    refireMouseMove();
   }
   scene.canvas.addEventListener("wheel", onWheel, { passive: false });
 
@@ -283,7 +267,6 @@ export function setupGestures(viewer: Viewer, options: GestureOptions): GestureH
 
   function destroy(): void {
     scene.canvas.removeEventListener("wheel", onWheel);
-    scene.canvas.removeEventListener("mousemove", onMouseMoveTrack);
     handler.destroy();
   }
 

--- a/src/scene/messier.ts
+++ b/src/scene/messier.ts
@@ -137,6 +137,13 @@ function generateMessierSprite(type: string): HTMLCanvasElement {
     ctx = null;
   }
   if (!ctx) return canvas;
+  // Fill the entire sprite with an effectively-invisible-but-non-zero alpha
+  // before drawing the stroked symbol. Cesium's billboard picker samples the
+  // texture's alpha channel — outline-only sprites with a fully transparent
+  // interior are unpickable except on the ~1.5-px-wide stroke. The 0.01 alpha
+  // adds no visible artifact but turns the full bounding box into a hit area.
+  ctx.fillStyle = "rgba(255,255,255,0.01)";
+  ctx.fillRect(0, 0, SYMBOL_SIZE, SYMBOL_SIZE);
   const spec = symbolSpec(type);
   const center = SYMBOL_SIZE / 2;
   const radius = SYMBOL_SIZE / 2;

--- a/src/scene/messier.ts
+++ b/src/scene/messier.ts
@@ -137,13 +137,6 @@ function generateMessierSprite(type: string): HTMLCanvasElement {
     ctx = null;
   }
   if (!ctx) return canvas;
-  // Fill the entire sprite with an effectively-invisible-but-non-zero alpha
-  // before drawing the stroked symbol. Cesium's billboard picker samples the
-  // texture's alpha channel — outline-only sprites with a fully transparent
-  // interior are unpickable except on the ~1.5-px-wide stroke. The 0.01 alpha
-  // adds no visible artifact but turns the full bounding box into a hit area.
-  ctx.fillStyle = "rgba(255,255,255,0.01)";
-  ctx.fillRect(0, 0, SYMBOL_SIZE, SYMBOL_SIZE);
   const spec = symbolSpec(type);
   const center = SYMBOL_SIZE / 2;
   const radius = SYMBOL_SIZE / 2;


### PR DESCRIPTION
## Summary

Hover popups for planets, stars, and satellites broke after #298 merged. Root cause: the post-scroll synthetic mousemove dispatch added to keep the hover tooltip in sync with a scroll-moved sky.

`new MouseEvent("mousemove", { clientX, clientY, … })` doesn't let you set `offsetX` / `offsetY` — Cesium's `ScreenSpaceEventType.MOUSE_MOVE` handler derives the canvas-local pick coord from those offset properties, so every synthetic event arrived as if the cursor were at (0, 0). That picked empty sky and corrupted the hover-tracking state for the rest of the session.

Fix: remove the synthetic dispatch and the cursor-position tracker that fed it. The wheel-pan handler keeps doing its job. The hover tooltip is allowed to stay briefly stale while the user is actively scroll-panning and refreshes on the next real cursor motion — much smaller UX cost than no popups at all.

## Test plan

- [x] `pnpm typecheck` / `pnpm lint` / `pnpm format:check` / `pnpm test:cov` (1300/1300; 96.61% / 87.54%) / `pnpm build` / `pnpm test:worker` (103/103) — all green.
- [ ] Manual: hover over a planet, star, satellite → popup shows. Scroll-pan a quarter turn → tooltip refreshes on next mouse motion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)