### PR TITLE
fix(ci): guard DORA for empty release list + force Node 24

### DIFF
--- a/.github/workflows/auto-label-incidents.yml
+++ b/.github/workflows/auto-label-incidents.yml
@@ -3,6 +3,9 @@ on:
   issues:
     types: [opened]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   label_incident:
     runs-on: ubuntu-latest

--- a/.github/workflows/dora-metrics.yml
+++ b/.github/workflows/dora-metrics.yml
@@ -6,6 +6,9 @@ on:
     - cron: "30 0 * * *"
   workflow_dispatch:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   dora-report:
     runs-on: ubuntu-latest
@@ -19,7 +22,16 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Count releases
+        id: releases
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          COUNT=$(gh release list --limit 1 --json tagName | jq 'length')
+          echo "count=$COUNT" >> "$GITHUB_OUTPUT"
+
       - name: Calculate DORA metrics
+        if: steps.releases.outputs.count != '0'
         id: dora
         uses: stenjo/devops-metrics-action@v1
         with:
@@ -27,13 +39,21 @@ jobs:
 
       - name: Write metrics to job summary
         run: |
-          {
-            echo "## DORA Metrics"
-            echo ""
-            echo "| Metric | Value |"
-            echo "|---|---|"
-            echo "| Deploy frequency | ${{ steps.dora.outputs.deploy-rate }} releases/week |"
-            echo "| Lead time | ${{ steps.dora.outputs.lead-time }} days |"
-            echo "| Change failure rate | ${{ steps.dora.outputs.change-failure-rate }}% |"
-            echo "| Mean time to restore | ${{ steps.dora.outputs.mttr }} hours |"
-          } >> "$GITHUB_STEP_SUMMARY"
+          if [ "${{ steps.releases.outputs.count }}" = "0" ]; then
+            {
+              echo "## DORA Metrics"
+              echo ""
+              echo "_No GitHub releases yet — cut a release to start tracking deploy frequency, change failure rate, and MTTR. The workflow will start reporting metrics on the next run after the first release._"
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            {
+              echo "## DORA Metrics"
+              echo ""
+              echo "| Metric | Value |"
+              echo "|---|---|"
+              echo "| Deploy frequency | ${{ steps.dora.outputs.deploy-rate }} releases/week |"
+              echo "| Lead time | ${{ steps.dora.outputs.lead-time }} days |"
+              echo "| Change failure rate | ${{ steps.dora.outputs.change-failure-rate }}% |"
+              echo "| Mean time to restore | ${{ steps.dora.outputs.mttr }} hours |"
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi


### PR DESCRIPTION
Two follow-up fixes for the DORA workflow:

1. **Empty release list error.** `stenjo/devops-metrics-action` errors out on `##[error]Empty release list` for repos without any GitHub releases. The workflow now pre-checks via `gh release list` and emits a friendly "no releases yet" summary instead of failing the build.
2. **Node 20 deprecation.** GitHub will force JS actions to Node 24 by default on June 2, 2026 and remove Node 20 from runners on Sept 16, 2026. Setting `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` at the workflow level opts every JS action (checkout, github-script, etc.) into Node 24 now.

Both `dora-metrics.yml` and `auto-label-incidents.yml` get the Node 24 env var. The DORA workflow gets the release-count guard.

No functional change once releases exist — the action runs the same way, just with the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)