### PR TITLE
fix(scripts): seed-plans reads D1 name from wrangler.jsonc

### DIFF
--- a/scripts/seed-plans.mjs
+++ b/scripts/seed-plans.mjs
@@ -117,11 +117,35 @@ function inlineStatement({ sql, binds }) {
   return sql.replace(/\?/g, () => sqlLiteral(binds[i++])) + ";";
 }
 
+/**
+ * Pull the D1 binding's `database_name` out of wrangler.jsonc so the seed
+ * script doesn't drift from the deploy config. The file is JSONC (with
+ * comments + trailing commas), so a strict JSON.parse fails — we strip
+ * `// …` line comments, `/* … *\/` block comments, and trailing commas
+ * before parsing. Cheaper than pulling in jsonc-parser as a dep.
+ */
+function readDatabaseNameFromWrangler(root) {
+  const wranglerPath = join(root, "wrangler.jsonc");
+  const raw = readFileSync(wranglerPath, "utf8");
+  const stripped = raw
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/(^|[^:])\/\/.*$/gm, "$1")
+    .replace(/,(\s*[}\]])/g, "$1");
+  const cfg = JSON.parse(stripped);
+  const dbs = Array.isArray(cfg.d1_databases) ? cfg.d1_databases : [];
+  const binding = dbs.find((d) => d.binding === "DB") ?? dbs[0];
+  if (!binding || typeof binding.database_name !== "string") {
+    throw new Error("wrangler.jsonc missing d1_databases[].database_name");
+  }
+  return binding.database_name;
+}
+
 function main() {
   const root = resolve(new URL(".", import.meta.url).pathname, "..");
   const plansDir = join(root, "data", "plans");
   const sqlPath = join(root, "scripts", ".seed-plans.sql");
   const isRemote = process.argv.includes("--remote");
+  const dbName = readDatabaseNameFromWrangler(root);
 
   let files;
   try {
@@ -150,13 +174,7 @@ function main() {
 
   writeFileSync(sqlPath, statements.join("\n") + "\n", "utf8");
 
-  const args = [
-    "d1",
-    "execute",
-    "planisphere",
-    isRemote ? "--remote" : "--local",
-    `--file=${sqlPath}`,
-  ];
+  const args = ["d1", "execute", dbName, isRemote ? "--remote" : "--local", `--file=${sqlPath}`];
   const result = spawnSync("wrangler", args, { stdio: "inherit" });
   if (result.status !== 0) {
     console.error("wrangler d1 execute failed");


### PR DESCRIPTION
## Summary

\`scripts/seed-plans.mjs\` hardcoded \`planisphere\` as the D1 database name. The provisioned D1 in this project is \`planisphere-dev\`, so \`pnpm seed-plans --remote\` failed with \`Couldn't find DB with name 'planisphere'\` — blocking the #220 production seed step.

Read the name from \`wrangler.jsonc\`'s \`d1_databases[binding=DB].database_name\` instead. JSONC parsing is done inline (strip block + line comments + trailing commas, then \`JSON.parse\`) — adding jsonc-parser as a devDep would have been overkill for this 5-line need.

## Test plan

- [x] \`pnpm typecheck\` / \`pnpm lint\` / \`pnpm format:check\` / \`pnpm test:cov\` (1300/1300, 96.61% / 87.54%) / \`pnpm build\` / \`pnpm test:worker\` (103/103) — all green.
- [x] \`pnpm test scripts/seed-plans.test.mjs\` — 10/10 (the parser/upsert tests are unaffected; the new helper has no test but is exercised by the next-commit deploy attempt).
- [ ] Manual: \`pnpm seed-plans --remote\` against the live D1 binding.

## Related

Surfaces during #220's post-merge deployment dance — Pro promotion + remote seed for the April viewing plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)