### PR TITLE
feat(sat,ui): TLE staleness banner when live fetch fails and bundle is Xd old (closes #354)

### DIFF
--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -590,7 +590,10 @@ vi.mock("../data/tle/visual.txt?raw", () => ({
 
 // Mock the sat module so tests don't do real network/propagation
 vi.mock("./sat", () => ({
-  fetchTle: vi.fn().mockResolvedValue({ ok: true, value: "" }),
+  fetchTle: vi.fn().mockResolvedValue({
+    ok: true,
+    value: { text: "", sourceAgeSeconds: 0, usedFallback: false },
+  }),
   parseTle: vi.fn().mockReturnValue({ ok: true, value: [] }),
   propagateSatellites: vi.fn().mockReturnValue([]),
 }));

--- a/src/app.ts
+++ b/src/app.ts
@@ -916,9 +916,15 @@ export async function bootstrap(
 
   // Satellite layer (async)
   let satelliteRecords: SatelliteRecord[] = [];
+  // Captured across the fetchTle boundary so we can decide whether to surface
+  // the offline-TLE staleness pill in the bottom HUD (#354).
+  let tleUsedFallback = false;
+  let tleSourceAgeSeconds = 0;
   const tleResult = await fetchTle();
   if (tleResult.ok) {
-    const satResult = parseTle(tleResult.value);
+    tleUsedFallback = tleResult.value.usedFallback;
+    tleSourceAgeSeconds = tleResult.value.sourceAgeSeconds;
+    const satResult = parseTle(tleResult.value.text);
     if (satResult.ok) {
       satelliteRecords = satResult.value;
       data.satelliteRecords = satResult;
@@ -1447,6 +1453,10 @@ export async function bootstrap(
         void refreshPlansView();
         return;
       }
+      case "open-help": {
+        helpModal?.open();
+        return;
+      }
     }
   }
 
@@ -1538,6 +1548,8 @@ export async function bootstrap(
       timeUtc: state.timeUtc,
       lat: state.observer.lat,
       lon: state.observer.lon,
+      tleUsedFallback,
+      tleSourceAgeSeconds,
     },
     handleIntent,
   );

--- a/src/sat/fetch.test.ts
+++ b/src/sat/fetch.test.ts
@@ -1,8 +1,11 @@
 /* SPDX-License-Identifier: Apache-2.0 */
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import { isOk, expectOk } from "../result";
 import { fetchTle } from "./fetch";
 
+// TLE epochs in the mocks below are anchored on 2024-04-09T12:00:00Z (year
+// 2024, day-of-year 100.5). The fake system time in the "age" tests below is
+// pinned so we can compute a deterministic sourceAgeSeconds.
 const MOCK_TLE = `ISS (ZARYA)
 1 25544U 98067A   24100.50000000  .00016717  00000-0  10270-3 0  9006
 2 25544  51.6400 208.9163 0002476 102.8574 355.4846 15.49909786447384`;
@@ -21,6 +24,10 @@ beforeEach(() => {
   vi.restoreAllMocks();
 });
 
+afterEach(() => {
+  vi.useRealTimers();
+});
+
 describe("fetchTle", () => {
   it("returns fresh TLE on successful fetch", async () => {
     vi.stubGlobal(
@@ -32,17 +39,17 @@ describe("fetchTle", () => {
     );
     const r = await fetchTle();
     expect(isOk(r)).toBe(true);
-    const text = expectOk(r);
-    expect(text).toContain("ISS");
+    const val = expectOk(r);
+    expect(val.text).toContain("ISS");
   });
 
   it("falls back to bundled data on fetch failure", async () => {
     vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network error")));
     const r = await fetchTle();
     expect(isOk(r)).toBe(true);
-    const text = expectOk(r);
-    expect(text).toContain("HUBBLE");
-    expect(text).toBe(BUNDLED_TLE);
+    const val = expectOk(r);
+    expect(val.text).toContain("HUBBLE");
+    expect(val.text).toBe(BUNDLED_TLE);
   });
 
   it("falls back to bundled data on non-ok response", async () => {
@@ -56,8 +63,117 @@ describe("fetchTle", () => {
     );
     const r = await fetchTle();
     expect(isOk(r)).toBe(true);
-    const text = expectOk(r);
-    expect(text).toContain("HUBBLE");
-    expect(text).toBe(BUNDLED_TLE);
+    const val = expectOk(r);
+    expect(val.text).toContain("HUBBLE");
+    expect(val.text).toBe(BUNDLED_TLE);
+  });
+
+  describe("usedFallback / sourceAgeSeconds", () => {
+    it("reports usedFallback:false and a computed sourceAgeSeconds on a successful live fetch", async () => {
+      // Freeze wall clock 30 days after the epoch of MOCK_TLE (2024-04-09T12:00Z).
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2024-05-09T12:00:00Z"));
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({
+          ok: true,
+          text: () => Promise.resolve(MOCK_TLE),
+        }),
+      );
+      const r = await fetchTle();
+      const val = expectOk(r);
+      expect(val.usedFallback).toBe(false);
+      expect(val.sourceAgeSeconds).toBe(30 * 86400);
+    });
+
+    it("reports usedFallback:true and an accurate sourceAgeSeconds when the fetch fails", async () => {
+      // 14 days after the epoch of the BUNDLED_TLE (2024-04-09T12:00Z).
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2024-04-23T12:00:00Z"));
+      vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network error")));
+      const r = await fetchTle();
+      const val = expectOk(r);
+      expect(val.usedFallback).toBe(true);
+      expect(val.sourceAgeSeconds).toBe(14 * 86400);
+    });
+
+    it("reports usedFallback:true when the response is non-ok", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2024-04-16T12:00:00Z"));
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({
+          ok: false,
+          status: 500,
+          statusText: "Server Error",
+        }),
+      );
+      const r = await fetchTle();
+      const val = expectOk(r);
+      expect(val.usedFallback).toBe(true);
+      expect(val.sourceAgeSeconds).toBe(7 * 86400);
+    });
+
+    it("uses the newest epoch across multiple TLE records", async () => {
+      // Two TLEs, epochs 30 days apart. The newest (day 200) should drive
+      // sourceAgeSeconds, not the older (day 100). Wall clock at day 210
+      // means the newest is 10 days old.
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date(Date.UTC(2024, 0, 1) + 209 * 86_400_000));
+      const twoRecords = `OLDER SAT
+1 11111U 90001A   24100.00000000  .00000001  00000+0  10000-4 0  9990
+2 11111  28.4700 123.4567 0002345  67.8901 292.1098 15.09876543210987
+NEWER SAT
+1 22222U 90002A   24200.00000000  .00000002  00000+0  20000-4 0  9991
+2 22222  51.6400 208.9163 0002476 102.8574 355.4846 15.49909786000000`;
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({
+          ok: true,
+          text: () => Promise.resolve(twoRecords),
+        }),
+      );
+      const r = await fetchTle();
+      const val = expectOk(r);
+      expect(val.usedFallback).toBe(false);
+      // 10 days = 864,000 seconds. Allow for TLE-epoch floor rounding.
+      expect(val.sourceAgeSeconds).toBe(10 * 86400);
+    });
+
+    it("skips malformed line-1s (too-short and non-numeric) and returns 0 age when nothing parses", async () => {
+      // Text contains a "line 1" prefix but no valid epoch fields at all —
+      // parseTleEpochMs returns null on both, and computeSourceAgeSeconds
+      // falls back to 0.
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2024-05-09T12:00:00Z"));
+      const garbage = "GARBAGE\n1 too short\n1 XXXXXU XXXXXA   XXXXX.XXXXXXXX";
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({
+          ok: true,
+          text: () => Promise.resolve(garbage),
+        }),
+      );
+      const r = await fetchTle();
+      const val = expectOk(r);
+      expect(val.usedFallback).toBe(false);
+      expect(val.sourceAgeSeconds).toBe(0);
+    });
+
+    it("treats an empty-text response as a failure and falls back to bundled data", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2024-04-16T12:00:00Z"));
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({
+          ok: true,
+          text: () => Promise.resolve("   \n  "),
+        }),
+      );
+      const r = await fetchTle();
+      const val = expectOk(r);
+      expect(val.usedFallback).toBe(true);
+      expect(val.text).toBe(BUNDLED_TLE);
+    });
   });
 });

