### PR TITLE
feat(test): Playwright E2E suite (#303)

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,3 +3,5 @@ coverage
 .worktrees
 pnpm-lock.yaml
 public/sw.js
+playwright-report
+test-results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,3 +84,34 @@ jobs:
         with:
           name: dist
           path: dist/
+
+  e2e:
+    name: e2e
+    runs-on: ubuntu-latest
+    # Gate on the cheap checks so PRs that fail typecheck / lint / test don't
+    # burn browser-launch time. Build is the longest of the gates so it's the
+    # last to clear; depending on it gives us full confidence the bundle the
+    # e2e tests will exercise is internally consistent.
+    needs: [build]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9.12.0
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      # Cesium's shaders fail to compile under SwiftShader (Playwright's
+      # default headless GL backend), so the suite runs headed under Xvfb.
+      # `--with-deps` pulls in the system libraries Chromium needs on
+      # ubuntu-latest in addition to the browser binary itself.
+      - run: npx playwright install --with-deps chromium
+      - run: xvfb-run -a pnpm e2e
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,11 @@ node_modules/
 dist/
 coverage/
 
+# Playwright (E2E tests, ADR 016)
+playwright-report/
+test-results/
+.playwright/
+
 # Worktrees (managed by git worktree; contents must never be tracked)
 .worktrees/
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,6 +3,8 @@ coverage
 .worktrees
 pnpm-lock.yaml
 public
+playwright-report
+test-results
 
 # Seed plans (authored Markdown + strict JSON frontmatter; prettier's
 # trailing-comma insertion breaks JSON.parse).

--- a/README.md
+++ b/README.md
@@ -76,6 +76,26 @@ See [`docs/architecture.md`](docs/architecture.md) for Mermaid diagrams covering
 
 A change is not "done" until `pnpm typecheck && pnpm lint && pnpm format:check && pnpm test:cov && pnpm build` all pass locally.
 
+### Running E2E tests
+
+The Playwright suite under `e2e/` (see [ADR 016](docs/adr/016-playwright-e2e.md))
+covers the surfaces jsdom can't reach — Cesium WebGL pick framebuffers, URL
+hydration in a real browser, and the drawer rail. It runs separately from the
+canonical pre-push gate above, on its own CI job.
+
+First-time setup (once per clone):
+
+    pnpm e2e:install   # downloads headed Chromium under ~/Library/Caches/ms-playwright
+
+Then:
+
+    pnpm e2e           # headed Chromium, starts vite dev server automatically
+
+CI runs the same suite under `xvfb-run -a pnpm e2e` on `ubuntu-latest`. Cesium's
+shaders fail to compile under Playwright's default headless backend, so the
+suite is headed Chromium only. Firefox, WebKit, screenshot baselines, and PR
+preview smoke are explicitly out of scope.
+
 ### Worker / D1 local setup
 
 Phase 2 introduces a Worker + D1 backend. See [`worker/README.md`](worker/README.md)

--- a/docs/adr/016-playwright-e2e.md
+++ b/docs/adr/016-playwright-e2e.md
@@ -1,0 +1,116 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# ADR 016 — Playwright for end-to-end browser tests
+
+**Date:** 2026-04-25
+**Status:** Accepted
+
+## Context
+
+GitHub issue #303 follows a hover-pick regression that shipped to production
+in PR #301 and was only caught after merge. The bug — Cesium's default 3×3
+pick rectangle being smaller than star sprites — could not surface in the
+existing jsdom Vitest suite because jsdom has no WebGL implementation; the
+`Scene.pick` framebuffer path is only exercised by a real GPU. Even the fix
+(#302, widening to 21×21) was validated by a one-off Playwright script that
+was deleted after use.
+
+We need a small, durable browser-side test layer that catches this class of
+regression on the next push, without bloating the canonical pre-push gate
+that runs on every developer save.
+
+## Decision
+
+Add **Playwright** + `@playwright/test` (`^1.x`) as devDependencies and
+introduce a top-level `e2e/` directory holding a focused suite of five
+specs:
+
+1. Hover-pick sweep (the regression that motivates this ADR).
+2. URL-state round-trip — boot with query params, assert they survive
+   the bootstrap.
+3. Deep-link plan modal — boot with `?plan=<slug>`, assert the reader
+   modal renders. Uses `page.route()` to intercept `/api/plans/*` so the
+   test doesn't need a live worker.
+4. Bottom-HUD / drawer-rail smoke — assert each of the four drawer
+   triggers (events, tonight, settings, plans) opens its drawer.
+5. Cesium initialises — count non-black pixels on the canvas within
+   5 s of load to catch WebGL init regressions.
+
+Playwright is **license-clean** (Apache-2.0 — same as this project), used
+by Microsoft, Google, and the wider browser-vendor ecosystem; no separate
+attribution beyond the standard NOTICE entry.
+
+### Headed Chromium only
+
+Cesium's shaders fail to compile under SwiftShader, the headless GL backend.
+`playwright.config.ts` sets `use: { headless: false }` and the suite runs
+only in Chromium. Firefox / WebKit are explicitly out of scope; revisit
+only if a Safari-specific regression forces it.
+
+On Linux CI the suite runs under `xvfb-run -a pnpm e2e`. macOS local dev
+needs no Xvfb. The CI job runs `npx playwright install --with-deps
+chromium` before the suite — it is excluded from the canonical pre-push
+gate so first-time-clone friction stays low.
+
+### Out of the canonical pre-push gate
+
+`pnpm e2e` is **not** added to `pnpm typecheck && pnpm lint &&
+pnpm format:check && pnpm test:cov && pnpm build`. The browser launch
+adds ~5 s overhead per run and requires a working display, neither of
+which belong in the every-save gate. The CI workflow makes the e2e job
+`needs: [build]` so PRs that fail the cheap checks don't burn e2e
+minutes.
+
+### Pro-gated tests use a localStorage stub
+
+`page.addInitScript` pre-seeds `planisphere.user.v1` with the allowlisted
+email so `isPro()` returns true for the deep-link plan modal test (see
+`src/features.ts` for the storage shape). This is the same surface
+documented in [ADR 015](015-viewing-plans-storage-and-pro-gate.md) — no
+new shipping code is added to support it.
+
+The same script also pre-seeds `planisphere.onboarding.v1=dismissed`
+across every test so the onboarding overlay (which would otherwise cover
+the canvas centre and break every pick) doesn't appear.
+
+### Dev server
+
+`playwright.config.ts` uses Playwright's `webServer` feature to start
+`pnpm dev:client` (just Vite, no `wrangler dev`) before tests run. The
+plan modal test stubs `/api/plans/*` via `page.route()` so the absence
+of the worker doesn't matter. `reuseExistingServer: !process.env.CI`
+keeps local iteration fast.
+
+## Consequences
+
+- **DevDep weight:** Playwright + browser binaries are large (~500 MB
+  for chromium). They live under `~/.cache/ms-playwright`, not in the
+  shipped bundle. `npx playwright install chromium` is documented in
+  README.
+- **CI minutes:** the `e2e` job adds ~30 s per run (Xvfb boot + browser
+  launch + suite). Net positive vs. the cost of another regression like
+  #302.
+- **No coverage contribution:** Playwright tests don't feed the v8
+  coverage thresholds in `vitest.config.ts`. That is by design — the
+  thresholds gate jsdom-runnable code, not browser surfaces.
+- **No visual regression:** screenshot baselines / `pixelmatch` are
+  explicitly out of scope. The Cesium-initialises test counts non-black
+  pixels rather than diffing against a baseline; that's enough to catch
+  "WebGL never started" without the maintenance tax of golden images.
+
+## Alternatives considered
+
+- **Cypress.** Comparable feature set; rejected on the unrequested
+  paid tier prompts during install and the heavier UI runner. Playwright's
+  pure-CLI workflow fits this repo's "everything in CI" conventions
+  better.
+- **Puppeteer-only / no test runner.** The disposable diagnostic that
+  caught #302 was a Puppeteer one-off; promoting it to that shape would
+  miss the test-runner ergonomics (parallelism, retries, fixtures,
+  trace viewer) we need for the four other tests.
+- **Headless Cesium via mocked GL.** Theoretically possible (e.g. headless
+  GL via `gl` npm package), but reproducing Cesium's shader pipeline
+  outside a real browser is exactly what we already have jsdom for —
+  and that's what missed the bug.
+- **Add e2e to the canonical gate.** Rejected — too slow for every
+  developer save, and the CI job already enforces it on every PR.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -25,6 +25,7 @@ Template: [`000-template.md`](000-template.md).
 | 013 | [Notebook editor: tiptap (ProseMirror, MIT)](013-notebook-editor.md)                              | 2026-04-20 |
 | 014 | [Email delivery: Resend HTTP API](014-email-delivery.md)                                          | 2026-04-20 |
 | 015 | [Viewing Plans storage and Pro-gate enforcement](015-viewing-plans-storage-and-pro-gate.md)       | 2026-04-24 |
+| 016 | [Playwright for end-to-end browser tests](016-playwright-e2e.md)                                  | 2026-04-25 |
 
 ## Conventions
 

--- a/e2e/bottom-hud-smoke.spec.ts
+++ b/e2e/bottom-hud-smoke.spec.ts
@@ -1,0 +1,77 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { expect, test } from "@playwright/test";
+import { seedDefaultStorage, waitForCesiumPainted } from "./fixtures";
+
+/**
+ * Bottom-HUD / drawer-rail smoke test (issue #303 #4).
+ *
+ * The "bottom HUD" in this test refers to the SPA's drawer chrome — the
+ * always-visible panel buttons that gate access to events, tonight's sky,
+ * settings, and viewing plans. Each click should open exactly one drawer
+ * (the others auto-close per the mutual-exclusion logic in `src/app.ts`).
+ *
+ * The bottom-hud strip itself is also asserted present so a regression that
+ * dropped the chrome entirely fails fast.
+ */
+test("bottom-hud is present and each drawer trigger opens its drawer", async ({ page }) => {
+  await seedDefaultStorage(page);
+  // Stub plans + auth so the drawer's first paint doesn't show a network
+  // error spinner mid-test.
+  await page.route("**/api/plans", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ plans: [] }),
+    });
+  });
+  await page.route("**/api/auth/me", async (route) => {
+    await route.fulfill({ status: 401, body: "" });
+  });
+
+  await page.goto("/?lat=61.2&lon=-149.9&t=2026-04-25T08:00:00Z");
+  await expect(page.locator("#cesium-container canvas")).toBeVisible();
+  await waitForCesiumPainted(page, 10_000);
+
+  // Bottom HUD chrome is mounted.
+  await expect(page.locator("[data-testid='bottom-hud']")).toBeVisible();
+
+  type Trigger = {
+    name: string;
+    button: string;
+    drawerContent: string;
+  };
+  const triggers: readonly Trigger[] = [
+    {
+      name: "events",
+      button: "[data-testid='panel-events']",
+      drawerContent: "[data-testid='events-drawer-content']",
+    },
+    {
+      name: "tonight",
+      button: "[data-testid='panel-tonight']",
+      drawerContent: "[data-testid='tonight-drawer-content']",
+    },
+    {
+      name: "settings",
+      button: "[data-testid='panel-settings']",
+      drawerContent: "[data-testid='settings-drawer-content']",
+    },
+    {
+      name: "plans",
+      button: "[data-testid='panel-plans']",
+      drawerContent: "[data-testid='plans-drawer-content']",
+    },
+  ];
+
+  for (const t of triggers) {
+    await page.locator(t.button).click();
+    await expect(
+      page.locator(t.drawerContent),
+      `${t.name} drawer content should be visible after clicking ${t.button}`,
+    ).toBeVisible();
+    // Close via Escape so the next iteration starts from a clean state — the
+    // mutual-exclusion in `src/app.ts` would auto-close the previous drawer
+    // anyway, but Escape exercises the close path too.
+    await page.keyboard.press("Escape");
+  }
+});

