### PR TITLE
chore(ts): drop unused baseUrl + @/* path alias from tsconfig (Mikado #335)

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,11 +21,6 @@
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true,
 
-    "baseUrl": ".",
-    "paths": {
-      "@/*": ["src/*"]
-    },
-
     "types": ["vite/client"]
   },
   "include": ["src"],


### PR DESCRIPTION
## Summary

**First Mikado leaf from #335.** TypeScript 6 (the eventual bulk-Dependabot bump) fails at:

```
tsconfig.json(24,5): error TS5101: Option 'baseUrl' is deprecated
and will stop functioning in TypeScript 7.0.
```

Two ways to satisfy TS 6:

1. Add `ignoreDeprecations: "6.0"` to `tsconfig.json` — one-line silence, kicks the can to TS 7.
2. Remove the deprecated option — permanent fix.

`grep -r 'from "@/' src/` returns nothing — the `@/*` path alias was never adopted. Both `baseUrl` and the `paths` block that requires it are dead config, so this PR removes them.

`tsconfig.json`'s remaining `moduleResolution: "Bundler"` handles Vite / Vitest module resolution without `baseUrl`. TS 5.5.4 (current) and TS 6.0.3 (future) both compile cleanly with this diff.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm format:check` — clean
- [x] `pnpm test:cov` — 1300 / 1300 pass, thresholds hold
- [x] `pnpm build` — succeeds

Refs #335.

https://claude.ai/code/session_planisphere-open-issues-QFuWY

---
_Generated by [Claude Code](https://claude.ai/code/session_01VKmj4YQnxN8sydc7X6v2ra)_