--- a/src/sat/fetch.ts
+++ b/src/sat/fetch.ts
@@ -4,20 +4,86 @@ import bundledTle from "../../data/tle/visual.txt?raw";
 
 export type TleFetchError = { kind: "tle-fetch-failed"; message: string };
 
+/**
+ * Result payload for a successful TLE resolution.
+ *
+ * `sourceAgeSeconds` is derived from the newest TLE epoch found in `text`;
+ * `usedFallback` is `true` iff the network fetch failed and we served the
+ * bundled snapshot instead. Together these let the UI decide whether to
+ * surface a "positions may be off" warning to the user (#354).
+ */
+export type TleFetchOk = {
+  readonly text: string;
+  readonly sourceAgeSeconds: number;
+  readonly usedFallback: boolean;
+};
+
 const CELESTRAK_URL = "https://celestrak.org/NORAD/elements/gp.php?GROUP=visual&FORMAT=tle";
 
-export async function fetchTle(): Promise<Result<string, TleFetchError>> {
+/**
+ * Extract the epoch (as milliseconds since Unix epoch) from a TLE line-1.
+ *
+ * Format: columns 19-20 hold the 2-digit year; columns 21-32 hold the day-of-
+ * year plus a fractional part. Two-digit-year convention (see the SGP4
+ * literature): 57–99 map to 1957–1999, 00–56 map to 2000–2056.
+ *
+ * Returns `null` for lines that are too short or contain non-numeric epoch
+ * fields — parsing skips those without failing the whole fetch.
+ */
+function parseTleEpochMs(line1: string): number | null {
+  if (line1.length < 32) return null;
+  const yy = parseInt(line1.substring(18, 20), 10);
+  const dayFrac = parseFloat(line1.substring(20, 32));
+  if (!Number.isFinite(yy) || !Number.isFinite(dayFrac)) return null;
+  const year = yy < 57 ? 2000 + yy : 1900 + yy;
+  const jan1Ms = Date.UTC(year, 0, 1);
+  return jan1Ms + (dayFrac - 1) * 86_400_000;
+}
+
+/**
+ * Age (seconds) of the freshest TLE in `text` relative to `nowMs`.
+ *
+ * We use the *newest* epoch across all records because a batch fetched from
+ * Celestrak contains records updated at slightly different times per
+ * satellite — the newest tells us when the mirror last received an update,
+ * which is what determines whether the whole snapshot has gone stale.
+ */
+function computeSourceAgeSeconds(text: string, nowMs: number): number {
+  let newestEpochMs: number | null = null;
+  for (const rawLine of text.split("\n")) {
+    const line = rawLine.trim();
+    if (!line.startsWith("1 ")) continue;
+    const epoch = parseTleEpochMs(line);
+    if (epoch === null) continue;
+    if (newestEpochMs === null || epoch > newestEpochMs) {
+      newestEpochMs = epoch;
+    }
+  }
+  if (newestEpochMs === null) return 0;
+  return Math.max(0, Math.floor((nowMs - newestEpochMs) / 1000));
+}
+
+export async function fetchTle(): Promise<Result<TleFetchOk, TleFetchError>> {
+  const nowMs = Date.now();
   try {
     const response = await fetch(CELESTRAK_URL);
     if (response.ok) {
       const text = await response.text();
       if (text.trim().length > 0) {
-        return ok(text);
+        return ok({
+          text,
+          sourceAgeSeconds: computeSourceAgeSeconds(text, nowMs),
+          usedFallback: false,
+        });
       }
     }
   } catch {
     // network error — fall through to bundled
   }
   console.warn("[planisphere] TLE fetch failed, using bundled data");
-  return ok(bundledTle);
+  return ok({
+    text: bundledTle,
+    sourceAgeSeconds: computeSourceAgeSeconds(bundledTle, nowMs),
+    usedFallback: true,
+  });
 }

--- a/src/sat/index.ts
+++ b/src/sat/index.ts
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 export { type SatelliteRecord, type TleParseError, parseTle } from "./tle";
 export { type VisibleSatellite, propagateSatellites } from "./propagate";
-export { type TleFetchError, fetchTle } from "./fetch";
+export { type TleFetchError, type TleFetchOk, fetchTle } from "./fetch";
 export { type IssPass, computeUpcomingPasses, isIssRecord } from "./passes";
 export { type IlluminationInfo, type Vec3, computeIllumination } from "./illumination";

--- a/src/ui/bottom-hud.test.ts
+++ b/src/ui/bottom-hud.test.ts
@@ -364,4 +364,116 @@ describe("createBottomHud", () => {
       expect(speedBtn!.textContent).toBe("1×");
     });
   });
