### PR TITLE
fix(ui): close search dropdown on Escape (closes #352)

### DIFF
--- a/src/ui/search.test.ts
+++ b/src/ui/search.test.ts
@@ -114,6 +114,21 @@ describe("createSearch", () => {
     expect(dropdown.style.display).toBe("none");
   });
 
+  it("pressing Escape clears the input and hides the dropdown", () => {
+    const input = el.querySelector<HTMLInputElement>("input[type='text']")!;
+    // Open the dropdown first
+    input.value = "sir";
+    input.dispatchEvent(new Event("input"));
+    const dropdown = el.querySelector<HTMLElement>("[data-testid='search-dropdown']")!;
+    expect(dropdown.style.display).not.toBe("none");
+
+    // Dispatch Escape keydown on the input
+    input.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+
+    expect(dropdown.style.display).toBe("none");
+    expect(input.value).toBe("");
+  });
+
   it("empty query hides dropdown", () => {
     const input = el.querySelector<HTMLInputElement>("input[type='text']")!;
     // First show some results

--- a/src/ui/search.ts
+++ b/src/ui/search.ts
@@ -171,6 +171,15 @@ export function createSearch(
     showResults(search(query));
   });
 
+  // Escape clears the query and closes the dropdown (Command Palette parity).
+  input.addEventListener("keydown", (e) => {
+    if (e.key === "Escape") {
+      e.preventDefault();
+      input.value = "";
+      hideDropdown();
+    }
+  });
+
   // Close dropdown when focus leaves the wrapper
   document.addEventListener(
     "click",


### PR DESCRIPTION
## Summary

- Escape on the search input now clears the query and closes the dropdown, matching Command Palette parity.
- Adds a `keydown` handler on the search input in `src/ui/search.ts`; when `e.key === "Escape"` it calls `preventDefault`, clears `input.value`, and hides the dropdown.

## Repro (from #352)

Focus the search input, type "sir" — the dropdown opens. Hit Escape.

- Expected: dropdown closes, input value cleared, focus stays on the input.
- Actual (before this change): dropdown stays open.

Fixes #352.

## Test plan

- [x] New test `pressing Escape clears the input and hides the dropdown` in `src/ui/search.test.ts` — types "sir", dispatches a `keydown` with `key: "Escape"`, then asserts `dropdown.style.display === "none"` and `input.value === ""`.
- [x] `pnpm typecheck && pnpm lint && pnpm format:check && pnpm test:cov && pnpm build` all green locally.

Command Palette Escape parity contract referenced: `src/ui/command-palette.ts` (its `close()` sets `input.value = ""` and hides the root).

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKmj4YQnxN8sydc7X6v2ra

---
_Generated by [Claude Code](https://claude.ai/code/session_01VKmj4YQnxN8sydc7X6v2ra)_