### PR TITLE
feat(scene): hover popup for constellation boundary lines (closes #307)

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -516,11 +516,15 @@ function doRerender(
   );
 
   if (data.boundaries.ok) {
+    const namesByCode = data.constellations.ok
+      ? new Map<string, string>(data.constellations.value.map((c) => [c.id, c.name] as const))
+      : undefined;
     const visibleBoundaries = filterVisibleBoundaries(
       data.boundaries.value,
       observer.lat,
       observer.lon,
       timeUtc,
+      namesByCode !== undefined ? { namesByCode } : undefined,
     );
     layers.boundary.update(visibleBoundaries, observer.lat, observer.lon);
   }
@@ -608,11 +612,15 @@ async function doRerenderWithWorker(
   layers.milkyWay.update(milkyWayPoints, observer.lat, observer.lon);
 
   if (data.boundaries.ok) {
+    const namesByCode = data.constellations.ok
+      ? new Map<string, string>(data.constellations.value.map((c) => [c.id, c.name] as const))
+      : undefined;
     const visibleBoundaries = filterVisibleBoundaries(
       data.boundaries.value,
       observer.lat,
       observer.lon,
       timeUtc,
+      namesByCode !== undefined ? { namesByCode } : undefined,
     );
     layers.boundary.update(visibleBoundaries, observer.lat, observer.lon);
   }
@@ -720,7 +728,7 @@ function pickedToCardData(
   picked: PickedObject,
   observer: { lat: number; lon: number },
   time: Date,
-): ObjectCardData {
+): ObjectCardData | null {
   switch (picked.kind) {
     case "star":
       return { kind: "star", star: picked.star };
@@ -732,6 +740,11 @@ function pickedToCardData(
       return { kind: "messier", messier: picked.messier };
     case "constellation":
       return { kind: "constellation", constellation: picked.constellation };
+    case "boundary":
+      // Boundaries currently render only a hover-name popup (#307). No
+      // pinned-card variant yet — return null so the click handler
+      // treats the boundary click as "no card".
+      return null;
   }
 }
 
@@ -1005,6 +1018,10 @@ export async function bootstrap(
         // Clicking an object replaces the empty-sky popover with the object card.
         emptySkyPopover?.close();
         const cardData = pickedToCardData(picked, state.observer, state.timeUtc);
+        if (cardData === null) {
+          // Boundary picks (#307) hover-only; no pinned card yet.
+          return;
+        }
         const objectKind = cardData.kind;
         const id = idForCardData(cardData);
         pendingCardData.set(positionKey(objectKind, id), cardData);

--- a/src/astro/boundaries.test.ts
+++ b/src/astro/boundaries.test.ts
@@ -146,4 +146,33 @@ describe("filterVisibleBoundaries", () => {
     const result = filterVisibleBoundaries(mixed, LAT, LON, TIME, stub);
     expect(result).toHaveLength(1);
   });
+
+  it("populates `name` from the provided namesByCode map (regression for #307)", () => {
+    const namesByCode = new Map<string, string>([
+      ["Ori", "Orion"],
+      ["UMa", "Ursa Major"],
+    ]);
+    const result = filterVisibleBoundaries(records, LAT, LON, TIME, {
+      namesByCode,
+      // Force all boundaries visible so the assertion is deterministic across time.
+      altFn: () => 30,
+    });
+    expect(result.map((b) => `${b.id}=${b.name}`).sort()).toEqual(["Ori=Orion", "UMa=Ursa Major"]);
+  });
+
+  it("falls back to the IAU code when the name map lacks an entry", () => {
+    const result = filterVisibleBoundaries(records, LAT, LON, TIME, {
+      namesByCode: new Map<string, string>([["Ori", "Orion"]]),
+      altFn: () => 30,
+    });
+    const uma = result.find((b) => b.id === "UMa");
+    expect(uma?.name).toBe("UMa");
+  });
+
+  it("falls back to the IAU code when no options are given at all", () => {
+    const result = filterVisibleBoundaries(records, LAT, LON, TIME, () => 30);
+    for (const b of result) {
+      expect(b.name).toBe(b.id);
+    }
+  });
 });

--- a/src/astro/boundaries.ts
+++ b/src/astro/boundaries.ts
@@ -16,6 +16,7 @@ export type BoundaryLoadError = { kind: "boundary-load-failed"; message: string 
 
 export type VisibleBoundary = {
   readonly id: string;
+  readonly name: string;
   readonly segments: readonly {
     readonly start: { readonly ra: number; readonly dec: number };
     readonly end: { readonly ra: number; readonly dec: number };
@@ -68,19 +69,32 @@ export function parseBoundaries(raw: unknown): Result<BoundaryRecord[], Boundary
  *
  * @param altFn - injectable altitude calculator for testing; defaults to raDecToAltAz
  */
+export type FilterVisibleBoundariesOptions = {
+  /** Optional lookup from IAU 3-letter code to display name (e.g. `"Ori" → "Orion"`).
+   *  When absent (or a boundary's id has no entry), `name` falls back to `id` —
+   *  the popup keeps working, it just shows the raw code. */
+  readonly namesByCode?: ReadonlyMap<string, string>;
+  /** Injectable altitude function (kept for existing tests that mock it). */
+  readonly altFn?: (ra: number, dec: number, lat: number, lon: number, time: Date) => number;
+};
+
 export function filterVisibleBoundaries(
   boundaries: BoundaryRecord[],
   lat: number,
   lon: number,
   timeUtc: Date,
-  altFn: (ra: number, dec: number, lat: number, lon: number, time: Date) => number = (
-    ra,
-    dec,
-    observerLat,
-    observerLon,
-    time,
-  ) => fastRaDecToAltAz(ra, dec, observerLat, observerLon, time).alt,
+  optionsOrAltFn?:
+    | FilterVisibleBoundariesOptions
+    | ((ra: number, dec: number, lat: number, lon: number, time: Date) => number),
 ): VisibleBoundary[] {
+  const options: FilterVisibleBoundariesOptions =
+    typeof optionsOrAltFn === "function" ? { altFn: optionsOrAltFn } : (optionsOrAltFn ?? {});
+  const altFn =
+    options.altFn ??
+    ((ra, dec, observerLat, observerLon, time) =>
+      fastRaDecToAltAz(ra, dec, observerLat, observerLon, time).alt);
+  const namesByCode = options.namesByCode;
+
   const result: VisibleBoundary[] = [];
 
   for (const boundary of boundaries) {
@@ -94,7 +108,11 @@ export function filterVisibleBoundaries(
       const end = boundary.vertices[(i + 1) % boundary.vertices.length]!;
       segments.push({ start, end });
     }
-    result.push({ id: boundary.id, segments });
+    result.push({
+      id: boundary.id,
+      name: namesByCode?.get(boundary.id) ?? boundary.id,
+      segments,
+    });
   }
 
   return result;

--- a/src/scene/boundaries.test.ts
+++ b/src/scene/boundaries.test.ts
@@ -62,6 +62,7 @@ function makeMockScene() {
 const BOUNDARIES: VisibleBoundary[] = [
   {
     id: "Ori",
+    name: "Orion",
     segments: [
       { start: { ra: 75, dec: 10 }, end: { ra: 90, dec: 10 } },
       { start: { ra: 90, dec: 10 }, end: { ra: 90, dec: -10 } },
@@ -69,6 +70,7 @@ const BOUNDARIES: VisibleBoundary[] = [
   },
   {
     id: "UMa",
+    name: "Ursa Major",
     segments: [{ start: { ra: 150, dec: 55 }, end: { ra: 180, dec: 55 } }],
   },
 ];
@@ -118,6 +120,17 @@ describe("BoundaryLayer.update", () => {
     layer.update(BOUNDARIES.slice(0, 1), 40, 0);
     expect(mockPolylineRemoveAll).toHaveBeenCalledOnce();
     expect(mockPolylineAdd).toHaveBeenCalledTimes(2);
+  });
+
+  it("attaches the VisibleBoundary as each polyline's pick id (regression for #307)", () => {
+    const layer = createBoundaryLayer(makeMockScene() as never);
+    layer.update(BOUNDARIES, 40, 0);
+    // 2 segments for Ori + 1 for UMa = 3 add() calls; each should have
+    // received an `id` matching its parent boundary.
+    const idsPassed = mockPolylineAdd.mock.calls.map(
+      (call) => (call[0] as { id?: { name?: string } }).id?.name,
+    );
+    expect(idsPassed).toEqual(["Orion", "Orion", "Ursa Major"]);
   });
 });
 

--- a/src/scene/boundaries.ts
+++ b/src/scene/boundaries.ts
@@ -44,6 +44,10 @@ export function createBoundaryLayer(scene: Scene): BoundaryLayer {
           material: Material.fromType("Color", {
             color: Color.WHITE.withAlpha(currentOpacity),
           }),
+          // Attach the VisibleBoundary so tooltip.pickObject can identify a
+          // boundary-line hit and open the "<name> — IAU boundary" popup
+          // (issue #307; mirrors the constellation figure-line fix in #305).
+          id: boundary,
         });
         addedPolylines.push(pl as never);
       }

--- a/src/scene/tooltip.test.ts
+++ b/src/scene/tooltip.test.ts
@@ -320,4 +320,54 @@ describe("createTooltip", () => {
     });
     expect(() => clickCallback({ position: { x: 10, y: 20 } })).not.toThrow();
   });
+
+  it("clicking an IAU boundary polyline invokes onObjectClicked with kind='boundary' (regression for #307)", () => {
+    const container = document.createElement("div");
+    const viewer = makeMockViewer();
+    const onObjectClicked = vi.fn();
+    createTooltip(viewer as never, container, { onObjectClicked });
+
+    const clickCallback = mockSetInputAction.mock.calls[1]![0] as (movement: {
+      position: { x: number; y: number };
+    }) => void;
+    // Shape mirrors VisibleBoundary from src/astro/boundaries.ts — id + name
+    // + segments, notably NO `centroid` / `lines` (which would type-guard
+    // it as a constellation instead).
+    mockPick.mockReturnValueOnce({
+      id: {
+        id: "Ori",
+        name: "Orion",
+        segments: [{ start: { ra: 75, dec: 10 }, end: { ra: 90, dec: 10 } }],
+      },
+    });
+    clickCallback({ position: { x: 200, y: 200 } });
+    expect(onObjectClicked).toHaveBeenCalledOnce();
+    const callArg = onObjectClicked.mock.calls[0]![0] as {
+      kind: string;
+      boundary?: { name: string };
+    };
+    expect(callArg.kind).toBe("boundary");
+    expect(callArg.boundary?.name).toBe("Orion");
+  });
+
+  it("hovering an IAU boundary polyline renders a name + '(IAU boundary)' hover tooltip", () => {
+    const container = document.createElement("div");
+    const viewer = makeMockViewer();
+    createTooltip(viewer as never, container);
+    const hoverCallback = mockSetInputAction.mock.calls[0]![0] as (movement: {
+      endPosition: { x: number; y: number };
+    }) => void;
+    mockPick.mockReturnValueOnce({
+      id: {
+        id: "UMa",
+        name: "Ursa Major",
+        segments: [{ start: { ra: 150, dec: 55 }, end: { ra: 180, dec: 55 } }],
+      },
+    });
+    hoverCallback({ endPosition: { x: 400, y: 100 } });
+    const el = document.querySelector<HTMLElement>("[data-tooltip-hover]");
+    expect(el).not.toBeNull();
+    expect(el!.innerHTML).toContain("Ursa Major");
+    expect(el!.innerHTML).toContain("IAU boundary");
+  });
 });

--- a/src/scene/tooltip.ts
+++ b/src/scene/tooltip.ts
@@ -6,6 +6,7 @@ import type { CelestialBody } from "../astro";
 import type { VisibleSatellite } from "../sat";
 import type { VisibleMessier } from "../astro/messier";
 import type { VisibleConstellation } from "../astro/constellations";
+import type { VisibleBoundary } from "../astro/boundaries";
 
 export type Tooltip = {
   destroy: () => void;
@@ -18,7 +19,8 @@ export type PickedObject =
   | { readonly kind: "body"; readonly body: CelestialBody }
   | { readonly kind: "satellite"; readonly satellite: VisibleSatellite }
   | { readonly kind: "messier"; readonly messier: VisibleMessier }
-  | { readonly kind: "constellation"; readonly constellation: VisibleConstellation };
+  | { readonly kind: "constellation"; readonly constellation: VisibleConstellation }
+  | { readonly kind: "boundary"; readonly boundary: VisibleBoundary };
 
 export type TooltipOptions = {
   /** Invoked on left-click. `picked` is the object under the cursor, or `null`
@@ -127,6 +129,20 @@ function isVisibleConstellation(obj: unknown): obj is VisibleConstellation {
   );
 }
 
+function isVisibleBoundary(obj: unknown): obj is VisibleBoundary {
+  return (
+    typeof obj === "object" &&
+    obj !== null &&
+    "id" in obj &&
+    "name" in obj &&
+    "segments" in obj &&
+    !("centroid" in obj) &&
+    !("lines" in obj) &&
+    typeof (obj as Record<string, unknown>).id === "string" &&
+    Array.isArray((obj as Record<string, unknown>).segments)
+  );
+}
+
 function formatMessier(obj: VisibleMessier): string {
   const label = obj.name.length > 0 ? `M${String(obj.m)} \u2014 ${obj.name}` : `M${String(obj.m)}`;
   return (
@@ -175,6 +191,7 @@ function pickObject(
   if (isVisibleSatellite(picked.id)) return { kind: "satellite", satellite: picked.id };
   if (isVisibleMessier(picked.id)) return { kind: "messier", messier: picked.id };
   if (isVisibleConstellation(picked.id)) return { kind: "constellation", constellation: picked.id };
+  if (isVisibleBoundary(picked.id)) return { kind: "boundary", boundary: picked.id };
   return null;
 }
 
@@ -190,6 +207,8 @@ function pickHtml(picked: PickedObject): string {
       return formatMessier(picked.messier);
     case "constellation":
       return `<strong>${picked.constellation.name}</strong><br>(constellation)`;
+    case "boundary":
+      return `<strong>${picked.boundary.name}</strong><br>(IAU boundary)`;
   }
 }
 


### PR DESCRIPTION
## Summary

Closes **#307**. Boundary polylines were added without a pick id, so hovering an IAU boundary line returned no popup — same shape as the constellation figure-line bug fixed in #305.

Implements approach 3 from the issue (boundary-specific popup, no cross-file coupling):

- **`VisibleBoundary` gains a `name` field.** `filterVisibleBoundaries` now accepts an options bag with `namesByCode: ReadonlyMap<string, string>` and populates `name`, falling back to the IAU id when no map is provided. The legacy positional `altFn` argument still works for the existing horizon-visibility tests.
- **Scene layer attaches the `VisibleBoundary` as each polyline's pick id** (mirrors the #305 fix on constellations.ts).
- **Tooltip picking** gains a `boundary` `PickedObject` variant, an `isVisibleBoundary` type guard, and a `<name><br>(IAU boundary)` popup format.
- **`app.ts`** builds a `Map<string, string>` from `data.constellations.value` at each filter call site and passes it in. No new file coupling.
- **Click-on-boundary** falls through the object-card path (`pickedToCardData` returns `null` for boundary picks) — no pinned card until a `kind: "boundary"` `ObjectCardData` variant is genuinely wanted.

## Tests

- `src/astro/boundaries.test.ts` — 3 new tests: name-map population, fallback when a code is missing, fallback when no map is given.
- `src/scene/boundaries.test.ts` — 1 new test asserts each polyline's `id` is the parent `VisibleBoundary`.
- `src/scene/tooltip.test.ts` — 2 new tests: click gives `kind: "boundary"`, hover renders `Ursa Major<br>(IAU boundary)`.

1300 → **1306** total; coverage thresholds unchanged.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm format:check` — clean
- [x] `pnpm test:cov` — 1306 / 1306, thresholds hold
- [x] `pnpm build` — succeeds

Closes #307.

https://claude.ai/code/session_planisphere-open-issues-QFuWY

---
_Generated by [Claude Code](https://claude.ai/code/session_01VKmj4YQnxN8sydc7X6v2ra)_