+
+  // Offline-TLE staleness pill (#354). Surfaces when the SGP4 propagator is
+  // running against the bundled snapshot and that snapshot is older than the
+  // 7-day accuracy window.
+  describe("TLE staleness pill (#354)", () => {
+    it("does not render the pill when no staleness props are provided", () => {
+      const pill = el.querySelector<HTMLElement>("[data-testid='hud-tle-staleness']");
+      // Either absent from the DOM or hidden — both are acceptable.
+      if (pill !== null) {
+        expect(pill.style.display).toBe("none");
+      }
+    });
+
+    it("renders the pill when usedFallback is true and age > 7 days", () => {
+      const localDispatch = vi.fn();
+      const h = createBottomHud(
+        {
+          timeUtc: BASE_TIME,
+          lat: 0,
+          lon: 0,
+          tleUsedFallback: true,
+          tleSourceAgeSeconds: 10 * 86400,
+        },
+        localDispatch,
+      );
+      document.body.appendChild(h.element);
+      try {
+        const pill = h.element.querySelector<HTMLElement>("[data-testid='hud-tle-staleness']");
+        expect(pill).not.toBeNull();
+        expect(pill!.style.display).not.toBe("none");
+        expect(pill!.textContent).toContain("Offline TLE");
+        expect(pill!.textContent).toContain("10d");
+      } finally {
+        h.destroy();
+        if (h.element.parentNode) h.element.parentNode.removeChild(h.element);
+      }
+    });
+
+    it("hides the pill when usedFallback is true but age ≤ 7 days", () => {
+      const localDispatch = vi.fn();
+      const h = createBottomHud(
+        {
+          timeUtc: BASE_TIME,
+          lat: 0,
+          lon: 0,
+          tleUsedFallback: true,
+          tleSourceAgeSeconds: 6 * 86400,
+        },
+        localDispatch,
+      );
+      document.body.appendChild(h.element);
+      try {
+        const pill = h.element.querySelector<HTMLElement>("[data-testid='hud-tle-staleness']");
+        if (pill !== null) {
+          expect(pill.style.display).toBe("none");
+        }
+      } finally {
+        h.destroy();
+        if (h.element.parentNode) h.element.parentNode.removeChild(h.element);
+      }
+    });
+
+    it("hides the pill when usedFallback is false even if age > 7 days", () => {
+      // A live fetch that happens to serve an old-ish snapshot should not
+      // scare the user — only offline fallback + old data does.
+      const localDispatch = vi.fn();
+      const h = createBottomHud(
+        {
+          timeUtc: BASE_TIME,
+          lat: 0,
+          lon: 0,
+          tleUsedFallback: false,
+          tleSourceAgeSeconds: 30 * 86400,
+        },
+        localDispatch,
+      );
+      document.body.appendChild(h.element);
+      try {
+        const pill = h.element.querySelector<HTMLElement>("[data-testid='hud-tle-staleness']");
+        if (pill !== null) {
+          expect(pill.style.display).toBe("none");
+        }
+      } finally {
+        h.destroy();
+        if (h.element.parentNode) h.element.parentNode.removeChild(h.element);
+      }
+    });
+
+    it("clicking the pill dispatches open-help", () => {
+      const localDispatch = vi.fn();
+      const h = createBottomHud(
+        {
+          timeUtc: BASE_TIME,
+          lat: 0,
+          lon: 0,
+          tleUsedFallback: true,
+          tleSourceAgeSeconds: 10 * 86400,
+        },
+        localDispatch,
+      );
+      document.body.appendChild(h.element);
+      try {
+        const pill = h.element.querySelector<HTMLElement>("[data-testid='hud-tle-staleness']");
+        expect(pill).not.toBeNull();
+        pill!.click();
+        expect(localDispatch).toHaveBeenCalledWith({ type: "open-help" } satisfies UIIntent);
+      } finally {
+        h.destroy();
+        if (h.element.parentNode) h.element.parentNode.removeChild(h.element);
+      }
+    });
+  });
 });