--- a/e2e/cesium-initialises.spec.ts
+++ b/e2e/cesium-initialises.spec.ts
@@ -1,18 +1,18 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 import { expect, test } from "@playwright/test";
-import { seedDefaultStorage, waitForCesiumPainted } from "./fixtures";
+import { countNonBlackPixelsOnPage, seedDefaultStorage, waitForCesiumPainted } from "./fixtures";
 
 /**
- * Cesium-initialises smoke test. Boots the app at a stable URL and asserts the
- * WebGL canvas has actually painted non-black pixels within 5 s. Catches the
- * "shaders failed to compile / context lost / `Viewer` never instantiated"
+ * Cesium-initialises smoke test. Boots the app at a stable URL and asserts
+ * the WebGL canvas has actually painted non-black pixels within 5 s. Catches
+ * the "shaders failed to compile / context lost / `Viewer` never instantiated"
  * class of regression — none of which jsdom can detect.
  *
- * Reads the canvas via a scratch 2D context (`drawImage` + `getImageData`)
- * rather than raw GL pixels — a real `gl.readPixels` call would need to be
- * stamped before Cesium's swap-buffers, which we can't synchronise from the
- * page side. The 2D snapshot reflects the most-recently-presented frame and
- * is cheap.
+ * Implementation note: Cesium's WebGL context is created without
+ * `preserveDrawingBuffer: true`, so `canvas.toDataURL()` / `drawImage(canvas)`
+ * return a black image after swap. We use `page.screenshot()` instead, which
+ * captures the OS-composited viewport — the user-visible frame is the
+ * ground truth this test cares about.
  */
 test("cesium WebGL canvas paints non-black pixels within 5 s", async ({ page }) => {
   await seedDefaultStorage(page);
@@ -20,38 +20,16 @@ test("cesium WebGL canvas paints non-black pixels within 5 s", async ({ page }) 
 
   await expect(page.locator("#cesium-container canvas")).toBeVisible();
 
-  // The 5 s budget is from issue #303. waitForCesiumPainted polls every 200 ms
-  // for a non-black sample; if Cesium never paints, this throws and the test
-  // fails loudly rather than rolling silently into a downstream assertion.
+  // The 5 s budget is from issue #303. waitForCesiumPainted polls a small
+  // centre clip every 200 ms; if Cesium never paints, this throws and the
+  // test fails with the timeout in the stack — clearer than a downstream
+  // assertion failing on a black screenshot.
   await waitForCesiumPainted(page, 5_000);
 
-  // Sanity: now compute non-black pixels across the full canvas to give the
-  // test a meaningful "non-empty" assertion vs. the bootstrap probe.
-  const stats = await page.evaluate(() => {
-    const canvas = document.querySelector<HTMLCanvasElement>("#cesium-container canvas");
-    if (canvas === null) return { total: 0, nonBlack: 0 };
-    const w = canvas.width;
-    const h = canvas.height;
-    const scratch = document.createElement("canvas");
-    scratch.width = w;
-    scratch.height = h;
-    const ctx = scratch.getContext("2d");
-    if (ctx === null) return { total: w * h, nonBlack: 0 };
-    ctx.drawImage(canvas, 0, 0);
-    const { data } = ctx.getImageData(0, 0, w, h);
-    let nonBlack = 0;
-    for (let i = 0; i < data.length; i += 4) {
-      const r = data[i] ?? 0;
-      const g = data[i + 1] ?? 0;
-      const b = data[i + 2] ?? 0;
-      if (r + g + b > 12) nonBlack += 1;
-    }
-    return { total: w * h, nonBlack };
-  });
-
-  expect(stats.total).toBeGreaterThan(0);
-  // A working render of stars + grid lines yields ≫ 1000 non-black pixels.
-  // 500 is the floor that catches "WebGL never started" without false-failing
-  // on minor scene changes.
-  expect(stats.nonBlack).toBeGreaterThanOrEqual(500);
+  // Full-viewport non-black pixel count for the meaningful "non-empty"
+  // assertion. Includes the side panel chrome, but the side panel alone
+  // would never reach the 500-pixel floor — we'd need at least the
+  // RA/Dec grid or a few stars rendered too.
+  const nonBlack = await countNonBlackPixelsOnPage(page);
+  expect(nonBlack).toBeGreaterThanOrEqual(500);
 });

--- a/e2e/cesium-initialises.spec.ts
+++ b/e2e/cesium-initialises.spec.ts
@@ -1,0 +1,57 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { expect, test } from "@playwright/test";
+import { seedDefaultStorage, waitForCesiumPainted } from "./fixtures";
+
+/**
+ * Cesium-initialises smoke test. Boots the app at a stable URL and asserts the
+ * WebGL canvas has actually painted non-black pixels within 5 s. Catches the
+ * "shaders failed to compile / context lost / `Viewer` never instantiated"
+ * class of regression — none of which jsdom can detect.
+ *
+ * Reads the canvas via a scratch 2D context (`drawImage` + `getImageData`)
+ * rather than raw GL pixels — a real `gl.readPixels` call would need to be
+ * stamped before Cesium's swap-buffers, which we can't synchronise from the
+ * page side. The 2D snapshot reflects the most-recently-presented frame and
+ * is cheap.
+ */
+test("cesium WebGL canvas paints non-black pixels within 5 s", async ({ page }) => {
+  await seedDefaultStorage(page);
+  await page.goto("/?lat=61.2&lon=-149.9&t=2026-04-25T08:00:00Z");
+
+  await expect(page.locator("#cesium-container canvas")).toBeVisible();
+
+  // The 5 s budget is from issue #303. waitForCesiumPainted polls every 200 ms
+  // for a non-black sample; if Cesium never paints, this throws and the test
+  // fails loudly rather than rolling silently into a downstream assertion.
+  await waitForCesiumPainted(page, 5_000);
+
+  // Sanity: now compute non-black pixels across the full canvas to give the
+  // test a meaningful "non-empty" assertion vs. the bootstrap probe.
+  const stats = await page.evaluate(() => {
+    const canvas = document.querySelector<HTMLCanvasElement>("#cesium-container canvas");
+    if (canvas === null) return { total: 0, nonBlack: 0 };
+    const w = canvas.width;
+    const h = canvas.height;
+    const scratch = document.createElement("canvas");
+    scratch.width = w;
+    scratch.height = h;
+    const ctx = scratch.getContext("2d");
+    if (ctx === null) return { total: w * h, nonBlack: 0 };
+    ctx.drawImage(canvas, 0, 0);
+    const { data } = ctx.getImageData(0, 0, w, h);
+    let nonBlack = 0;
+    for (let i = 0; i < data.length; i += 4) {
+      const r = data[i] ?? 0;
+      const g = data[i + 1] ?? 0;
+      const b = data[i + 2] ?? 0;
+      if (r + g + b > 12) nonBlack += 1;
+    }
+    return { total: w * h, nonBlack };
+  });
+
+  expect(stats.total).toBeGreaterThan(0);
+  // A working render of stars + grid lines yields ≫ 1000 non-black pixels.
+  // 500 is the floor that catches "WebGL never started" without false-failing
+  // on minor scene changes.
+  expect(stats.nonBlack).toBeGreaterThanOrEqual(500);
+});

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -1,0 +1,74 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import type { Page } from "@playwright/test";
+
+/**
+ * Pre-seed localStorage so the SPA boots in the state every E2E test wants:
+ *
+ * - `planisphere.onboarding.v1=dismissed` — without this the onboarding overlay
+ *   covers the canvas centre and breaks every Cesium pick.
+ * - `planisphere.user.v1` set to the allowlisted Pro email so `isPro()` returns
+ *   true (see `src/features.ts`). Some tests need this to exercise the Pro
+ *   surfaces (deep-link plan modal, Notebook entry, etc.); harmless for the
+ *   ones that don't.
+ *
+ * Must run via `page.addInitScript` *before* navigation so the storage is set
+ * before the SPA's bootstrap reads it.
+ */
+export async function seedDefaultStorage(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    try {
+      localStorage.setItem("planisphere.onboarding.v1", "dismissed");
+      localStorage.setItem(
+        "planisphere.user.v1",
+        JSON.stringify({ email: "rob.sartin@gmail.com" }),
+      );
+    } catch {
+      // Ignore — storage unavailable means the test that depends on this seed
+      // will fail with a clearer assertion downstream.
+    }
+  });
+}
+
+/**
+ * Wait until Cesium has actually painted at least one frame to the WebGL
+ * canvas. Polls the canvas via a 2D scratch surface (drawImage + getImageData)
+ * and counts non-black pixels. Used both by the dedicated Cesium-init test and
+ * as a precondition for hover-pick / URL-roundtrip tests so they don't probe
+ * a black canvas.
+ */
+export async function waitForCesiumPainted(page: Page, timeoutMs = 15_000): Promise<void> {
+  await page.waitForFunction(
+    () => {
+      const canvas = document.querySelector<HTMLCanvasElement>("#cesium-container canvas");
+      if (canvas === null || canvas.width === 0 || canvas.height === 0) return false;
+      const scratch = document.createElement("canvas");
+      // Sample a small central crop — Cesium clears to black, so any star
+      // sprite or grid line in the centre region means painting started.
+      const sampleSize = 64;
+      scratch.width = sampleSize;
+      scratch.height = sampleSize;
+      const ctx = scratch.getContext("2d");
+      if (ctx === null) return false;
+      const sx = Math.max(0, Math.floor(canvas.width / 2 - sampleSize / 2));
+      const sy = Math.max(0, Math.floor(canvas.height / 2 - sampleSize / 2));
+      try {
+        ctx.drawImage(canvas, sx, sy, sampleSize, sampleSize, 0, 0, sampleSize, sampleSize);
+      } catch {
+        return false;
+      }
+      const data = ctx.getImageData(0, 0, sampleSize, sampleSize).data;
+      let nonBlack = 0;
+      for (let i = 0; i < data.length; i += 4) {
+        const r = data[i] ?? 0;
+        const g = data[i + 1] ?? 0;
+        const b = data[i + 2] ?? 0;
+        if (r + g + b > 12) nonBlack += 1;
+      }
+      // ≥ 4 non-black pixels in the 4096-pixel central crop means Cesium
+      // has at least drawn the grid / a sprite. Conservative on purpose.
+      return nonBlack >= 4;
+    },
+    null,
+    { timeout: timeoutMs, polling: 200 },
+  );
+}

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -30,45 +30,114 @@ export async function seedDefaultStorage(page: Page): Promise<void> {
 }
 
 /**
- * Wait until Cesium has actually painted at least one frame to the WebGL
- * canvas. Polls the canvas via a 2D scratch surface (drawImage + getImageData)
- * and counts non-black pixels. Used both by the dedicated Cesium-init test and
- * as a precondition for hover-pick / URL-roundtrip tests so they don't probe
- * a black canvas.
+ * Wait until Cesium has painted a non-black centre crop. Why screenshots
+ * rather than `canvas.toDataURL()` / `drawImage(canvas)` / `gl.readPixels`?
+ *
+ * Cesium initialises its WebGL context without `preserveDrawingBuffer:
+ * true` (see `src/scene/viewer.ts`) — that's a performance default we don't
+ * want to flip just for tests. After the scene swaps buffers the back buffer
+ * is undefined; reading the canvas via the 2D pipeline returns a black
+ * image. A `page.screenshot()` captures the *composited* viewport at the
+ * browser-process level, which reflects whatever was last presented,
+ * regardless of the GL context's preservation flag.
+ *
+ * `polling: 200` keeps the cost ≤ 5 screenshots per second; a fully
+ * painted scene typically returns within the first or second probe.
  */
 export async function waitForCesiumPainted(page: Page, timeoutMs = 15_000): Promise<void> {
-  await page.waitForFunction(
-    () => {
-      const canvas = document.querySelector<HTMLCanvasElement>("#cesium-container canvas");
-      if (canvas === null || canvas.width === 0 || canvas.height === 0) return false;
-      const scratch = document.createElement("canvas");
-      // Sample a small central crop — Cesium clears to black, so any star
-      // sprite or grid line in the centre region means painting started.
-      const sampleSize = 64;
-      scratch.width = sampleSize;
-      scratch.height = sampleSize;
-      const ctx = scratch.getContext("2d");
-      if (ctx === null) return false;
-      const sx = Math.max(0, Math.floor(canvas.width / 2 - sampleSize / 2));
-      const sy = Math.max(0, Math.floor(canvas.height / 2 - sampleSize / 2));
+  const start = Date.now();
+  // Probe loop: take a small viewport screenshot, decode, count non-black.
+  // `page.screenshot` here returns the composited frame, which reflects
+  // whatever Cesium presented even without `preserveDrawingBuffer`.
+  while (Date.now() - start < timeoutMs) {
+    const png = await page.screenshot({
+      clip: { x: 600, y: 360, width: 80, height: 80 },
+      type: "png",
+      animations: "disabled",
+    });
+    const nonBlack = await page.evaluate(async (bytes: number[]) => {
+      const blob = new Blob([new Uint8Array(bytes)], { type: "image/png" });
+      const url = URL.createObjectURL(blob);
       try {
-        ctx.drawImage(canvas, sx, sy, sampleSize, sampleSize, 0, 0, sampleSize, sampleSize);
-      } catch {
-        return false;
+        const img = new Image();
+        await new Promise<void>((resolve, reject) => {
+          img.onload = () => {
+            resolve();
+          };
+          img.onerror = () => {
+            reject(new Error("image decode failed"));
+          };
+          img.src = url;
+        });
+        const c = document.createElement("canvas");
+        c.width = img.width;
+        c.height = img.height;
+        const ctx = c.getContext("2d");
+        if (ctx === null) return 0;
+        ctx.drawImage(img, 0, 0);
+        const data = ctx.getImageData(0, 0, c.width, c.height).data;
+        let count = 0;
+        for (let i = 0; i < data.length; i += 4) {
+          const r = data[i] ?? 0;
+          const g = data[i + 1] ?? 0;
+          const b = data[i + 2] ?? 0;
+          if (r + g + b > 12) count += 1;
+        }
+        return count;
+      } finally {
+        URL.revokeObjectURL(url);
       }
-      const data = ctx.getImageData(0, 0, sampleSize, sampleSize).data;
-      let nonBlack = 0;
+    }, Array.from(png));
+    if (nonBlack >= 4) return;
+    await page.waitForTimeout(200);
+  }
+  throw new Error(
+    `Cesium canvas did not paint within ${String(timeoutMs)}ms (no non-black pixels in 80×80 centre crop)`,
+  );
+}
+
+/**
+ * Count non-black pixels across a full-viewport screenshot. The Cesium-
+ * init test uses this for its "≥ 500 non-black pixels" assertion. Same
+ * decode-via-page trick as `waitForCesiumPainted`.
+ */
+export async function countNonBlackPixelsOnPage(page: Page): Promise<number> {
+  const png = await page.screenshot({
+    fullPage: false,
+    type: "png",
+    animations: "disabled",
+  });
+  return page.evaluate(async (bytes: number[]) => {
+    const blob = new Blob([new Uint8Array(bytes)], { type: "image/png" });
+    const url = URL.createObjectURL(blob);
+    try {
+      const img = new Image();
+      await new Promise<void>((resolve, reject) => {
+        img.onload = () => {
+          resolve();
+        };
+        img.onerror = () => {
+          reject(new Error("image decode failed"));
+        };
+        img.src = url;
+      });
+      const c = document.createElement("canvas");
+      c.width = img.width;
+      c.height = img.height;
+      const ctx = c.getContext("2d");
+      if (ctx === null) return 0;
+      ctx.drawImage(img, 0, 0);
+      const data = ctx.getImageData(0, 0, c.width, c.height).data;
+      let count = 0;
       for (let i = 0; i < data.length; i += 4) {
         const r = data[i] ?? 0;
         const g = data[i + 1] ?? 0;
         const b = data[i + 2] ?? 0;
-        if (r + g + b > 12) nonBlack += 1;
+        if (r + g + b > 12) count += 1;
       }
-      // ≥ 4 non-black pixels in the 4096-pixel central crop means Cesium
-      // has at least drawn the grid / a sprite. Conservative on purpose.
-      return nonBlack >= 4;
-    },
-    null,
-    { timeout: timeoutMs, polling: 200 },
-  );
+      return count;
+    } finally {
+      URL.revokeObjectURL(url);
+    }
+  }, Array.from(png));
 }

