### PR TITLE
fix(scene): widen Cesium pick rect 3×3 → 21×21 (re-apply, lost in #301 squash)

### DIFF
--- a/src/scene/tooltip.ts
+++ b/src/scene/tooltip.ts
@@ -146,13 +146,27 @@ function formatSatellite(sat: VisibleSatellite): string {
   );
 }
 
+/**
+ * Cesium's `Scene.pick` defaults to a 3x3-pixel pick rectangle. Star and
+ * Messier sprites are 6–10 px and the cursor rarely lands exactly on them —
+ * users perceive hover as "broken" because most positions return null.
+ * Widening the rectangle to 21x21 makes the hit area roughly star-sized
+ * without spuriously latching onto distant objects. Verified via Playwright
+ * grid sweep: 3x3 → 12 hits / 259 (4.6%); 21x21 → 36 / 259 (13.9%).
+ */
+const PICK_RECT_PX = 21;
+
 function pickObject(
-  viewer: { scene: { pick: (pos: Cartesian2) => unknown } },
+  viewer: {
+    scene: { pick: (pos: Cartesian2, width?: number, height?: number) => unknown };
+  },
   position: Cartesian2,
 ): PickedObject | null {
-  const picked: { id?: unknown } | undefined = viewer.scene.pick(position) as
-    | { id?: unknown }
-    | undefined;
+  const picked: { id?: unknown } | undefined = viewer.scene.pick(
+    position,
+    PICK_RECT_PX,
+    PICK_RECT_PX,
+  ) as { id?: unknown } | undefined;
 
   if (!defined(picked) || picked === undefined) return null;
 


### PR DESCRIPTION
## Summary

Re-applies the actual root-cause fix for the hover-popup-broken-on-left bug. The final commit (`ab68ca7`) of PR #301 didn't make it into the squash-merge — only the body-mount + clientX/clientY work landed. Hover popups on main are still failing for the same reason that PR was opened to address.

Cesium's `Scene.pick()` defaults to a 3×3-pixel rectangle. Star and Messier sprites are 6–10 px. Cursors miss most of the time. Widening to 21×21 makes the hit area roughly star-sized.

## Diagnostic numbers (Playwright sweep)

| Pick rect | Hits / 259 | % |
|---|---|---|
| 3×3 (default) | 12 | 4.6% |
| 13×13 | 20 | 7.7% |
| 21×21 (this) | 36 | 13.9% |

## Test plan

- [x] `pnpm typecheck` / `pnpm lint` / `pnpm format:check` / `pnpm test:cov` (1300/1300, 96.61% / 87.54%) / `pnpm build` / `pnpm test:worker` (103/103) — all green.
- [ ] Manual: hover stars/planets/satellites/messier on the left and right sides of the canvas — hit rate noticeably better than current main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)