--- a/src/ui/bottom-hud.ts
+++ b/src/ui/bottom-hud.ts
@@ -11,6 +11,12 @@ const MIN_PER_MS = 60_000;
 const HOUR_PER_MS = 3_600_000;
 const DAY_PER_MS = 86_400_000;
 
+/** SGP4 accuracy degrades noticeably beyond ~1 week from the TLE epoch — an
+ *  ISS TLE two weeks old can be tens of km off. Above this threshold, and
+ *  only when we're serving the bundled fallback, we surface the staleness
+ *  pill (#354). */
+const TLE_STALE_THRESHOLD_SECONDS = 7 * 86_400;
+
 /**
  * Pixel-to-millisecond ratio while drag-scrubbing. Tuned so a full-width drag on
  * a ~1000px viewport covers roughly a 30-minute window — enough to feel responsive
@@ -107,7 +113,17 @@ function eventTargetsEditable(e: KeyboardEvent): boolean {
 }
 
 export function createBottomHud(
-  initial: { timeUtc: Date; lat: number; lon: number },
+  initial: {
+    timeUtc: Date;
+    lat: number;
+    lon: number;
+    /** Whether the current TLE dataset came from the bundled fallback (i.e.
+     *  the live Celestrak fetch failed). Combined with `tleSourceAgeSeconds`
+     *  to decide whether to surface the offline-staleness pill (#354). */
+    tleUsedFallback?: boolean;
+    /** Age (seconds) of the newest TLE epoch in the current dataset. */
+    tleSourceAgeSeconds?: number;
+  },
   dispatch: (intent: UIIntent) => void,
 ): BottomHud {
   let currentTime = new Date(initial.timeUtc);
@@ -223,6 +239,49 @@ export function createBottomHud(
     style: { ...CHIP_STYLE, fontVariantNumeric: "tabular-nums" },
   });
 
