### PR TITLE
fix(scene): hover popup tracks cursor at every canvas position (supersedes #300)

### DIFF
--- a/src/scene/tooltip.test.ts
+++ b/src/scene/tooltip.test.ts
@@ -24,27 +24,36 @@ function makeMockViewer() {
   };
 }
 
+function findTooltip(): HTMLElement {
+  const el = document.body.querySelector<HTMLElement>("[data-tooltip-hover]");
+  if (el === null) throw new Error("tooltip element not found in document.body");
+  return el;
+}
+
 describe("createTooltip", () => {
   beforeEach(() => {
     mockSetInputAction.mockClear();
     mockDestroy.mockClear();
     mockPick.mockClear();
+    document.body.querySelectorAll("[data-tooltip-hover]").forEach((node) => {
+      node.remove();
+    });
   });
 
-  it("creates a hover tooltip div inside the container", () => {
+  it("creates a hover tooltip div on document.body (escapes containing-block traps)", () => {
     const container = document.createElement("div");
     const viewer = makeMockViewer();
     createTooltip(viewer as never, container);
-    const tooltipDiv = container.querySelector("div");
-    expect(tooltipDiv).toBeTruthy();
-    expect(tooltipDiv!.style.display).toBe("none");
+    const tooltipDiv = findTooltip();
+    expect(tooltipDiv.style.display).toBe("none");
+    expect(container.querySelector("[data-tooltip-hover]")).toBeNull();
   });
 
-  it("creates exactly one DOM element (hover only — no pinned tooltip any more)", () => {
+  it("creates exactly one tooltip element (hover only — no pinned tooltip any more)", () => {
     const container = document.createElement("div");
     const viewer = makeMockViewer();
     createTooltip(viewer as never, container);
-    expect(container.querySelectorAll("div").length).toBe(1);
+    expect(document.body.querySelectorAll("[data-tooltip-hover]").length).toBe(1);
     expect(container.querySelector("[data-pinned]")).toBeNull();
   });
 
@@ -79,7 +88,7 @@ describe("createTooltip", () => {
     });
     moveCallback({ endPosition: { x: 100, y: 200 } });
 
-    const tooltipDiv = container.querySelector("div")!;
+    const tooltipDiv = findTooltip();
     expect(tooltipDiv.style.display).toBe("block");
     expect(tooltipDiv.innerHTML).toContain("Sirius");
     expect(tooltipDiv.innerHTML).toContain("-1.44");
@@ -98,7 +107,7 @@ describe("createTooltip", () => {
     mockPick.mockReturnValueOnce(undefined);
     moveCallback({ endPosition: { x: 100, y: 200 } });
 
-    const tooltipDiv = container.querySelector("div")!;
+    const tooltipDiv = findTooltip();
     expect(tooltipDiv.style.display).toBe("none");
   });
 
@@ -108,7 +117,7 @@ describe("createTooltip", () => {
     const tooltip = createTooltip(viewer as never, container);
     tooltip.destroy();
     expect(mockDestroy).toHaveBeenCalledOnce();
-    expect(container.querySelectorAll("div").length).toBe(0);
+    expect(document.body.querySelectorAll("[data-tooltip-hover]").length).toBe(0);
   });
 
   it("shows tooltip with body info when a CelestialBody billboard is picked", () => {
@@ -136,7 +145,7 @@ describe("createTooltip", () => {
     });
     moveCallback({ endPosition: { x: 150, y: 250 } });
 
-    const tooltipDiv = container.querySelector("div")!;
+    const tooltipDiv = findTooltip();
     expect(tooltipDiv.style.display).toBe("block");
     expect(tooltipDiv.innerHTML).toContain("Moon");
     expect(tooltipDiv.innerHTML).toContain("-12.7");
@@ -165,7 +174,7 @@ describe("createTooltip", () => {
     });
     moveCallback({ endPosition: { x: 200, y: 300 } });
 
-    const tooltipDiv = container.querySelector("div")!;
+    const tooltipDiv = findTooltip();
     expect(tooltipDiv.style.display).toBe("block");
     expect(tooltipDiv.innerHTML).toContain("ISS");
     expect(tooltipDiv.innerHTML).toContain("25544");
@@ -196,7 +205,7 @@ describe("createTooltip", () => {
     });
     moveCallback({ endPosition: { x: 100, y: 200 } });
 
-    const tooltipDiv = container.querySelector("div")!;
+    const tooltipDiv = findTooltip();
     expect(tooltipDiv.style.display).toBe("block");
     expect(tooltipDiv.innerHTML).toContain("M42");
     expect(tooltipDiv.innerHTML).toContain("Orion Nebula");

--- a/src/scene/tooltip.ts
+++ b/src/scene/tooltip.ts
@@ -180,19 +180,41 @@ function pickHtml(picked: PickedObject): string {
 }
 
 const HOVER_STYLE =
-  "position:absolute;pointer-events:none;display:none;background:rgba(0,0,0,0.85);" +
+  "position:fixed;pointer-events:none;display:none;background:rgba(0,0,0,0.85);" +
   "color:#fff;font:12px/1.4 monospace;padding:6px 10px;border-radius:4px;" +
   "border:1px solid rgba(255,255,255,0.2);white-space:nowrap;z-index:10";
 
 export function createTooltip(
   viewer: Viewer,
-  container: HTMLElement,
+  _container: HTMLElement,
   options: TooltipOptions = {},
 ): Tooltip {
   // Hover tooltip only — pinned / card presentation now lives in ui/object-cards-manager.
+  // Mounted on document.body (not the caller-supplied container) so the popup's
+  // `position: fixed` containing block is the viewport regardless of how the
+  // host app wraps the canvas. The container parameter is kept in the signature
+  // for backward compatibility with existing callers.
   const hoverEl = document.createElement("div");
+  hoverEl.dataset.tooltipHover = "";
   hoverEl.style.cssText = HOVER_STYLE;
-  container.appendChild(hoverEl);
+  document.body.appendChild(hoverEl);
+
+  // Parallel DOM mousemove tracker on the canvas. Cesium's
+  // ScreenSpaceEventType.MOUSE_MOVE delivers `endPosition` in canvas-local
+  // coords, which is correct for picking but cannot be reliably converted
+  // back to viewport coords for popup placement: `getBoundingClientRect()`
+  // breaks under any ancestor with `filter` / `transform` / `will-change`
+  // (e.g. the night-vision filter on `body`), which create new containing
+  // blocks for `position: fixed` descendants. Capture clientX/clientY off
+  // the DOM event — universally viewport-relative — and use those for
+  // placement, while still using Cesium's endPosition for the pick.
+  let lastClientX = 0;
+  let lastClientY = 0;
+  function trackPointer(e: MouseEvent): void {
+    lastClientX = e.clientX;
+    lastClientY = e.clientY;
+  }
+  viewer.scene.canvas.addEventListener("mousemove", trackPointer);
 
   const handler = new ScreenSpaceEventHandler(viewer.scene.canvas);
 
@@ -201,8 +223,8 @@ export function createTooltip(
     if (picked !== null) {
       hoverEl.innerHTML = pickHtml(picked);
       hoverEl.style.display = "block";
-      hoverEl.style.left = `${String(movement.endPosition.x + 14)}px`;
-      hoverEl.style.top = `${String(movement.endPosition.y + 14)}px`;
+      hoverEl.style.left = `${String(lastClientX + 14)}px`;
+      hoverEl.style.top = `${String(lastClientY + 14)}px`;
     } else {
       hoverEl.style.display = "none";
     }
@@ -215,6 +237,7 @@ export function createTooltip(
   }, ScreenSpaceEventType.LEFT_CLICK);
 
   function destroy(): void {
+    viewer.scene.canvas.removeEventListener("mousemove", trackPointer);
     handler.destroy();
     hoverEl.remove();
   }

--- a/src/scene/tooltip.ts
+++ b/src/scene/tooltip.ts
@@ -208,22 +208,6 @@ export function createTooltip(
   // blocks for `position: fixed` descendants. Capture clientX/clientY off
   // the DOM event — universally viewport-relative — and use those for
   // placement, while still using Cesium's endPosition for the pick.
-  // ===== TEMP DEBUG OVERLAY (remove before merge) ============================
-  // Pinned top-left div that prints live diagnostic info every mousemove.
-  // Goal: figure out which layer is failing for "hover broken on left side."
-  const debugEl = document.createElement("div");
-  debugEl.dataset.tooltipDebug = "";
-  debugEl.style.cssText =
-    "position:fixed;top:8px;left:8px;z-index:99999;pointer-events:none;" +
-    "background:rgba(0,0,0,0.85);color:#0f0;font:11px/1.3 monospace;" +
-    "padding:6px 10px;border:1px solid #0f0;white-space:pre;border-radius:4px;";
-  debugEl.textContent = "[hover-debug] waiting for mousemove…";
-  document.body.appendChild(debugEl);
-  function logDebug(line: string): void {
-    debugEl.textContent = line;
-  }
-  // ===== END TEMP DEBUG OVERLAY ==============================================
-
   let lastClientX = 0;
   let lastClientY = 0;
   function trackPointer(e: MouseEvent): void {
@@ -236,8 +220,6 @@ export function createTooltip(
 
   handler.setInputAction((movement: { endPosition: Cartesian2 }) => {
     const picked = pickObject(viewer, movement.endPosition);
-    const rect = viewer.scene.canvas.getBoundingClientRect();
-    const dpr = window.devicePixelRatio;
     if (picked !== null) {
       hoverEl.innerHTML = pickHtml(picked);
       hoverEl.style.display = "block";
@@ -246,16 +228,6 @@ export function createTooltip(
     } else {
       hoverEl.style.display = "none";
     }
-    logDebug(
-      `cursor.client=(${String(lastClientX)}, ${String(lastClientY)})\n` +
-        `cesium.endPos=(${String(Math.round(movement.endPosition.x))}, ${String(Math.round(movement.endPosition.y))})\n` +
-        `canvas.rect=L${String(Math.round(rect.left))} T${String(Math.round(rect.top))} W${String(Math.round(rect.width))} H${String(Math.round(rect.height))}\n` +
-        `dpr=${String(dpr)}\n` +
-        `picked.kind=${picked?.kind ?? "null"}\n` +
-        `popup.display=${hoverEl.style.display}\n` +
-        `popup.left=${hoverEl.style.left || "(unset)"}\n` +
-        `popup.top=${hoverEl.style.top || "(unset)"}`,
-    );
   }, ScreenSpaceEventType.MOUSE_MOVE);
 
   handler.setInputAction((movement: { position: Cartesian2 }) => {

--- a/src/scene/tooltip.ts
+++ b/src/scene/tooltip.ts
@@ -208,6 +208,22 @@ export function createTooltip(
   // blocks for `position: fixed` descendants. Capture clientX/clientY off
   // the DOM event — universally viewport-relative — and use those for
   // placement, while still using Cesium's endPosition for the pick.
+  // ===== TEMP DEBUG OVERLAY (remove before merge) ============================
+  // Pinned top-left div that prints live diagnostic info every mousemove.
+  // Goal: figure out which layer is failing for "hover broken on left side."
+  const debugEl = document.createElement("div");
+  debugEl.dataset.tooltipDebug = "";
+  debugEl.style.cssText =
+    "position:fixed;top:8px;left:8px;z-index:99999;pointer-events:none;" +
+    "background:rgba(0,0,0,0.85);color:#0f0;font:11px/1.3 monospace;" +
+    "padding:6px 10px;border:1px solid #0f0;white-space:pre;border-radius:4px;";
+  debugEl.textContent = "[hover-debug] waiting for mousemove…";
+  document.body.appendChild(debugEl);
+  function logDebug(line: string): void {
+    debugEl.textContent = line;
+  }
+  // ===== END TEMP DEBUG OVERLAY ==============================================
+
   let lastClientX = 0;
   let lastClientY = 0;
   function trackPointer(e: MouseEvent): void {
@@ -220,6 +236,8 @@ export function createTooltip(
 
   handler.setInputAction((movement: { endPosition: Cartesian2 }) => {
     const picked = pickObject(viewer, movement.endPosition);
+    const rect = viewer.scene.canvas.getBoundingClientRect();
+    const dpr = window.devicePixelRatio;
     if (picked !== null) {
       hoverEl.innerHTML = pickHtml(picked);
       hoverEl.style.display = "block";
@@ -228,6 +246,16 @@ export function createTooltip(
     } else {
       hoverEl.style.display = "none";
     }
+    logDebug(
+      `cursor.client=(${String(lastClientX)}, ${String(lastClientY)})\n` +
+        `cesium.endPos=(${String(Math.round(movement.endPosition.x))}, ${String(Math.round(movement.endPosition.y))})\n` +
+        `canvas.rect=L${String(Math.round(rect.left))} T${String(Math.round(rect.top))} W${String(Math.round(rect.width))} H${String(Math.round(rect.height))}\n` +
+        `dpr=${String(dpr)}\n` +
+        `picked.kind=${picked?.kind ?? "null"}\n` +
+        `popup.display=${hoverEl.style.display}\n` +
+        `popup.left=${hoverEl.style.left || "(unset)"}\n` +
+        `popup.top=${hoverEl.style.top || "(unset)"}`,
+    );
   }, ScreenSpaceEventType.MOUSE_MOVE);
 
   handler.setInputAction((movement: { position: Cartesian2 }) => {


### PR DESCRIPTION
## Summary

Hover popups failed away from the center of the screen, even after #300. Root cause:

- Popup was rendered with canvas-local Cesium \`endPosition\` coords
- \`position: absolute\` resolved offsetParent up to \`body\`, so popup placement only matched the cursor when the canvas top-left was at body (0, 0)
- #300 attempted to fix by translating canvas-local → viewport via \`canvas.getBoundingClientRect()\`. This is unreliable: any ancestor with \`filter\` / \`transform\` / \`will-change\` (e.g., the night-vision filter on \`body\`) creates a new containing block for \`position: fixed\` descendants, breaking the conversion asymmetrically — popups still failed on the left side of the screen

## Fix

- Add a parallel DOM \`mousemove\` listener on the canvas. Capture \`clientX\` / \`clientY\` directly from the DOM event (always viewport-relative, regardless of filter/transform context)
- Mount the popup directly on \`document.body\` so \`position: fixed\` resolves to the same containing block as the captured viewport coords
- Cesium's \`endPosition\` continues to be used for the pick — only popup placement math changes

## Test plan

- [x] \`pnpm typecheck\` / \`pnpm lint\` / \`pnpm format:check\` / \`pnpm test:cov\` (1300/1300, 96.61% / 87.54%) / \`pnpm build\` / \`pnpm test:worker\` (103/103) — all green.
- [ ] Manual: hover stars / planets / satellites / messier on the LEFT side of the screen and at all four corners. Popup should glue to the cursor at every position. Test with night-vision toggled both on and off (the original failure mode).

## Related

Closes the same root issue described in #300; #300 closed in favor of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)