### PR TITLE
chore(deps): ignore wrangler bumps until Cloudflare integration catches up

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Dependabot config. Prior to this file the repository ran on Dependabot's
+# default behaviour (weekly npm bumps into a single `npm_and_yarn` group).
+# This file preserves that behaviour and adds a targeted ignore rule for
+# `wrangler` — see the note below.
+
+version: 2
+
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      npm_and_yarn:
+        patterns:
+          - "*"
+    ignore:
+      # Cloudflare's Workers-Build Git integration rejects the build (0 s
+      # dispatch → failure, no Actions-side logs) when `wrangler` is
+      # bumped past 4.83.x on a PR branch. Reproduced on #313 both after
+      # a rebase onto current main (Node 20.19.4 via #316) and after a
+      # subsequent empty-commit retrigger. Same bump group succeeds when
+      # only touching Node / Vite (#316 was green with wrangler still at
+      # 4.83). Pin until the integration catches up.
+      - dependency-name: "wrangler"


### PR DESCRIPTION
## Summary

Ships `.github/dependabot.yml`, which the repo didn't previously have — Dependabot was running on default behaviour (weekly npm bumps into a single `npm_and_yarn` group). This preserves that behaviour and **adds a targeted ignore rule for `wrangler`**.

## Why

Step 2 of unsticking dependabot **PR #313**. Recap of the investigation:

- #313 is a grouped bump of `protobufjs 8.0.1 → 8.2.0`, `vite ~6.4.2 → ~7.3.2`, `wrangler ^4.83.0 → ^4.84.0`, and `@cloudflare/workerd-*` binaries.
- With Node bumped to 20.19.4 (#316, merged) the `build`, `test`, `lint`, `typecheck`, and `e2e` jobs are all green on #313.
- The only remaining red is **`Workers Builds: planisphere`** — Cloudflare's Workers-Build Git integration rejects the deploy at dispatch time (0-second status → failure). No Actions-side logs to inspect, and the Cloudflare dashboard is auth-walled (WebFetch → 403).
- Differential vs #316 (which is green with the same Node/Vite bumps but no wrangler bump): `wrangler ^4.83.0 → ^4.84.0` plus its workerd binary bumps.
- Empty-commit retrigger on #313's branch reproduced the same 0-second failure.

Ignoring `wrangler` in the npm group lets Dependabot recreate #313 without the wrangler bump — protobufjs / workerd binaries / any future group members keep flowing normally. Remove the ignore once the Workers-Build integration accepts wrangler ≥ 4.84.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean (config file is YAML with SPDX header, matches the repo's existing SPDX sweep)
- [x] `pnpm format:check` — clean

This PR is config-only (`.github/dependabot.yml`), no source changes; no test / build implications.

https://claude.ai/code/session_planisphere-open-issues-QFuWY

---
_Generated by [Claude Code](https://claude.ai/code/session_01VKmj4YQnxN8sydc7X6v2ra)_