+  // TLE staleness pill (#354) — subtle amber warning surfaced only when the
+  // network fetch fell back to the bundled snapshot AND that snapshot is
+  // older than 7 days (satellite positions degrade fast — an ISS TLE two
+  // weeks old can be tens of km off). Clicking opens the Help modal so the
+  // user has a place to read what "offline TLE" means.
+  const usedFallback = initial.tleUsedFallback ?? false;
+  const ageSeconds = initial.tleSourceAgeSeconds ?? 0;
+  const shouldShowStalenessPill = usedFallback && ageSeconds > TLE_STALE_THRESHOLD_SECONDS;
+  const stalenessDays = Math.floor(ageSeconds / 86_400);
+  const stalenessPill = el("button", {
+    testid: "hud-tle-staleness",
+    type: "button",
+    text: shouldShowStalenessPill
+      ? `Offline TLE — positions may be off (${String(stalenessDays)}d old)`
+      : "",
+    attrs: {
+      title: "The live TLE fetch failed and the bundled snapshot is old — click for help",
+      "aria-label": "TLE data is stale — click for help",
+    },
+    style: {
+      background: "rgba(120, 80, 0, 0.35)",
+      border: "1px solid rgba(255, 180, 60, 0.55)",
+      borderRadius: "999px",
+      padding: "4px 10px",
+      color: "#ffcc80",
+      fontFamily: FONT_FAMILY,
+      fontSize: "12px",
+      cursor: "pointer",
+      display: shouldShowStalenessPill ? "" : "none",
+    },
+    on: {
+      click: (e) => {
+        e.stopPropagation();
+        dispatch({ type: "open-help" });
+      },
+    },
+  });
+
+  const rightGroup = el("div", {
+    style: { display: "flex", gap: "8px", alignItems: "center" },
+    children: [stalenessPill, compassChip],
+  });
+
   const root = el("div", {
     testid: "bottom-hud",
     style: {
@@ -248,7 +307,7 @@ export function createBottomHud(
       userSelect: "none",
       touchAction: "none",
     },
-    children: [locationChip, center, compassChip],
+    children: [locationChip, center, rightGroup],
   });
 
   // --- Idle fade ---

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -116,7 +116,8 @@ export type UIIntent =
     }
   | { readonly type: "set-active-plan"; readonly slug: string | null }
   | { readonly type: "open-sign-in" }
