### PR TITLE
feat(time): play/pause + 1×/10×/100× speed animation (closes #136)

### DIFF
--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -398,6 +398,7 @@ vi.mock("./ui", () => ({
       setTime: vi.fn(),
       setObserver: vi.fn(),
       setCompass: vi.fn(),
+      setAnimation: vi.fn(),
       destroy: vi.fn(),
     };
   }),
@@ -1153,6 +1154,19 @@ describe("handleIntent routing", () => {
     const { root, panelRoot } = makeRoot();
     await bootstrap(root);
     expect(() => capturedDispatch!({ type: "toggle-animation" })).not.toThrow();
+    // Second toggle stops the animation loop — also must not throw.
+    expect(() => capturedDispatch!({ type: "toggle-animation" })).not.toThrow();
+    document.body.removeChild(root);
+    document.body.removeChild(panelRoot);
+  });
+
+  it("set-animation-speed intent is handled without throwing (#136)", async () => {
+    capturedDispatch = null;
+    const { root, panelRoot } = makeRoot();
+    await bootstrap(root);
+    expect(() => capturedDispatch!({ type: "set-animation-speed", speed: 10 })).not.toThrow();
+    expect(() => capturedDispatch!({ type: "set-animation-speed", speed: 100 })).not.toThrow();
+    expect(() => capturedDispatch!({ type: "set-animation-speed", speed: 1 })).not.toThrow();
     document.body.removeChild(root);
     document.body.removeChild(panelRoot);
   });

--- a/src/app.ts
+++ b/src/app.ts
@@ -1081,6 +1081,51 @@ export async function bootstrap(
   }
 
   let bottomHud: BottomHud | null = null;
+
+  // #136 — time animation state. Not URL-synced; animation is a transient
+  // client-side thing that shouldn't survive reload.
+  const animation: { playing: boolean; speed: 1 | 10 | 100 } = {
+    playing: false,
+    speed: 1,
+  };
+  let animationRafId: number | null = null;
+  let animationLastFrameMs = 0;
+  const ANIMATION_BASE_MS_PER_MS = 60_000; // 1× wall-second = 1 minute of sky time
+
+  function startAnimationLoop(): void {
+    if (animationRafId !== null) return;
+    animationLastFrameMs = 0;
+    const raf =
+      typeof globalThis.requestAnimationFrame === "function"
+        ? globalThis.requestAnimationFrame.bind(globalThis)
+        : null;
+    if (raf === null) return;
+    const tick = (): void => {
+      if (!animation.playing) {
+        animationRafId = null;
+        return;
+      }
+      const now =
+        typeof globalThis.performance?.now === "function" ? globalThis.performance.now() : 0;
+      const dt = animationLastFrameMs === 0 ? 16 : now - animationLastFrameMs;
+      animationLastFrameMs = now;
+      const advanceMs = dt * animation.speed * (ANIMATION_BASE_MS_PER_MS / 1000);
+      const next = new Date(state.timeUtc.getTime() + advanceMs);
+      handleIntent({ type: "set-time", time: next });
+      animationRafId = raf(tick);
+    };
+    animationRafId = raf(tick);
+  }
+
+  function stopAnimationLoop(): void {
+    if (animationRafId === null) return;
+    const caf =
+      typeof globalThis.cancelAnimationFrame === "function"
+        ? globalThis.cancelAnimationFrame.bind(globalThis)
+        : null;
+    if (caf !== null) caf(animationRafId);
+    animationRafId = null;
+  }
   let locationPicker: ReturnType<typeof createLocationPickerOverlay> | null = null;
   let notebookWorkspace: ReturnType<typeof createNotebookWorkspace> | null = null;
   let loginModal: ReturnType<typeof createLoginModal> | null = null;
@@ -1239,10 +1284,22 @@ export async function bootstrap(
     refreshTonight(state);
   }
 
-  function handleModeIntent(intent: UIIntent & { type: "set-mode" | "toggle-animation" }): void {
+  function handleModeIntent(
+    intent: UIIntent & { type: "set-mode" | "toggle-animation" | "set-animation-speed" },
+  ): void {
     if (intent.type === "toggle-animation") {
-      // Plan 08 / issue #136 will wire the actual play/pause animator.
-      // TODO(#136): start/stop the time-advance loop here.
+      animation.playing = !animation.playing;
+      bottomHud?.setAnimation(animation.playing, animation.speed);
+      if (animation.playing) {
+        startAnimationLoop();
+      } else {
+        stopAnimationLoop();
+      }
+      return;
+    }
+    if (intent.type === "set-animation-speed") {
+      animation.speed = intent.speed;
+      bottomHud?.setAnimation(animation.playing, animation.speed);
       return;
     }
     // Notebook is a Pro feature (issue #224). Non-Pro users attempting to
@@ -1349,6 +1406,7 @@ export async function bootstrap(
         return handleTrailIntent(intent);
       case "set-mode":
       case "toggle-animation":
+      case "set-animation-speed":
         return handleModeIntent(intent);
       case "open-location-picker":
       case "copy-link":

--- a/src/ui/bottom-hud.test.ts
+++ b/src/ui/bottom-hud.test.ts
@@ -309,4 +309,59 @@ describe("createBottomHud", () => {
       expect(localDispatch).not.toHaveBeenCalled();
     });
   });
+
+  // Play / pause / speed cycler for time animation (#136).
+  describe("animation controls (#136)", () => {
+    it("renders a play button that dispatches toggle-animation on click", () => {
+      const playBtn = el.querySelector<HTMLButtonElement>("[data-testid='hud-play']");
+      expect(playBtn).not.toBeNull();
+      playBtn!.click();
+      expect(dispatch).toHaveBeenCalledWith({ type: "toggle-animation" } satisfies UIIntent);
+    });
+
+    it("renders a speed button that cycles 1× → 10× → 100× → 1× and dispatches set-animation-speed", () => {
+      const speedBtn = el.querySelector<HTMLButtonElement>("[data-testid='hud-speed']");
+      expect(speedBtn).not.toBeNull();
+      // Starts at 1× (default) — first click should ask for 10×.
+      speedBtn!.click();
+      expect(dispatch).toHaveBeenLastCalledWith({
+        type: "set-animation-speed",
+        speed: 10,
+      } satisfies UIIntent);
+      // After caller reflects the new state with setAnimation(false, 10), the
+      // next click should ask for 100×.
+      hud.setAnimation(false, 10);
+      speedBtn!.click();
+      expect(dispatch).toHaveBeenLastCalledWith({
+        type: "set-animation-speed",
+        speed: 100,
+      } satisfies UIIntent);
+      // 100 wraps back to 1.
+      hud.setAnimation(false, 100);
+      speedBtn!.click();
+      expect(dispatch).toHaveBeenLastCalledWith({
+        type: "set-animation-speed",
+        speed: 1,
+      } satisfies UIIntent);
+    });
+
+    it("setAnimation updates the play icon between ▶ and ⏸", () => {
+      const playBtn = el.querySelector<HTMLButtonElement>("[data-testid='hud-play']");
+      expect(playBtn!.textContent).toBe("▶");
+      hud.setAnimation(true, 1);
+      expect(playBtn!.textContent).toBe("⏸");
+      hud.setAnimation(false, 1);
+      expect(playBtn!.textContent).toBe("▶");
+    });
+
+    it("setAnimation updates the speed button label", () => {
+      const speedBtn = el.querySelector<HTMLButtonElement>("[data-testid='hud-speed']");
+      hud.setAnimation(false, 10);
+      expect(speedBtn!.textContent).toBe("10×");
+      hud.setAnimation(true, 100);
+      expect(speedBtn!.textContent).toBe("100×");
+      hud.setAnimation(false, 1);
+      expect(speedBtn!.textContent).toBe("1×");
+    });
+  });
 });

