### PR TITLE
fix(scene): wheel-pan dispatches set-view so 'Copy link' captures the panned view

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1029,6 +1029,13 @@ export async function bootstrap(
     getObserver: () => ({ lat: state.observer.lat, lon: state.observer.lon }),
     resolveObjectAt,
     onZoom: () => layers.reticle?.render(),
+    onPan: (az, alt) => {
+      // Mirror the wheel-pan into AppState so the URL serialiser picks up
+      // the new view direction (`?vaz=…&valt=…`). Without this, panning
+      // visually moves the camera but the URL stays bare — "Copy link"
+      // produces a default-pointing URL instead of the user's current view.
+      handleIntent({ type: "set-view", az, alt });
+    },
   });
 
   // Events drawer — celestial event alerts (conjunctions / lunar eclipses / meteor showers / ISS).

--- a/src/app.ts
+++ b/src/app.ts
@@ -791,7 +791,11 @@ export async function bootstrap(
     state.view.az,
     state.view.alt,
   );
-  setupTrackballControls(viewer);
+  setupTrackballControls(viewer, {
+    onPan: (az, alt) => {
+      handleIntent({ type: "set-view", az, alt });
+    },
+  });
 
   // Create all layers
   const cesiumContainerEl = document.getElementById("cesium-container");

--- a/src/scene/camera.ts
+++ b/src/scene/camera.ts
@@ -282,7 +282,18 @@ export function setupGestures(viewer: Viewer, options: GestureOptions): GestureH
   return { destroy };
 }
 
-export function setupTrackballControls(viewer: Viewer): void {
+export type TrackballOptions = {
+  /**
+   * Called after each drag-rotation (or inertia frame) with the camera's
+   * current heading/pitch in degrees. Lets the caller mirror the rotation
+   * into AppState so URL serialisation (`?vaz=…&valt=…`) stays in sync —
+   * without it, drag-panning leaves "Copy link" producing a default URL.
+   * Mirrors `GestureOptions.onPan` for the wheel-pan path.
+   */
+  onPan?: (azDeg: number, altDeg: number) => void;
+};
+
+export function setupTrackballControls(viewer: Viewer, options: TrackballOptions = {}): void {
   const scene = viewer.scene;
   const camera = viewer.camera;
   const controller = scene.screenSpaceCameraController;
@@ -323,6 +334,15 @@ export function setupTrackballControls(viewer: Viewer): void {
     Cartesian3.normalize(camera.right, camera.right);
     Cartesian3.cross(camera.right, camera.direction, camera.up);
     Cartesian3.normalize(camera.up, camera.up);
+
+    // After rotation, sync the new heading/pitch back into state.view via
+    // onPan (if provided). Cesium derives heading/pitch from the
+    // direction/up/right vectors we just mutated.
+    if (options.onPan !== undefined) {
+      const az = getCameraHeadingDeg(camera);
+      const alt = getCameraPitchDeg(camera);
+      options.onPan(az, alt);
+    }
   }
 
   handler.setInputAction((click: ScreenSpaceEventHandler.PositionedEvent) => {

--- a/src/scene/camera.ts
+++ b/src/scene/camera.ts
@@ -125,6 +125,14 @@ export type GestureOptions = {
   resolveObjectAt: (x: number, y: number) => AzAltPosition | null;
   /** Called after a zoom changes the camera FOV (so callers can re-render reticle). */
   onZoom?: () => void;
+  /**
+   * Called after a wheel-pan changes the camera's az/alt. Lets the caller
+   * propagate the new view direction into AppState so URL serialisation
+   * (`?vaz=…&valt=…`) and other state-derived UI stay in sync. Without
+   * this, scroll-panning leaves the URL pointing at the default view —
+   * "Copy link" produces a bare URL.
+   */
+  onPan?: (azDeg: number, altDeg: number) => void;
 };
 
 export type GestureHandle = {
@@ -197,6 +205,7 @@ export function setupGestures(viewer: Viewer, options: GestureOptions): GestureH
     );
     const nextAz = wrapAz(currentAz + deltaXPx * WHEEL_PAN_DEG_PER_PX);
     setCameraView(camera, lat, lon, nextAz, nextAlt);
+    options.onPan?.(nextAz, nextAlt);
   }
 
   // Bypass Cesium's WHEEL action so we can read both deltaX (trackpad


### PR DESCRIPTION
## Summary

Reported: "link request gets bare link, not one pointed where/when I am."

The wheel-pan handler in \`setupGestures\` was calling \`setCameraView\` directly to move the camera, but never dispatching a \`set-view\` intent — so \`state.view\` stayed at the default (az=0, alt=89.9), the URL serialiser never wrote \`?vaz=…&valt=…\`, and the "Copy link" button always produced a default-pointing URL regardless of how far the user had scroll-panned.

## Fix

Add an \`onPan?: (az, alt) => void\` callback to \`GestureOptions\`. The wheel-pan handler invokes it after \`setCameraView\`. \`app.ts\` wires it to dispatch a \`set-view\` intent, which updates state via the existing handler chain and triggers \`updateUrl\`.

## Verification (Playwright)

\`\`\`
BEFORE pan: URL = http://localhost:5173/
AFTER 30 wheel ticks: URL = http://localhost:5173/?lat=0&lon=0&t=2026-04-26T15:36:10.600Z&vaz=220&valt=0
\`\`\`

## Adjacent finding

The user's "no popups when I pan to Monoceros" report turned out to be a sky-state issue rather than a hover bug. At lat=0/lon=0/now, Monoceros is below the observer's horizon, so its stars/lines are culled (\`alt > 0\` filter in \`filterVisibleStars\` / \`filterVisibleConstellations\`). Panning the camera doesn't move the observer, so the culled region stays culled. With this fix landed, that relationship is now reproducible by URL — paste a panned link and the observer's sky-state is unchanged. Not opening a separate issue; flagging here for awareness.

## Test plan

- [x] \`pnpm typecheck\` / \`pnpm lint\` / \`pnpm format:check\` / \`pnpm test:cov\` (1300/1300, 96.61% / 87.54%) / \`pnpm build\` / \`pnpm test:worker\` (103/103) — all green.
- [ ] Manual: scroll-pan, hit Copy link, paste into a fresh tab — should open at the panned view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)