### PR TITLE
chore(ci): add DORA metrics + auto-label-incidents workflows

### DIFF
--- a/.github/workflows/auto-label-incidents.yml
+++ b/.github/workflows/auto-label-incidents.yml
@@ -1,0 +1,34 @@
+name: Auto Label Incidents
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  label_incident:
+    runs-on: ubuntu-latest
+    if: contains(github.event.issue.title, 'PROD') || contains(github.event.issue.title, 'CRASH')
+    permissions:
+      issues: write
+    steps:
+      - name: Ensure incident label exists and tag the issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            try {
+              await github.rest.issues.createLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: 'incident',
+                color: 'b60205',
+                description: 'Production incident (auto-labelled from issue title)'
+              });
+            } catch (e) {
+              if (e.status !== 422) { throw e; }
+            }
+
+            await github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ['incident']
+            });

--- a/.github/workflows/dora-metrics.yml
+++ b/.github/workflows/dora-metrics.yml
@@ -1,0 +1,39 @@
+name: DORA Metrics
+on:
+  push:
+    branches: [ main ]
+  schedule:
+    - cron: '30 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  dora-report:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: read
+      pull-requests: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Calculate DORA metrics
+        id: dora
+        uses: stenjo/devops-metrics-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Write metrics to job summary
+        run: |
+          {
+            echo "## DORA Metrics"
+            echo ""
+            echo "| Metric | Value |"
+            echo "|---|---|"
+            echo "| Deploy frequency | ${{ steps.dora.outputs.deploy-rate }} releases/week |"
+            echo "| Lead time | ${{ steps.dora.outputs.lead-time }} days |"
+            echo "| Change failure rate | ${{ steps.dora.outputs.change-failure-rate }}% |"
+            echo "| Mean time to restore | ${{ steps.dora.outputs.mttr }} hours |"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/dora-metrics.yml
+++ b/.github/workflows/dora-metrics.yml
@@ -1,9 +1,9 @@
 name: DORA Metrics
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   schedule:
-    - cron: '30 0 * * *'
+    - cron: "30 0 * * *"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Adds two CI hygiene workflows, matching the rollout across my other repos:

1. **DORA metrics** (`.github/workflows/dora-metrics.yml`) — runs `stenjo/devops-metrics-action@v1` daily and on push to `main`; computes deploy frequency, lead time, change failure rate, and MTTR; writes results to the workflow run summary.
2. **Auto-label incidents** (`.github/workflows/auto-label-incidents.yml`) — tags newly opened issues with `incident` when the title contains `PROD` or `CRASH`. Idempotently creates the `incident` label on first run.

No code changes. No code dependencies. Token permissions scoped to read-only for DORA, and `issues: write` for auto-label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)