--- a/src/ui/bottom-hud.ts
+++ b/src/ui/bottom-hud.ts
@@ -28,13 +28,26 @@ const CHIP_STYLE: Partial<CSSStyleDeclaration> = {
   fontSize: "13px",
 };
 
+export type AnimationSpeed = 1 | 10 | 100;
+
 export type BottomHud = {
   readonly element: HTMLElement;
   setTime(d: Date): void;
   setObserver(lat: number, lon: number): void;
   setCompass(azDeg: number): void;
+  /** Reflect the current animation state — updates the play/pause icon and
+   *  the speed-cycle button label. Called by app.ts whenever it flips
+   *  animation.playing or animation.speed (#136). */
+  setAnimation(playing: boolean, speed: AnimationSpeed): void;
   destroy(): void;
 };
+
+/** Cycle 1x → 10x → 100x → 1x. Exported for the bottom-hud unit tests. */
+export function nextAnimationSpeed(current: AnimationSpeed): AnimationSpeed {
+  if (current === 1) return 10;
+  if (current === 10) return 100;
+  return 1;
+}
 
 function pad(n: number): string {
   return String(n).padStart(2, "0");
@@ -127,6 +140,67 @@ export function createBottomHud(
     children: [utcEl, localEl],
   });
 
+  // --- Play/pause + speed cycle (#136) ---
+  //
+  // The two buttons sit above the time readout inside the scrub-center area
+  // so they don't steal room from the compass / location chips at the edges.
+  // Click handlers dispatch intents that app.ts translates into rAF-loop
+  // start/stop and speed change; the icon/label is updated via setAnimation
+  // once the intent has been applied to state.
+  let currentSpeed: AnimationSpeed = 1;
+
+  const playBtn = el("button", {
+    testid: "hud-play",
+    type: "button",
+    text: "▶",
+    attrs: { title: "Play / pause (Space)", "aria-label": "Play animation" },
+    style: {
+      background: SURFACE,
+      border: "1px solid rgba(255,255,255,0.25)",
+      borderRadius: "999px",
+      padding: "4px 10px",
+      color: TEXT_COLOR,
+      fontFamily: FONT_FAMILY,
+      fontSize: "13px",
+      cursor: "pointer",
+    },
+    on: {
+      click: (e) => {
+        e.stopPropagation();
+        dispatch({ type: "toggle-animation" });
+      },
+    },
+  });
+
+  const speedBtn = el("button", {
+    testid: "hud-speed",
+    type: "button",
+    text: `${String(currentSpeed)}×`,
+    attrs: { title: "Cycle animation speed 1× → 10× → 100×", "aria-label": "Animation speed" },
+    style: {
+      background: SURFACE,
+      border: "1px solid rgba(255,255,255,0.25)",
+      borderRadius: "999px",
+      padding: "4px 10px",
+      color: TEXT_COLOR,
+      fontFamily: FONT_FAMILY,
+      fontSize: "13px",
+      cursor: "pointer",
+      fontVariantNumeric: "tabular-nums",
+    },
+    on: {
+      click: (e) => {
+        e.stopPropagation();
+        dispatch({ type: "set-animation-speed", speed: nextAnimationSpeed(currentSpeed) });
+      },
+    },
+  });
+
+  const animateRow = el("div", {
+    style: { display: "flex", gap: "6px", alignItems: "center" },
+    children: [playBtn, speedBtn],
+  });
+
   const center = el("div", {
     testid: "hud-scrub",
     attrs: {
@@ -140,7 +214,7 @@ export function createBottomHud(
       justifyContent: "center",
       cursor: "ew-resize",
     },
-    children: [timeRow],
+    children: [animateRow, timeRow],
   });
 
   const compassChip = el("div", {
@@ -282,6 +356,12 @@ export function createBottomHud(
     },
     setCompass(azDeg: number): void {
       compassChip.textContent = formatCompass(azDeg);
+    },
+    setAnimation(playing: boolean, speed: AnimationSpeed): void {
+      currentSpeed = speed;
+      playBtn.textContent = playing ? "⏸" : "▶";
+      playBtn.setAttribute("aria-label", playing ? "Pause animation" : "Play animation");
+      speedBtn.textContent = `${String(speed)}×`;
     },
     destroy(): void {
       clearIdleTimer();

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -97,6 +97,7 @@ export type UIIntent =
   | { type: "now" }
   | { type: "open-location-picker" }
   | { type: "toggle-animation" }
+  | { type: "set-animation-speed"; speed: 1 | 10 | 100 }
   | { type: "pin-object"; id: string }
   | { type: "copy-link" }
   | {


### PR DESCRIPTION
## Summary

Closes **#136**. Wires up the `toggle-animation` TODO that has lived in `app.ts` since the Bottom HUD shipped, and adds the 1× / 10× / 100× speed selector called out in the issue.

## Design

- **Two new buttons** on the Bottom HUD (`hud-play`, `hud-speed`) sit above the time readout inside the scrub-center area. Click on ▶ dispatches `toggle-animation` (same intent already sent by Space). Click on the speed pill dispatches the new `set-animation-speed` intent with the next value in the 1 → 10 → 100 → 1 cycle.
- **`BottomHud.setAnimation(playing, speed)`** is called by `app.ts` after each intent lands so the ▶ / ⏸ icon and the `1× / 10× / 100×` label stay in sync.
- **`AnimationSpeed = 1 | 10 | 100`** and the `nextAnimationSpeed()` cycler live in `src/ui/bottom-hud.ts` and are unit-tested end-to-end.
- **Animation state (`{ playing, speed }`) lives in `app.ts`, NOT `AppState`.** Play/pause is transient — losing it on reload matches how the object-trail token behaves and avoids polluting URL params.
- **rAF loop** in `startAnimationLoop` / `stopAnimationLoop`. Each frame it dispatches `set-time` with `state.timeUtc + dt * speed * (60_000 / 1000)` — at 1× one wall-clock second advances one minute of sky time, so play mode feels like a continuous drag-scrub at the same 1 min / pixel ratio.
- **Zero-config fallback** — `requestAnimationFrame` / `performance.now` / `cancelAnimationFrame` are all optionally probed via `globalThis`, so the loop is a no-op in environments that lack them (jsdom test contexts, older headless runners).

## Tests

- 4 new `src/ui/bottom-hud.test.ts` cases cover:
  - the play button dispatches `toggle-animation`,
  - the speed button cycles 1 → 10 → 100 → 1 across three consecutive clicks (each mirrored back via `setAnimation`),
  - `setAnimation` swaps the ▶ / ⏸ icon,
  - `setAnimation` updates the speed pill label.
- `src/app.test.ts` gains a `set-animation-speed` smoke and extends the existing `toggle-animation` smoke to a second toggle (start + stop the loop, both must not throw).
- The `createBottomHud` mock inside `app.test.ts` now returns a `setAnimation: vi.fn()` so bootstrap doesn't blow up on the new call.

Test count: **1300 → 1305**. Coverage thresholds unchanged.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm format:check` — clean
- [x] `pnpm test:cov` — 1305 / 1305, thresholds hold
- [x] `pnpm build` — succeeds

Closes #136.

https://claude.ai/code/session_planisphere-open-issues-QFuWY

---
_Generated by [Claude Code](https://claude.ai/code/session_01VKmj4YQnxN8sydc7X6v2ra)_