### PR TITLE
chore(deps): bump typescript 5.5 → 6.0 (Mikado follow-up to #335)

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "jsdom": "~29.1.1",
     "playwright": "^1.61.1",
     "prettier": "~3.9.4",
-    "typescript": "~5.5.4",
+    "typescript": "~6.0.3",
     "vite": "~8.1.3",
     "vite-plugin-cesium": "^1.2.23",
     "vitest": "~3.2.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,10 +59,10 @@ importers:
         version: 22.12.0
       '@typescript-eslint/eslint-plugin':
         specifier: ~8.62.1
-        version: 8.62.1(@typescript-eslint/parser@8.62.1(eslint@10.6.0)(typescript@5.5.4))(eslint@10.6.0)(typescript@5.5.4)
+        version: 8.62.1(@typescript-eslint/parser@8.62.1(eslint@10.6.0)(typescript@6.0.3))(eslint@10.6.0)(typescript@6.0.3)
       '@typescript-eslint/parser':
         specifier: ~8.62.1
-        version: 8.62.1(eslint@10.6.0)(typescript@5.5.4)
+        version: 8.62.1(eslint@10.6.0)(typescript@6.0.3)
       '@vitest/coverage-v8':
         specifier: ~3.2.6
         version: 3.2.6(vitest@3.2.6(@types/node@22.12.0)(jsdom@29.1.1)(lightningcss@1.32.0))
@@ -88,11 +88,11 @@ importers:
         specifier: ~3.9.4
         version: 3.9.4
       typescript:
-        specifier: ~5.5.4
-        version: 5.5.4
+        specifier: ~6.0.3
+        version: 6.0.3
       typescript-eslint:
         specifier: ~8.62.1
-        version: 8.62.1(eslint@10.6.0)(typescript@5.5.4)
+        version: 8.62.1(eslint@10.6.0)(typescript@6.0.3)
       vite:
         specifier: ~8.1.3
         version: 8.1.3(@types/node@22.12.0)(esbuild@0.28.1)
@@ -2424,8 +2424,8 @@ packages:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
-  typescript@5.5.4:
-    resolution: {integrity: sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==}
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -3599,40 +3599,40 @@ snapshots:
   '@types/trusted-types@2.0.7':
     optional: true
 
-  '@typescript-eslint/eslint-plugin@8.62.1(@typescript-eslint/parser@8.62.1(eslint@10.6.0)(typescript@5.5.4))(eslint@10.6.0)(typescript@5.5.4)':
+  '@typescript-eslint/eslint-plugin@8.62.1(@typescript-eslint/parser@8.62.1(eslint@10.6.0)(typescript@6.0.3))(eslint@10.6.0)(typescript@6.0.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.62.1(eslint@10.6.0)(typescript@5.5.4)
+      '@typescript-eslint/parser': 8.62.1(eslint@10.6.0)(typescript@6.0.3)
       '@typescript-eslint/scope-manager': 8.62.1
-      '@typescript-eslint/type-utils': 8.62.1(eslint@10.6.0)(typescript@5.5.4)
-      '@typescript-eslint/utils': 8.62.1(eslint@10.6.0)(typescript@5.5.4)
+      '@typescript-eslint/type-utils': 8.62.1(eslint@10.6.0)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.62.1(eslint@10.6.0)(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.62.1
       eslint: 10.6.0
       ignore: 7.0.5
       natural-compare: 1.4.0
-      ts-api-utils: 2.5.0(typescript@5.5.4)
-      typescript: 5.5.4
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.62.1(eslint@10.6.0)(typescript@5.5.4)':
+  '@typescript-eslint/parser@8.62.1(eslint@10.6.0)(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.62.1
       '@typescript-eslint/types': 8.62.1
-      '@typescript-eslint/typescript-estree': 8.62.1(typescript@5.5.4)
+      '@typescript-eslint/typescript-estree': 8.62.1(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.62.1
       debug: 4.4.3
       eslint: 10.6.0
-      typescript: 5.5.4
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.62.1(typescript@5.5.4)':
+  '@typescript-eslint/project-service@8.62.1(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.62.1(typescript@5.5.4)
+      '@typescript-eslint/tsconfig-utils': 8.62.1(typescript@6.0.3)
       '@typescript-eslint/types': 8.62.1
       debug: 4.4.3
-      typescript: 5.5.4
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -3641,47 +3641,47 @@ snapshots:
       '@typescript-eslint/types': 8.62.1
       '@typescript-eslint/visitor-keys': 8.62.1
 
-  '@typescript-eslint/tsconfig-utils@8.62.1(typescript@5.5.4)':
+  '@typescript-eslint/tsconfig-utils@8.62.1(typescript@6.0.3)':
     dependencies:
-      typescript: 5.5.4
+      typescript: 6.0.3
 
-  '@typescript-eslint/type-utils@8.62.1(eslint@10.6.0)(typescript@5.5.4)':
+  '@typescript-eslint/type-utils@8.62.1(eslint@10.6.0)(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/types': 8.62.1
-      '@typescript-eslint/typescript-estree': 8.62.1(typescript@5.5.4)
-      '@typescript-eslint/utils': 8.62.1(eslint@10.6.0)(typescript@5.5.4)
+      '@typescript-eslint/typescript-estree': 8.62.1(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.62.1(eslint@10.6.0)(typescript@6.0.3)
       debug: 4.4.3
       eslint: 10.6.0
-      ts-api-utils: 2.5.0(typescript@5.5.4)
-      typescript: 5.5.4
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
   '@typescript-eslint/types@8.62.1': {}
 
-  '@typescript-eslint/typescript-estree@8.62.1(typescript@5.5.4)':
+  '@typescript-eslint/typescript-estree@8.62.1(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.62.1(typescript@5.5.4)
-      '@typescript-eslint/tsconfig-utils': 8.62.1(typescript@5.5.4)
+      '@typescript-eslint/project-service': 8.62.1(typescript@6.0.3)
+      '@typescript-eslint/tsconfig-utils': 8.62.1(typescript@6.0.3)
       '@typescript-eslint/types': 8.62.1
       '@typescript-eslint/visitor-keys': 8.62.1
       debug: 4.4.3
       minimatch: 10.2.5
       semver: 7.7.4
       tinyglobby: 0.2.17
-      ts-api-utils: 2.5.0(typescript@5.5.4)
-      typescript: 5.5.4
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.62.1(eslint@10.6.0)(typescript@5.5.4)':
+  '@typescript-eslint/utils@8.62.1(eslint@10.6.0)(typescript@6.0.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@10.6.0)
       '@typescript-eslint/scope-manager': 8.62.1
       '@typescript-eslint/types': 8.62.1
-      '@typescript-eslint/typescript-estree': 8.62.1(typescript@5.5.4)
+      '@typescript-eslint/typescript-estree': 8.62.1(typescript@6.0.3)
       eslint: 10.6.0
-      typescript: 5.5.4
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -4822,9 +4822,9 @@ snapshots:
 
   tree-kill@1.2.2: {}
 
-  ts-api-utils@2.5.0(typescript@5.5.4):
+  ts-api-utils@2.5.0(typescript@6.0.3):
     dependencies:
-      typescript: 5.5.4
+      typescript: 6.0.3
 
   tslib@2.8.1: {}
 
@@ -4832,18 +4832,18 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
-  typescript-eslint@8.62.1(eslint@10.6.0)(typescript@5.5.4):
+  typescript-eslint@8.62.1(eslint@10.6.0)(typescript@6.0.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.62.1(@typescript-eslint/parser@8.62.1(eslint@10.6.0)(typescript@5.5.4))(eslint@10.6.0)(typescript@5.5.4)
-      '@typescript-eslint/parser': 8.62.1(eslint@10.6.0)(typescript@5.5.4)
-      '@typescript-eslint/typescript-estree': 8.62.1(typescript@5.5.4)
-      '@typescript-eslint/utils': 8.62.1(eslint@10.6.0)(typescript@5.5.4)
+      '@typescript-eslint/eslint-plugin': 8.62.1(@typescript-eslint/parser@8.62.1(eslint@10.6.0)(typescript@6.0.3))(eslint@10.6.0)(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.62.1(eslint@10.6.0)(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.62.1(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.62.1(eslint@10.6.0)(typescript@6.0.3)
       eslint: 10.6.0
-      typescript: 5.5.4
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  typescript@5.5.4: {}
+  typescript@6.0.3: {}
 
   undici-types@6.20.0: {}
 


### PR DESCRIPTION
## Summary

**Follow-up to the Mikado tree in #335** — TypeScript's 6.0 major landed after the original planning; picking it up now so the codebase stays on the current major.

## Bump

| Package | From | To |
|---|---|---|
| `typescript` | ~5.5.4 | **~6.0.3** |

## Why zero source changes

- `typescript-eslint@8.62` (landed in #339) declares TS `>=4.8.4 <6.1.0`, so 6.0.3 is in-range for our lint parser.
- 6.0's breaking changes are mostly around the compiler internals + the `--isolatedDeclarations` mode we don't use. Every strict-mode setting we already turn on was tightened *forward-compatibly*; no new errors fire on this repo.

## Test plan

- [x] `pnpm typecheck` — clean under 6.0.3
- [x] `pnpm lint` — clean (typescript-eslint 8 accepts 6.0)
- [x] `pnpm format:check` — clean
- [x] `pnpm test:cov` — 1315/1315 pass, thresholds hold
- [x] `pnpm test:worker` — 103/103 pass
- [x] `pnpm build` — succeeds

Depends on nothing else on the Mikado tree; can land in any order relative to #346 (Vitest 4).

---
_Generated by [Claude Code](https://claude.ai/code/session_01VKmj4YQnxN8sydc7X6v2ra)_