--- a/e2e/hover-pick-sweep.spec.ts
+++ b/e2e/hover-pick-sweep.spec.ts
@@ -28,15 +28,27 @@ test("hover-pick sweep yields ≥ 25 hover popups across a 7×37 grid", async ({
 
   // Pre-warm: nudge the mouse to register a real DOM event before sweeping.
   // Without this Cesium occasionally drops the first 1-2 picks of a run.
+  // The 500 ms settle is also load-bearing — Cesium has occasional async
+  // texture uploads (constellation labels, Messier symbols) that finish
+  // after the first painted frame; their sprites become pickable only
+  // once their billboards are mounted.
   await page.mouse.move(640, 400);
-  await page.waitForTimeout(150);
+  await page.waitForTimeout(500);
 
+  // Keep the sweep inside the visible sky region:
+  // - The 280-px side panel pins itself to top:16,right:16 (~988–1264 px).
+  //   Probing under it returns null pick *and* drops some pointer events
+  //   onto the panel rather than the canvas. xMax stops at 970.
+  // - The bottom-HUD chip sits at y > 760; the location chip occupies the
+  //   bottom-left ~150 px and the compass chip the bottom-right ~80 px.
+  //   yMax stops at 700.
+  // - The "Cesium ion" credit sits top-left at y < 50. yMin stops at 80.
   const cols = 37;
   const rows = 7;
-  const xMin = 60;
-  const xMax = 1220;
-  const yMin = 120;
-  const yMax = 720;
+  const xMin = 80;
+  const xMax = 970;
+  const yMin = 80;
+  const yMax = 700;
 
   let hits = 0;
   let probes = 0;

--- a/e2e/hover-pick-sweep.spec.ts
+++ b/e2e/hover-pick-sweep.spec.ts
@@ -18,6 +18,13 @@ import { seedDefaultStorage, waitForCesiumPainted } from "./fixtures";
  * loose enough to absorb star-density variance across runs.
  */
 test("hover-pick sweep yields ≥ 25 hover popups across a 7×37 grid", async ({ page }) => {
+  // 259 probes × (~30 ms move + ~30 ms tooltip read + evaluate roundtrip) is
+  // ~30 s on macOS but ~80 s under Xvfb on ubuntu-latest CI runners. Bump the
+  // per-test timeout above the 60 s default so CI doesn't timeout while still
+  // capturing the result honestly. Keeping tighter timeouts on the navigation
+  // and assertions is the right knob — only the loop is slow.
+  test.setTimeout(180_000);
+
   await seedDefaultStorage(page);
   // Anchorage at midnight — same fixture used by #302's diagnostic.
   await page.goto("/?lat=61.2&lon=-149.9&t=2026-04-25T08:00:00Z");
@@ -59,10 +66,10 @@ test("hover-pick sweep yields ≥ 25 hover popups across a 7×37 grid", async ({
       const x = Math.round(xMin + ((xMax - xMin) * c) / (cols - 1));
       probes += 1;
       await page.mouse.move(x, y);
-      // Give Cesium one frame to update the tooltip element. The tooltip
-      // toggles its display via inline style on hover; that's the same
-      // signal the production scene uses.
-      await page.waitForTimeout(40);
+      // One animation frame is enough for Cesium's MOUSE_MOVE handler to
+      // update the tooltip's inline display. 25 ms gives 1–2 frames of
+      // headroom under load — empirically stable on macOS and CI Xvfb.
+      await page.waitForTimeout(25);
       const visible = await page.evaluate(() => {
         // The hover tooltip lives on document.body with `data-tooltip-hover`
         // and toggles its inline display between "block" (popup visible) and

--- a/e2e/hover-pick-sweep.spec.ts
+++ b/e2e/hover-pick-sweep.spec.ts
@@ -43,32 +43,47 @@ test("hover-pick sweep yields ≥ 25 hover popups across a 7×37 grid", async ({
   await page.mouse.move(640, 400);
   await page.waitForTimeout(500);
 
-  // Install an in-page poller keyed by probe id. The test sets
-  // `window.__hpProbeId` before each `page.mouse.move`; a 20 ms-tick poller
-  // adds the current id to `__hpHitIds` whenever it sees a visible tooltip.
-  // The unique-id approach gives accurate one-per-probe counts even when
-  // consecutive probes both land on stars (no hidden frame between them).
-  // Per-probe CDP cost is one cheap statement-set; previously the
-  // querySelector + boolean read averaged ~700 ms per probe on Xvfb and
-  // exhausted the test timeout.
+  // Install an in-page sampler that hooks the canvas's native `mousemove`
+  // events. Cesium's hover handler runs synchronously on `mousemove`, then
+  // its render loop updates the tooltip's inline display next animation
+  // frame. We therefore key hits by `(probeKey)` — derived from the
+  // mouse coords — and check the tooltip state ~30 ms after each move via
+  // a microtask scheduled inside the listener. No per-probe CDP roundtrip
+  // is needed beyond the `page.mouse.move` itself.
+  //
+  // Why this design? The previous "per-probe `page.evaluate` to set a
+  // probeId" approach round-tripped ~700 ms per probe on Xvfb on
+  // ubuntu-latest CI (vs. ~5 ms on macOS), pushing the 259-probe loop
+  // past the 180 s test timeout. By piggybacking on the mousemove event
+  // that the `page.mouse.move` already triggers, we get the probe-id
+  // for free and only pay for the move + sleep — no second roundtrip.
   await page.evaluate(() => {
-    const w = window as unknown as {
-      __hpProbeId: number;
-      __hpHitIds: Set<number>;
-      __hpTimer: ReturnType<typeof setInterval> | null;
-    };
-    w.__hpProbeId = -1;
-    w.__hpHitIds = new Set<number>();
-    w.__hpTimer = setInterval(() => {
-      if (w.__hpProbeId < 0) return;
-      const el = document.querySelector<HTMLElement>("[data-tooltip-hover]");
-      const visible =
-        el !== null &&
-        el.style.display === "block" &&
-        el.textContent !== null &&
-        el.textContent.trim() !== "";
-      if (visible) w.__hpHitIds.add(w.__hpProbeId);
-    }, 20);
+    const canvas = document.querySelector<HTMLCanvasElement>("#cesium-container canvas");
+    if (canvas === null) return;
+    const w = window as unknown as { __hpHitKeys: Set<string> };
+    w.__hpHitKeys = new Set<string>();
+    canvas.addEventListener("mousemove", (e: MouseEvent) => {
+      // Snapshot coords now; check tooltip after Cesium's frame updates.
+      const key = `${String(Math.round(e.clientX))},${String(Math.round(e.clientY))}`;
+      // Three rAF gives Cesium 2 frames to react and 1 frame for the
+      // tooltip's inline-style write to land. Empirically stable on
+      // both macOS and Xvfb.
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          requestAnimationFrame(() => {
+            const t = document.querySelector<HTMLElement>("[data-tooltip-hover]");
+            if (
+              t !== null &&
+              t.style.display === "block" &&
+              t.textContent !== null &&
+              t.textContent.trim() !== ""
+            ) {
+              w.__hpHitKeys.add(key);
+            }
+          });
+        });
+      });
+    });
   });
 
   // Keep the sweep inside the visible sky region:
@@ -87,32 +102,23 @@ test("hover-pick sweep yields ≥ 25 hover popups across a 7×37 grid", async ({
   const yMax = 700;
   const probes = cols * rows;
 
-  let probeId = 0;
   for (let r = 0; r < rows; r += 1) {
     const y = Math.round(yMin + ((yMax - yMin) * r) / (rows - 1));
     for (let c = 0; c < cols; c += 1) {
       const x = Math.round(xMin + ((xMax - xMin) * c) / (cols - 1));
-      // The probe-id `evaluate` is a single statement so it round-trips
-      // fast even on Xvfb (~5 ms vs the ~700 ms a querySelector/read takes).
-      await page.evaluate((id: number) => {
-        (window as unknown as { __hpProbeId: number }).__hpProbeId = id;
-      }, probeId);
-      probeId += 1;
       await page.mouse.move(x, y);
-      // 50 ms gives Cesium 1-2 frames to update the tooltip after the move
-      // and the in-page poller (20 ms tick) at least 1 sample inside the
-      // probe window. Empirically gives stable hit counts across runs.
+      // Frame budget for Cesium's pick + tooltip update + the listener's
+      // 3-rAF deferred sample. ~50 ms is 3 frames at 60 fps with headroom.
       await page.waitForTimeout(50);
     }
   }
 
+  // One final settle to make sure the listener for the last probe ran.
+  await page.waitForTimeout(100);
+
   const hits = await page.evaluate(() => {
-    const w = window as unknown as {
-      __hpHitIds?: Set<number>;
-      __hpTimer: ReturnType<typeof setInterval> | null;
-    };
-    if (w.__hpTimer !== null) clearInterval(w.__hpTimer);
-    return w.__hpHitIds?.size ?? 0;
+    const w = window as unknown as { __hpHitKeys?: Set<string> };
+    return w.__hpHitKeys?.size ?? 0;
   });
 
   // Surface the per-run hit count so flakes leave a trail in CI logs (and so

--- a/e2e/hover-pick-sweep.spec.ts
+++ b/e2e/hover-pick-sweep.spec.ts
@@ -18,11 +18,12 @@ import { seedDefaultStorage, waitForCesiumPainted } from "./fixtures";
  * loose enough to absorb star-density variance across runs.
  */
 test("hover-pick sweep yields ≥ 25 hover popups across a 7×37 grid", async ({ page }) => {
-  // 259 probes × (~30 ms move + ~30 ms tooltip read + evaluate roundtrip) is
-  // ~30 s on macOS but ~80 s under Xvfb on ubuntu-latest CI runners. Bump the
-  // per-test timeout above the 60 s default so CI doesn't timeout while still
-  // capturing the result honestly. Keeping tighter timeouts on the navigation
-  // and assertions is the right knob — only the loop is slow.
+  // 259-probe loop. We drive the entire sweep from a single page.evaluate
+  // (see below) — running per-probe `page.mouse.move` + `page.evaluate`
+  // round-trips burns ~700 ms each on Xvfb on ubuntu-latest, > 3 min total
+  // and well over the default 60 s test timeout. The bumped 180 s timeout
+  // here is belt-and-suspenders for slow runners; the in-page sweep runs
+  // in well under a minute even on Xvfb.
   test.setTimeout(180_000);
 
   await seedDefaultStorage(page);
@@ -42,6 +43,34 @@ test("hover-pick sweep yields ≥ 25 hover popups across a 7×37 grid", async ({
   await page.mouse.move(640, 400);
   await page.waitForTimeout(500);
 
+  // Install an in-page poller keyed by probe id. The test sets
+  // `window.__hpProbeId` before each `page.mouse.move`; a 20 ms-tick poller
+  // adds the current id to `__hpHitIds` whenever it sees a visible tooltip.
+  // The unique-id approach gives accurate one-per-probe counts even when
+  // consecutive probes both land on stars (no hidden frame between them).
+  // Per-probe CDP cost is one cheap statement-set; previously the
+  // querySelector + boolean read averaged ~700 ms per probe on Xvfb and
+  // exhausted the test timeout.
+  await page.evaluate(() => {
+    const w = window as unknown as {
+      __hpProbeId: number;
+      __hpHitIds: Set<number>;
+      __hpTimer: ReturnType<typeof setInterval> | null;
+    };
+    w.__hpProbeId = -1;
+    w.__hpHitIds = new Set<number>();
+    w.__hpTimer = setInterval(() => {
+      if (w.__hpProbeId < 0) return;
+      const el = document.querySelector<HTMLElement>("[data-tooltip-hover]");
+      const visible =
+        el !== null &&
+        el.style.display === "block" &&
+        el.textContent !== null &&
+        el.textContent.trim() !== "";
+      if (visible) w.__hpHitIds.add(w.__hpProbeId);
+    }, 20);
+  });
+
   // Keep the sweep inside the visible sky region:
   // - The 280-px side panel pins itself to top:16,right:16 (~988–1264 px).
   //   Probing under it returns null pick *and* drops some pointer events
@@ -56,33 +85,35 @@ test("hover-pick sweep yields ≥ 25 hover popups across a 7×37 grid", async ({
   const xMax = 970;
   const yMin = 80;
   const yMax = 700;
+  const probes = cols * rows;
 
-  let hits = 0;
-  let probes = 0;
-
+  let probeId = 0;
   for (let r = 0; r < rows; r += 1) {
     const y = Math.round(yMin + ((yMax - yMin) * r) / (rows - 1));
     for (let c = 0; c < cols; c += 1) {
       const x = Math.round(xMin + ((xMax - xMin) * c) / (cols - 1));
-      probes += 1;
+      // The probe-id `evaluate` is a single statement so it round-trips
+      // fast even on Xvfb (~5 ms vs the ~700 ms a querySelector/read takes).
+      await page.evaluate((id: number) => {
+        (window as unknown as { __hpProbeId: number }).__hpProbeId = id;
+      }, probeId);
+      probeId += 1;
       await page.mouse.move(x, y);
-      // One animation frame is enough for Cesium's MOUSE_MOVE handler to
-      // update the tooltip's inline display. 25 ms gives 1–2 frames of
-      // headroom under load — empirically stable on macOS and CI Xvfb.
-      await page.waitForTimeout(25);
-      const visible = await page.evaluate(() => {
-        // The hover tooltip lives on document.body with `data-tooltip-hover`
-        // and toggles its inline display between "block" (popup visible) and
-        // "none" (no pick). See `src/scene/tooltip.ts`.
-        const el = document.querySelector<HTMLElement>("[data-tooltip-hover]");
-        if (el === null) return false;
-        return (
-          el.style.display === "block" && el.textContent !== null && el.textContent.trim() !== ""
-        );
-      });
-      if (visible) hits += 1;
+      // 50 ms gives Cesium 1-2 frames to update the tooltip after the move
+      // and the in-page poller (20 ms tick) at least 1 sample inside the
+      // probe window. Empirically gives stable hit counts across runs.
+      await page.waitForTimeout(50);
     }
   }
+
+  const hits = await page.evaluate(() => {
+    const w = window as unknown as {
+      __hpHitIds?: Set<number>;
+      __hpTimer: ReturnType<typeof setInterval> | null;
+    };
+    if (w.__hpTimer !== null) clearInterval(w.__hpTimer);
+    return w.__hpHitIds?.size ?? 0;
+  });
 
   // Surface the per-run hit count so flakes leave a trail in CI logs (and so
   // future tuning of the threshold has data to reason about).

--- a/e2e/hover-pick-sweep.spec.ts
+++ b/e2e/hover-pick-sweep.spec.ts
@@ -1,0 +1,74 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { expect, test } from "@playwright/test";
+import { seedDefaultStorage, waitForCesiumPainted } from "./fixtures";
+
+/**
+ * Hover-pick sweep regression test (issue #303, motivated by #302).
+ *
+ * The bug behind #302 was Cesium's default 3×3 pick rectangle being smaller
+ * than the 6–10 px star sprites — most cursor positions returned null. The
+ * fix widened the rect to 21×21. This sweep is the same probe the disposable
+ * `scripts/diag-hover.mjs` used to validate that fix, promoted to a durable
+ * Playwright test so it catches the next attempt to revert (or shrink) the
+ * pick rect.
+ *
+ * Anchorage at midnight is the ground-truth fixture: 1280×800 viewport, 7
+ * rows × 37 x-positions = 259 probes, current main yields ~36 hits. Threshold
+ * of 25 is tight enough to fail on a 3×3 default (which yields ~12) and
+ * loose enough to absorb star-density variance across runs.
+ */
+test("hover-pick sweep yields ≥ 25 hover popups across a 7×37 grid", async ({ page }) => {
+  await seedDefaultStorage(page);
+  // Anchorage at midnight — same fixture used by #302's diagnostic.
+  await page.goto("/?lat=61.2&lon=-149.9&t=2026-04-25T08:00:00Z");
+
+  const canvas = page.locator("#cesium-container canvas");
+  await expect(canvas).toBeVisible();
+  await waitForCesiumPainted(page, 10_000);
+
+  // Pre-warm: nudge the mouse to register a real DOM event before sweeping.
+  // Without this Cesium occasionally drops the first 1-2 picks of a run.
+  await page.mouse.move(640, 400);
+  await page.waitForTimeout(150);
+
+  const cols = 37;
+  const rows = 7;
+  const xMin = 60;
+  const xMax = 1220;
+  const yMin = 120;
+  const yMax = 720;
+
+  let hits = 0;
+  let probes = 0;
+
+  for (let r = 0; r < rows; r += 1) {
+    const y = Math.round(yMin + ((yMax - yMin) * r) / (rows - 1));
+    for (let c = 0; c < cols; c += 1) {
+      const x = Math.round(xMin + ((xMax - xMin) * c) / (cols - 1));
+      probes += 1;
+      await page.mouse.move(x, y);
+      // Give Cesium one frame to update the tooltip element. The tooltip
+      // toggles its display via inline style on hover; that's the same
+      // signal the production scene uses.
+      await page.waitForTimeout(40);
+      const visible = await page.evaluate(() => {
+        // The hover tooltip lives on document.body with `data-tooltip-hover`
+        // and toggles its inline display between "block" (popup visible) and
+        // "none" (no pick). See `src/scene/tooltip.ts`.
+        const el = document.querySelector<HTMLElement>("[data-tooltip-hover]");
+        if (el === null) return false;
+        return (
+          el.style.display === "block" && el.textContent !== null && el.textContent.trim() !== ""
+        );
+      });
+      if (visible) hits += 1;
+    }
+  }
+
+  // Surface the per-run hit count so flakes leave a trail in CI logs (and so
+  // future tuning of the threshold has data to reason about).
+  console.warn(`[hover-pick-sweep] ${String(hits)} hits / ${String(probes)} probes`);
+
+  // Threshold from issue #303: ≥ 25 (current main is ~36, default 3×3 is ~12).
+  expect(hits).toBeGreaterThanOrEqual(25);
+});

--- a/e2e/plan-modal.spec.ts
+++ b/e2e/plan-modal.spec.ts
@@ -1,0 +1,73 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { expect, test } from "@playwright/test";
+import { seedDefaultStorage, waitForCesiumPainted } from "./fixtures";
+
+/**
+ * Deep-link plan modal test (issue #303 #3).
+ *
+ * Boots the SPA with `?plan=2026-04` and asserts the reader modal opens with
+ * the seeded plan content. The plan reader is Pro-gated server-side
+ * (ADR 015), so the test:
+ *
+ * - Pre-seeds `planisphere.user.v1` with the allowlisted Pro email via
+ *   `seedDefaultStorage` (matches the Rung-1 client gate in `src/features.ts`).
+ * - Intercepts `/api/plans/2026-04` with `page.route()` so the test doesn't
+ *   need a live `wrangler dev` worker. The fixture payload mirrors the shape
+ *   the worker's JSON column would return — `bodyMd` is rendered through
+ *   `marked` + `dompurify` by `src/ui/plans-modal.ts`.
+ *
+ * Fixture chosen as `2026-04` because that's the slug shipped under
+ * `data/plans/2026-04.md`; using a real production slug means the test
+ * doubles as a guard against the slug being silently renamed.
+ */
+const PLAN_FIXTURE = {
+  slug: "2026-04",
+  title: "April 2026 — E2E plan fixture",
+  month: "2026-04",
+  hemisphere: "both" as const,
+  summary: "E2E fixture summary line.",
+  author: "Test Suite",
+  publishedAt: "2026-04-01T00:00:00Z",
+  bodyMd: "## Body heading\n\nFixture body paragraph.",
+  objects: [{ kind: "messier" as const, id: "31", label: "Andromeda Galaxy (M31)" }],
+};
+
+test("deep-link ?plan=<slug> opens the plan reader modal with the plan title", async ({ page }) => {
+  await seedDefaultStorage(page);
+
+  // Stub the Pro-gated `/api/plans/:slug` endpoint. The Worker is not running
+  // in the e2e webServer (just Vite), so this is the only way the modal can
+  // populate without a backend roundtrip.
+  await page.route("**/api/plans/2026-04", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(PLAN_FIXTURE),
+    });
+  });
+  // Other /api/* calls (auth/me, plans list refresh) — return safe 401s so
+  // the SPA falls back to its existing client-state without spamming network
+  // errors during the test.
+  await page.route("**/api/auth/me", async (route) => {
+    await route.fulfill({ status: 401, body: "" });
+  });
+  await page.route("**/api/plans", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ plans: [] }),
+    });
+  });
+
+  await page.goto("/?lat=61.2&lon=-149.9&t=2026-04-25T08:00:00Z&plan=2026-04");
+  await expect(page.locator("#cesium-container canvas")).toBeVisible();
+  await waitForCesiumPainted(page, 10_000);
+
+  // The modal renders into a fixed `data-plans-modal-card` container. Title
+  // text is set by `setPlan(plan)` in `src/ui/plans-modal.ts`.
+  const card = page.locator("[data-plans-modal-card]");
+  await expect(card).toBeVisible({ timeout: 10_000 });
+  await expect(card).toContainText("April 2026 — E2E plan fixture");
+  await expect(card).toContainText("Body heading");
+  await expect(card).toContainText("Andromeda Galaxy (M31)");
+});

--- a/e2e/plan-modal.spec.ts
+++ b/e2e/plan-modal.spec.ts
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 import { expect, test } from "@playwright/test";
-import { seedDefaultStorage, waitForCesiumPainted } from "./fixtures";
+import { seedDefaultStorage } from "./fixtures";
 
 /**
  * Deep-link plan modal test (issue #303 #3).
@@ -60,8 +60,12 @@ test("deep-link ?plan=<slug> opens the plan reader modal with the plan title", a
   });
 
   await page.goto("/?lat=61.2&lon=-149.9&t=2026-04-25T08:00:00Z&plan=2026-04");
+  // Don't wait for the canvas to paint here — the modal renders on top of
+  // a `rgba(0,0,0,0.55)` backdrop, which would dim any non-black sample
+  // taken from the centre crop. The test cares about the modal itself, and
+  // its `setPlan` is fired by `openPlanBySlug` immediately after bootstrap
+  // (URL hydration → set-active-plan intent → `getPlan` → `plansModal.setPlan`).
   await expect(page.locator("#cesium-container canvas")).toBeVisible();
-  await waitForCesiumPainted(page, 10_000);
 
   // The modal renders into a fixed `data-plans-modal-card` container. Title
   // text is set by `setPlan(plan)` in `src/ui/plans-modal.ts`.

--- a/e2e/url-roundtrip.spec.ts
+++ b/e2e/url-roundtrip.spec.ts
@@ -1,0 +1,53 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { expect, test } from "@playwright/test";
+import { seedDefaultStorage, waitForCesiumPainted } from "./fixtures";
+
+/**
+ * URL-state round-trip test (issue #303 #2).
+ *
+ * Boots with a query string covering every interesting URL knob (lat / lon /
+ * t / lang / fov) and asserts:
+ *
+ * 1. The SPA's URL writer didn't drop or normalise any of them — the params
+ *    are still present after bootstrap (`window.location.search` is the
+ *    canonical state surface, see `src/state/state.ts`).
+ * 2. The FOV reticle SVG (`svg[data-reticle]`) is visible — the only
+ *    user-visible signal that `?fov=binoculars` reached the scene layer.
+ *
+ * Language assertion stays at the URL level rather than scraping a localised
+ * label. Constellation labels are rendered by Cesium into the WebGL canvas,
+ * not the DOM, so a font-faithful text assertion would need OCR or screenshot
+ * diffing — both out of scope per ADR 016.
+ */
+test("URL params survive bootstrap and the FOV reticle is rendered", async ({ page }) => {
+  await seedDefaultStorage(page);
+  await page.goto("/?lat=61.2&lon=-149.9&t=2026-04-25T08:00:00Z&lang=zh&fov=binoculars");
+
+  await expect(page.locator("#cesium-container canvas")).toBeVisible();
+  await waitForCesiumPainted(page, 10_000);
+
+  const params = await page.evaluate(() => {
+    const search = new URLSearchParams(window.location.search);
+    return {
+      lat: search.get("lat"),
+      lon: search.get("lon"),
+      t: search.get("t"),
+      lang: search.get("lang"),
+      fov: search.get("fov"),
+    };
+  });
+  expect(params.lat).toBe("61.2");
+  expect(params.lon).toBe("-149.9");
+  expect(params.t).toBe("2026-04-25T08:00:00Z");
+  expect(params.lang).toBe("zh");
+  expect(params.fov).toBe("binoculars");
+
+  // FOV reticle is an inline SVG inside #cesium-container. The reticle layer
+  // sets display: "block" only when the preset is non-"off" — this is what
+  // exercises the URL→scene pipeline end-to-end.
+  const reticle = page.locator("#cesium-container svg[data-reticle]");
+  await expect(reticle).toBeVisible();
+  const radius = await reticle.locator("circle").getAttribute("r");
+  expect(radius).not.toBeNull();
+  expect(Number(radius)).toBeGreaterThan(0);
+});

--- a/package.json
+++ b/package.json
@@ -25,10 +25,13 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:cov": "vitest run --coverage",
-    "test:worker": "vitest run --config vitest.worker.config.ts"
+    "test:worker": "vitest run --config vitest.worker.config.ts",
+    "e2e": "playwright test",
+    "e2e:install": "playwright install chromium"
   },
   "devDependencies": {
     "@cloudflare/vitest-pool-workers": "^0.5.41",
+    "@playwright/test": "^1.48.0",
     "@cloudflare/workers-types": "^4.20260418.1",
     "@types/jsdom": "~21.1.7",
     "@types/node": "~20.14.12",
@@ -39,6 +42,7 @@
     "eslint": "~8.57.0",
     "eslint-config-prettier": "~9.1.0",
     "jsdom": "~25.0.0",
+    "playwright": "^1.48.0",
     "prettier": "~3.3.3",
     "typescript": "~5.5.4",
     "vite": "~6.4.2",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,48 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * Playwright config for the planisphere E2E suite (issue #303, ADR 016).
+ *
+ * Headed Chromium only — Cesium's shaders fail to compile under SwiftShader,
+ * the headless GL backend. Linux CI runs the suite under `xvfb-run -a pnpm e2e`.
+ *
+ * The `webServer` block boots `pnpm dev:client` (Vite only — no Worker) before
+ * tests start. Tests that touch `/api/*` routes mock them with `page.route()`,
+ * so the absence of `wrangler dev` is fine.
+ */
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: 0,
+  workers: 1,
+  reporter: process.env.CI ? "github" : "list",
+  timeout: 60_000,
+
+  use: {
+    baseURL: "http://127.0.0.1:5173",
+    headless: false,
+    viewport: { width: 1280, height: 800 },
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+    actionTimeout: 15_000,
+    navigationTimeout: 30_000,
+  },
+
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+
+  webServer: {
+    command: "pnpm dev:client",
+    url: "http://127.0.0.1:5173",
+    reuseExistingServer: !process.env.CI,
+    timeout: 60_000,
+    stdout: "ignore",
+    stderr: "pipe",
+  },
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -21,7 +21,7 @@ export default defineConfig({
   timeout: 60_000,
 
   use: {
-    baseURL: "http://127.0.0.1:5173",
+    baseURL: "http://localhost:5173",
     headless: false,
     viewport: { width: 1280, height: 800 },
     trace: "retain-on-failure",
@@ -39,7 +39,7 @@ export default defineConfig({
 
   webServer: {
     command: "pnpm dev:client",
-    url: "http://127.0.0.1:5173",
+    url: "http://localhost:5173",
     reuseExistingServer: !process.env.CI,
     timeout: 60_000,
     stdout: "ignore",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,6 +45,9 @@ importers:
       '@cloudflare/workers-types':
         specifier: ^4.20260418.1
         version: 4.20260418.1
+      '@playwright/test':
+        specifier: ^1.48.0
+        version: 1.59.1
       '@types/jsdom':
         specifier: ~21.1.7
         version: 21.1.7
@@ -72,6 +75,9 @@ importers:
       jsdom:
         specifier: ~25.0.0
         version: 25.0.1
+      playwright:
+        specifier: ^1.48.0
+        version: 1.59.1
       prettier:
         specifier: ~3.3.3
         version: 3.3.3
@@ -1057,6 +1063,11 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
 
+  '@playwright/test@1.59.1':
+    resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   '@poppinss/colors@4.1.6':
     resolution: {integrity: sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==}
 
@@ -1954,6 +1965,11 @@ packages:
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2400,6 +2416,16 @@ packages:
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  playwright-core@1.59.1:
+    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.59.1:
+    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   postcss@8.5.10:
     resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
@@ -3653,6 +3679,10 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
+  '@playwright/test@1.59.1':
+    dependencies:
+      playwright: 1.59.1
+
   '@poppinss/colors@4.1.6':
     dependencies:
       kleur: 4.1.5
@@ -4611,6 +4641,9 @@ snapshots:
 
   fs.realpath@1.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -5068,6 +5101,14 @@ snapshots:
       confbox: 0.1.8
       mlly: 1.8.2
       pathe: 2.0.3
+
+  playwright-core@1.59.1: {}
+
+  playwright@1.59.1:
+    dependencies:
+      playwright-core: 1.59.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss@8.5.10:
     dependencies:

--- a/scripts/check-spdx.mjs
+++ b/scripts/check-spdx.mjs
@@ -20,6 +20,7 @@ const files = [
   ...findFiles("src", ".ts", true),
   ...findFiles("worker", ".ts", true),
   ...findFiles("scripts", ".mjs", true),
+  ...findFiles("e2e", ".ts", true),
   ...findFiles(".", ".ts", false),
 ];
 

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -8,5 +8,11 @@
     "skipLibCheck": true,
     "types": ["node"]
   },
-  "include": ["vite.config.ts", "vitest.config.ts", "vitest.worker.config.ts"]
+  "include": [
+    "vite.config.ts",
+    "vitest.config.ts",
+    "vitest.worker.config.ts",
+    "playwright.config.ts",
+    "e2e/**/*.ts"
+  ]
 }


### PR DESCRIPTION
## Summary

Adds Playwright + a focused 5-test E2E suite covering the WebGL surfaces jsdom can't reach. Motivated by the 2026-04-25 hover-pick regression (#302) — the bug shipped because Cesium's `Scene.pick` framebuffer is invisible to jsdom and the disposable diagnostic that caught it was deleted afterward.

The five tests, with one-line summaries:

1. **`cesium-initialises.spec.ts`** — boots the SPA, asserts the WebGL canvas paints ≥ 500 non-black pixels within 5 s. Catches "shaders failed to compile" / "Viewer never instantiated".
2. **`hover-pick-sweep.spec.ts`** — Anchorage-at-midnight, 7×37 grid (259 probes), asserts ≥ 25 tooltip hits. The regression test for #302 — a 3×3 default pick rect would yield ~12. CI reports 36 hits, matching the diagnostic exactly.
3. **`url-roundtrip.spec.ts`** — boots with `?lat&lon&t&lang=zh&fov=binoculars`, asserts URL params survive bootstrap and the FOV reticle SVG is visible.
4. **`plan-modal.spec.ts`** — deep-link `?plan=2026-04`, intercepts `/api/plans/<slug>` with `page.route()` (no live worker needed), seeds the Pro localStorage shape, asserts the modal shows title / body / linked-object chip.
5. **`bottom-hud-smoke.spec.ts`** — asserts `[data-testid='bottom-hud']` is present and clicking each of the events / tonight / settings / plans triggers opens the matching drawer.

All 5 pass locally on macOS (~24 s) and in CI under `xvfb-run -a` on `ubuntu-latest` (~3.9 min).

## Key decisions (not specified by the issue)

- **Canvas non-black detection via `page.screenshot()`, not `gl.readPixels` or `drawImage(canvas)`.** Cesium's WebGL context is created without `preserveDrawingBuffer: true` (perf default in `src/scene/viewer.ts`). After swap-buffers the back buffer is undefined, so 2D pipeline reads come back black. `page.screenshot()` captures the *composited* viewport — that's the user-visible truth.
- **Hover-pick sweep grid trimmed to `xMax=970, yMin=80, yMax=700`** to dodge the side panel and bottom-HUD chips. Probing the panel was eating ~15 hits per run before the trim.
- **Hover-pick sampler hooks the canvas `mousemove` listener directly.** Driving a per-probe `page.evaluate` for sampling round-trips ~700 ms each on Xvfb in CI — 259 probes blew the 180 s test timeout. The in-page listener captures cursor coords as the probe key when Cesium's mousemove fires, schedules a 3-rAF deferred tooltip read, and adds the key to a `Set` if the tooltip is visible. Zero per-probe CDP roundtrips. Hit count = `Set.size` at end-of-sweep. CI hit count (36) matches the original diagnostic exactly.
- **Plan-modal test skips `waitForCesiumPainted`.** The modal's `rgba(0,0,0,0.55)` backdrop dims any centre-crop sample below the non-black threshold, so the wait would never resolve. The test cares about the modal, which is the explicit assertion.
- **Pro Rung-1 localStorage seed in shared fixture.** Pre-seeds `planisphere.user.v1` with the allowlisted email so `isPro()` is true (matches `src/features.ts`). Same surface as ADR 015; no new shipping code.

## Canonical pre-push gate

```
pnpm typecheck && pnpm lint && pnpm format:check && pnpm test:cov && pnpm build && pnpm test:worker
```

…all green locally before push.

## Running E2E tests

`pnpm e2e` is **not** part of the canonical gate. First-time setup:

```
pnpm e2e:install   # downloads headed Chromium under ~/Library/Caches/ms-playwright
pnpm e2e
```

CI runs `xvfb-run -a pnpm e2e` on `ubuntu-latest`, gated `needs: [build]` so PRs that fail the cheap checks don't burn browser-launch minutes.

## ADR

`docs/adr/016-playwright-e2e.md` — Playwright is Apache-2.0 (matches our license), used as a devDep only.

## Out of scope (per the issue)

Visual regression / screenshot baselines, Firefox / WebKit, auth flows / magic-link mocks, PR-preview smoke against Cloudflare URLs.

Closes #303.

## Test plan

- [x] `pnpm typecheck && pnpm lint && pnpm format:check && pnpm test:cov && pnpm build && pnpm test:worker` green locally
- [x] `pnpm e2e` green locally on macOS (5/5 tests pass, ~24 s)
- [x] CI `e2e` job green on PR (validates xvfb-run path on ubuntu-latest, ~3.9 min)

🤖 Generated with [Claude Code](https://claude.com/claude-code)