### PR TITLE
feat(scene): mirror constellation labels into hidden DOM spans for e2e (closes #306)

### DIFF
--- a/e2e/label-language.spec.ts
+++ b/e2e/label-language.spec.ts
@@ -1,0 +1,67 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { expect, test } from "@playwright/test";
+import { seedDefaultStorage, waitForCesiumPainted } from "./fixtures";
+
+/**
+ * Constellation-label language regression test (#306).
+ *
+ * Cesium renders constellation labels into its WebGL font atlas, so a naive
+ * `expect(page.locator("canvas")).toContainText("大熊座")` can't work. The
+ * scene layer (`src/scene/constellations.ts`) mirrors every rendered label
+ * into a hidden `<span data-label-for="constellation-<id>">…</span>` under a
+ * `[data-label-mirror='constellations']` container off-screen. That gives us
+ * a DOM-side handle to assert language selection without OCR / screenshot
+ * diffing (both rejected per ADR 016).
+ *
+ * The two fixtures pick constellations whose names are unambiguously
+ * different between Latin (default) and a non-Latin skyculture / language,
+ * so the assertion is meaningful.
+ */
+
+test("?lang=zh renders constellation labels in Chinese (DOM mirror asserted, not the WebGL canvas)", async ({
+  page,
+}) => {
+  await seedDefaultStorage(page);
+  await page.goto("/?lat=61.2&lon=-149.9&t=2026-04-25T08:00:00Z&lang=zh");
+
+  await expect(page.locator("#cesium-container canvas")).toBeVisible();
+  await waitForCesiumPainted(page, 10_000);
+
+  const mirror = page.locator("[data-label-mirror='constellations']");
+  await expect(mirror).toBeAttached();
+
+  // The Anchorage-at-midnight fixture has UMa (Ursa Major) reliably above
+  // the horizon; its Chinese name in the shipped names/zh.json is 大熊座.
+  const uma = mirror.locator("[data-label-for='constellation-UMa']");
+  await expect(uma).toHaveText("大熊座", { timeout: 5_000 });
+
+  // Sanity check: the Latin default would have been "Ursa Major"; make sure
+  // that text isn't lurking in a stray span (would indicate a stale mirror).
+  const latinCount = await mirror.getByText("Ursa Major").count();
+  expect(latinCount).toBe(0);
+});
+
+test("?sky=chinese renders Chinese skyculture asterism labels", async ({ page }) => {
+  await seedDefaultStorage(page);
+  await page.goto("/?lat=61.2&lon=-149.9&t=2026-04-25T08:00:00Z&sky=chinese");
+
+  await expect(page.locator("#cesium-container canvas")).toBeVisible();
+  await waitForCesiumPainted(page, 10_000);
+
+  // The Chinese asterism set doesn't use IAU ids, so we can't target a
+  // single well-known asterism; instead assert the mirror is populated with
+  // at least a few Chinese labels (non-Latin characters).
+  const mirror = page.locator("[data-label-mirror='constellations']");
+  await expect(mirror).toBeAttached();
+
+  // Wait for at least one Chinese-character label to appear.
+  await expect
+    .poll(
+      async () => {
+        const texts = await mirror.locator("[data-label-for]").allTextContents();
+        return texts.some((t) => /[一-鿿]/.test(t));
+      },
+      { timeout: 5_000 },
+    )
+    .toBe(true);
+});

--- a/src/scene/constellations.test.ts
+++ b/src/scene/constellations.test.ts
@@ -128,6 +128,60 @@ describe("ConstellationLayer.update", () => {
     expect(mockPolylineAdd).toHaveBeenCalledTimes(2);
     expect(mockLabelAdd).toHaveBeenCalledTimes(1);
   });
+
+  // #306 — DOM label mirror. Cesium renders label text into the WebGL font
+  // atlas, so end-to-end tests need an alternative surface for asserting
+  // translation. The mirror is a hidden `<span>` per label under a sentinel
+  // container on document.body.
+  describe("label DOM mirror (#306)", () => {
+    beforeEach(() => {
+      document.querySelectorAll("[data-label-mirror]").forEach((el) => el.remove());
+    });
+
+    it("appends a hidden `<span data-label-for>` per constellation on update", () => {
+      const layer = createConstellationLayer(makeMockScene() as never);
+      layer.update(CONSTELLATIONS, 33, -117);
+      const spans = document.querySelectorAll<HTMLElement>(
+        "[data-label-mirror='constellations'] [data-label-for]",
+      );
+      expect(spans.length).toBe(CONSTELLATIONS.length);
+      const byId = new Map([...spans].map((s) => [s.dataset["labelFor"], s.textContent] as const));
+      for (const c of CONSTELLATIONS) {
+        expect(byId.get(`constellation-${c.id}`)).toBe(c.name);
+      }
+    });
+
+    it("mirror text tracks the language override", () => {
+      const layer = createConstellationLayer(makeMockScene() as never);
+      const overrides: Record<string, string> = {};
+      for (const c of CONSTELLATIONS) overrides[c.id] = `TRANSLATED-${c.id}`;
+      layer.setNameOverrides(overrides);
+      layer.update(CONSTELLATIONS, 33, -117);
+      const span = document.querySelector<HTMLElement>(
+        `[data-label-for='constellation-${CONSTELLATIONS[0]!.id}']`,
+      );
+      expect(span?.textContent).toBe(`TRANSLATED-${CONSTELLATIONS[0]!.id}`);
+    });
+
+    it("clears the mirror between updates so stale spans don't accumulate", () => {
+      const layer = createConstellationLayer(makeMockScene() as never);
+      layer.update(CONSTELLATIONS, 33, -117);
+      layer.update(CONSTELLATIONS.slice(0, 1), 33, -117);
+      const spans = document.querySelectorAll(
+        "[data-label-mirror='constellations'] [data-label-for]",
+      );
+      expect(spans.length).toBe(1);
+    });
+
+    it("clearing to empty leaves the mirror container empty rather than removed", () => {
+      const layer = createConstellationLayer(makeMockScene() as never);
+      layer.update(CONSTELLATIONS, 33, -117);
+      layer.update([], 33, -117);
+      const container = document.querySelector<HTMLElement>("[data-label-mirror='constellations']");
+      expect(container).not.toBeNull();
+      expect(container!.children.length).toBe(0);
+    });
+  });
 });
 
 describe("ConstellationLayer.setVisible", () => {

--- a/src/scene/constellations.ts
+++ b/src/scene/constellations.ts
@@ -28,6 +28,32 @@ export function createConstellationLayer(scene: Scene): ConstellationLayer {
   scene.primitives.add(polylines);
   scene.primitives.add(labels);
 
+  // Hidden DOM mirror of the label text (#306). Cesium renders labels into
+  // the WebGL canvas via its font atlas, so end-to-end tests can't scrape
+  // them from the DOM. Every call to update() also rebuilds a matching set
+  // of `<span data-label-for="constellation-<id>">…</span>` nodes inside a
+  // sentinel container off-screen so Playwright can assert language / sky-
+  // culture translations without OCR or screenshot diffing. The container
+  // is created lazily to keep unit-test environments without a DOM working.
+  let labelMirrorRoot: HTMLDivElement | null = null;
+  function ensureLabelMirrorRoot(): HTMLDivElement | null {
+    if (labelMirrorRoot !== null) return labelMirrorRoot;
+    if (typeof document === "undefined") return null;
+    const root = document.createElement("div");
+    root.dataset["labelMirror"] = "constellations";
+    root.style.position = "absolute";
+    root.style.left = "-9999px";
+    root.style.top = "-9999px";
+    root.style.width = "1px";
+    root.style.height = "1px";
+    root.style.overflow = "hidden";
+    root.style.pointerEvents = "none";
+    root.setAttribute("aria-hidden", "true");
+    document.body.appendChild(root);
+    labelMirrorRoot = root;
+    return root;
+  }
+
   const addedPolylines: Array<{ material: { uniforms: { color: { alpha: number } } } }> = [];
   let nameOverrides: ConstellationNameOverrides = null;
 
@@ -43,6 +69,9 @@ export function createConstellationLayer(scene: Scene): ConstellationLayer {
     polylines.removeAll();
     labels.removeAll();
     addedPolylines.length = 0;
+
+    const mirror = ensureLabelMirrorRoot();
+    if (mirror !== null) mirror.replaceChildren();
 
     for (const constellation of constellations) {
       for (const line of constellation.lines) {
@@ -71,9 +100,10 @@ export function createConstellationLayer(scene: Scene): ConstellationLayer {
         lat,
         lon,
       );
+      const labelText = labelFor(constellation);
       labels.add({
         position: centroidPos,
-        text: labelFor(constellation),
+        text: labelText,
         font: "12px sans-serif",
         fillColor: Color.WHITE.withAlpha(0.6),
         style: LabelStyle.FILL,
@@ -84,6 +114,15 @@ export function createConstellationLayer(scene: Scene): ConstellationLayer {
         // resolve clicks on the label back to a typed structured payload.
         id: constellation,
       });
+
+      // Mirror the rendered label text into a hidden DOM span so e2e tests
+      // (#306) can assert language / skyculture translations without OCR.
+      if (mirror !== null) {
+        const span = document.createElement("span");
+        span.dataset["labelFor"] = `constellation-${constellation.id}`;
+        span.textContent = labelText;
+        mirror.appendChild(span);
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Closes **#306**. Cesium renders constellation labels into its WebGL font atlas, so a Playwright-side text assertion can't scrape them. This PR ships **approach 3** from the issue: mirror every rendered label into a hidden `<span data-label-for="constellation-<id>">…</span>` under a sentinel `[data-label-mirror='constellations']` container off-screen, so e2e specs can assert language / skyculture translations without OCR or screenshot diffing.

## Implementation

- **`src/scene/constellations.ts`**:
  - `ensureLabelMirrorRoot()` creates the container lazily on first `update()` so unit environments without a DOM (e.g. worker tests that `vi.mock` cesium) stay green.
  - Container is `absolute; left/top: -9999px; width/height: 1px; overflow: hidden; pointer-events: none; aria-hidden="true"` — invisible to users, screen readers, and click hit-testing, but fully queryable by Playwright.
  - Every `update()` calls `mirror.replaceChildren()` so stale spans don't accumulate across time / language / skyculture changes.
  - Each label's mirror `<span>` carries the same effective text as Cesium's `LabelCollection.add({ text: labelFor(constellation) })`, so language overrides + skyculture switching all reflect naturally.

## Tests

- **4 new unit cases in `src/scene/constellations.test.ts`**: one span per constellation with the right text, language overrides propagate to the mirror, the mirror clears between updates, empty updates leave the container empty (not removed).
- **`e2e/label-language.spec.ts` (new)**: boots the SPA under `?lang=zh` and asserts UMa's mirror text is `大熊座`, plus a second case under `?sky=chinese` that checks the mirror has at least one Chinese-character label. Uses the standard `seedDefaultStorage` + `waitForCesiumPainted` fixture pair from #303's suite.

1311 → **1315** total; coverage thresholds hold.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm format:check` — clean
- [x] `pnpm test:cov` — 1315/1315 pass, thresholds hold
- [x] `pnpm build` — succeeds

Closes #306.

https://claude.ai/code/session_planisphere-open-issues-QFuWY

---
_Generated by [Claude Code](https://claude.ai/code/session_01VKmj4YQnxN8sydc7X6v2ra)_