-  | { readonly type: "retry-plans" };
+  | { readonly type: "retry-plans" }
+  | { readonly type: "open-help" };
 
 export { createPlanCard } from "./plans-card";
 export { createPlansDrawer } from "./plans-drawer";


### PR DESCRIPTION
## Summary

TLE positions degrade fast — an ISS TLE two weeks old can be tens of km off. `fetchTle` in `src/sat/` used to fall back to the bundled snapshot silently when the network path failed, so users blamed the app for drift rather than the stale data. Surface the condition instead.

### `fetchTle` shape change

The `ok` branch now carries a small payload instead of the raw string:

```ts
export type TleFetchOk = {
  readonly text: string;
  readonly sourceAgeSeconds: number; // newest TLE epoch in the payload, in seconds ago
  readonly usedFallback: boolean;    // true iff we served the bundled snapshot
};
```

The `TleFetchError` union is untouched (still declared, still never actually returned — that's a pre-existing quirk of `fetchTle`, out of scope here).

### HUD pill

`src/ui/bottom-hud.ts` gains an amber `hud-tle-staleness` pill that only renders when `usedFallback === true` **and** `sourceAgeSeconds > 7 * 86400`. Text: `Offline TLE — positions may be off (Xd old)`. Clicking dispatches a new `open-help` intent that `app.ts` routes to the existing Help modal.

### Test cases

- `src/sat/fetch.test.ts`: six new cases exercising the payload shape and the epoch-age math — success (`usedFallback: false` + accurate `sourceAgeSeconds`), fetch-rejection fallback (`usedFallback: true` + accurate age), non-ok-response fallback, newest-epoch-wins across a multi-record payload, malformed-line-1 fallback to age 0, and empty-text response falling through to the bundled fallback.
- `src/ui/bottom-hud.test.ts`: pill hidden when no props / age ≤ 7d / `usedFallback: false`; visible with correct label when both conditions are met; click dispatches `{ type: "open-help" }`.

Pre-push gate (typecheck / lint / format:check / test:cov / build) all green locally.

## Test plan

- [x] `pnpm typecheck && pnpm lint && pnpm format:check && pnpm test:cov && pnpm build` clean
- [ ] Manual smoke: block Celestrak in DevTools → reload → confirm the amber pill appears in the bottom HUD and clicking opens the Help modal
- [ ] Manual smoke: normal load → confirm no pill is visible

Closes #354

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKmj4YQnxN8sydc7X6v2ra

---
_Generated by [Claude Code](https://claude.ai/code/session_01VKmj4YQnxN8sydc7X6v2ra)_