### PR TITLE
test(e2e): lock in constellation-line hover-pick (regression test for #305)

### DIFF
--- a/e2e/hover-pick-sweep.spec.ts
+++ b/e2e/hover-pick-sweep.spec.ts
@@ -60,8 +60,16 @@ test("hover-pick sweep yields ≥ 25 hover popups across a 7×37 grid", async ({
   await page.evaluate(() => {
     const canvas = document.querySelector<HTMLCanvasElement>("#cesium-container canvas");
     if (canvas === null) return;
-    const w = window as unknown as { __hpHitKeys: Set<string> };
+    const w = window as unknown as {
+      __hpHitKeys: Set<string>;
+      __hpKindCounts: Record<string, number>;
+    };
     w.__hpHitKeys = new Set<string>();
+    // Per-pick "kind" tally so we can assert that the sweep doesn't go all
+    // stars — constellation-line picks (regression case from #305) need to
+    // show up too. Star popups end with "RA …", constellation popups with
+    // "(constellation)"; we key on those textContent suffixes.
+    w.__hpKindCounts = { star: 0, constellation: 0, other: 0 };
     canvas.addEventListener("mousemove", (e: MouseEvent) => {
       // Snapshot coords now; check tooltip after Cesium's frame updates.
       const key = `${String(Math.round(e.clientX))},${String(Math.round(e.clientY))}`;
@@ -79,6 +87,16 @@ test("hover-pick sweep yields ≥ 25 hover popups across a 7×37 grid", async ({
               t.textContent.trim() !== ""
             ) {
               w.__hpHitKeys.add(key);
+              const txt = t.textContent;
+              if (txt.includes("(constellation)")) {
+                w.__hpKindCounts.constellation += 1;
+              } else if (/RA \d+h/.test(txt)) {
+                // Stars / planets / Messier all show RA — distinguishing
+                // them further isn't useful for this regression assertion.
+                w.__hpKindCounts.star += 1;
+              } else {
+                w.__hpKindCounts.other += 1;
+              }
             }
           });
         });
@@ -116,15 +134,34 @@ test("hover-pick sweep yields ≥ 25 hover popups across a 7×37 grid", async ({
   // One final settle to make sure the listener for the last probe ran.
   await page.waitForTimeout(100);
 
-  const hits = await page.evaluate(() => {
-    const w = window as unknown as { __hpHitKeys?: Set<string> };
-    return w.__hpHitKeys?.size ?? 0;
+  const sample = await page.evaluate(() => {
+    const w = window as unknown as {
+      __hpHitKeys?: Set<string>;
+      __hpKindCounts?: Record<string, number>;
+    };
+    return {
+      hits: w.__hpHitKeys?.size ?? 0,
+      kinds: w.__hpKindCounts ?? { star: 0, constellation: 0, other: 0 },
+    };
   });
 
   // Surface the per-run hit count so flakes leave a trail in CI logs (and so
   // future tuning of the threshold has data to reason about).
-  console.warn(`[hover-pick-sweep] ${String(hits)} hits / ${String(probes)} probes`);
+  console.warn(
+    `[hover-pick-sweep] ${String(sample.hits)} hits / ${String(probes)} probes ` +
+      `(stars=${String(sample.kinds.star)}, ` +
+      `constellations=${String(sample.kinds.constellation)}, ` +
+      `other=${String(sample.kinds.other)})`,
+  );
 
   // Threshold from issue #303: ≥ 25 (current main is ~36, default 3×3 is ~12).
-  expect(hits).toBeGreaterThanOrEqual(25);
+  expect(sample.hits).toBeGreaterThanOrEqual(25);
+
+  // Regression test for #305: constellation polylines must carry an `id` so
+  // hovering a stick-figure line opens its constellation popup. With #305
+  // landed, the 7×37 grid over Anchorage at midnight reliably picks up at
+  // least 1 constellation line (Ursa Major's stick figure is dead centre).
+  // Without #305, this drops to 0 — labels alone are too small to land in
+  // the sweep.
+  expect(sample.kinds.constellation).toBeGreaterThanOrEqual(1);
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -17,7 +17,11 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: 0,
   workers: 1,
-  reporter: process.env.CI ? "github" : "list",
+  // CI gets GitHub annotations *and* an HTML report written to
+  // `playwright-report/` so the workflow's upload-artifact step has
+  // something to upload (it currently warns "No files were found"
+  // because neither "github" nor "list" writes a report directory).
+  reporter: process.env.CI ? [["github"], ["html", { open: "never" }]] : "list",
   timeout: 60_000,
 
   use: {


### PR DESCRIPTION
## Summary

Adds a regression assertion to the hover-pick sweep so a future revert of #305's polyline-id fix fails CI.

The existing sweep counts total hits but star popups alone hit ≥ 25 even when constellation lines silently break, so the existing threshold doesn't catch the #305 class of bug. New: in-page sampler tallies by popup kind via textContent — "(constellation)" suffix vs "RA <h>" for everything else — and asserts \`constellation >= 1\`.

## Local run

\`\`\`
[hover-pick-sweep] 52 hits / 259 probes (stars=36, constellations=16, other=0)
✓ hover-pick sweep yields ≥ 25 hover popups across a 7×37 grid (18.8s)
5 passed (27.0s)
\`\`\`

## Test plan

- [x] \`pnpm typecheck\` / \`pnpm lint\` / \`pnpm format:check\` / \`pnpm test:cov\` (1300/1300, 96.61% / 87.54%) / \`pnpm build\` / \`pnpm test:worker\` (103/103) all green.
- [x] \`pnpm e2e\` locally on macOS — 5 passed including the new constellation-≥1 assertion.
- [ ] CI \`e2e\` job on Xvfb — verifies constellation hits aren't macOS-only.

## Related

- Filed #307 for the analogous boundary-line gap (deferred).

🤖 Generated with [Claude Code](https://claude.com/claude-code)