### PR TITLE
chore(deps): unpin wrangler + add github-actions dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # Dependabot config. Prior to this file the repository ran on Dependabot's
-# default behaviour (weekly npm bumps into a single `npm_and_yarn` group).
-# This file preserves that behaviour and adds a targeted ignore rule for
-# `wrangler` — see the note below.
+# default behaviour. This file makes the schedule explicit and keeps the
+# grouping we've been using.
 
 version: 2
 
 updates:
+  # npm dependencies (both prod and dev) — grouped into one PR per week so
+  # security and version bumps land together and only need one CI cycle.
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
@@ -17,12 +18,12 @@ updates:
       npm_and_yarn:
         patterns:
           - "*"
-    ignore:
-      # Cloudflare's Workers-Build Git integration rejects the build (0 s
-      # dispatch → failure, no Actions-side logs) when `wrangler` is
-      # bumped past 4.83.x on a PR branch. Reproduced on #313 both after
-      # a rebase onto current main (Node 20.19.4 via #316) and after a
-      # subsequent empty-commit retrigger. Same bump group succeeds when
-      # only touching Node / Vite (#316 was green with wrangler still at
-      # 4.83). Pin until the integration catches up.
-      - dependency-name: "wrangler"
+
+  # GitHub Actions used by the workflows in .github/workflows/. Pinning them
+  # to tagged versions and letting Dependabot open PRs for each new release
+  # keeps supply-chain risk down without turning into manual work.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## Summary

Two related edits to `.github/dependabot.yml`:

1. **Remove the `wrangler` ignore rule.** It was added in #317 on the theory that `wrangler ^4.83.0 → ^4.84.0` was breaking the Cloudflare Workers Build on #313. Root cause turned out to be a stray `.node-version` file pinning Node 20.11.1 (fixed in #319); wrangler 4.84 was innocent and #313 landed green with it in place.
2. **Add a `github-actions` ecosystem entry** so Dependabot keeps the pinned actions in `.github/workflows/` up to date — weekly cadence, capped at 5 open PRs. This addresses your "check if we need dependency updates periodically" follow-up: npm was already weekly (from #317), this brings the same cadence to GitHub Actions versions.

Trimmed the file's comment header to just document the config, since it no longer needs to explain a workaround.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean (SPDX header preserved)
- [x] `pnpm format:check` — clean

Config-only. No source changes.

https://claude.ai/code/session_planisphere-open-issues-QFuWY

---
_Generated by [Claude Code](https://claude.ai/code/session_01VKmj4YQnxN8sydc7X6v2ra)_