### PR TITLE
fix(app): skip onboarding overlay when ?plan= slug is in the URL (closes #353)

### DIFF
--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -1794,6 +1794,47 @@ describe("handleIntent routing", () => {
     vi.useRealTimers();
   });
 
+  it("does NOT start the onboarding overlay when booting with ?plan=<slug>", async () => {
+    // Regression #353: the transparent onboarding click-shield used to sit
+    // above the plan-reader modal on first visit with ?plan= in the URL,
+    // no-op'ing the modal's "×" close button. When a slug is in the URL the
+    // user has expressed a clear intent to read a plan — hydrate that, not the
+    // tour. Don't persist a "dismissed" flag on this path; they still deserve
+    // the tour on a subsequent open without a slug.
+    vi.useFakeTimers();
+    capturedDispatch = null;
+    onboardingOverlayMock = null;
+    plansModalMock = null;
+    globalThis.localStorage?.removeItem("planisphere.onboarding.v1");
+    getPlanResult = {
+      ok: true,
+      value: {
+        slug: "2026-04",
+        title: "April",
+        month: "2026-04",
+        hemisphere: "both",
+        summary: "Stub",
+        author: "Rob",
+        publishedAt: "2026-04-01T00:00:00.000Z",
+        bodyMd: "Body",
+        objects: [],
+      },
+    };
+    const { root, panelRoot } = makeRoot();
+    await bootstrap(root, new URLSearchParams({ plan: "2026-04" }));
+    expect(onboardingOverlayMock).not.toBeNull();
+    vi.advanceTimersByTime(1000);
+    expect(onboardingOverlayMock!.start).not.toHaveBeenCalled();
+    // The flag stays unset so the tour will still fire on a later open without ?plan=.
+    expect(globalThis.localStorage?.getItem("planisphere.onboarding.v1")).toBeNull();
+    document.body.removeChild(root);
+    document.body.removeChild(panelRoot);
+    document
+      .querySelectorAll("[data-testid='onboarding-overlay']")
+      .forEach((el) => el.parentNode?.removeChild(el));
+    vi.useRealTimers();
+  });
+
   it("passes an onReplayTour callback into createHelpModal that invokes overlay.replay()", async () => {
     capturedDispatch = null;
     onboardingOverlayMock = null;

--- a/src/app.ts
+++ b/src/app.ts
@@ -1687,7 +1687,11 @@ export async function bootstrap(
 
   // First-load onboarding tour — start after a small delay so Cesium has a
   // chance to paint before the dimmed overlay comes up. Skipped when the user
-  // has previously dismissed the tour (persisted in localStorage).
+  // has previously dismissed the tour (persisted in localStorage), and skipped
+  // when a plan slug is in the URL (#353): the reader modal is about to open
+  // and the transparent tour click-shield would sit above it, blocking the
+  // modal's close button. Don't persist "dismissed" on that path — the tour
+  // still deserves to fire on a later open without a slug.
   const onboardingFlag = (() => {
     try {
       return globalThis.localStorage?.getItem(ONBOARDING_STORAGE_KEY);
@@ -1695,7 +1699,7 @@ export async function bootstrap(
       return null;
     }
   })();
-  if (onboardingFlag !== "dismissed") {
+  if (onboardingFlag !== "dismissed" && state.activePlanSlug === null) {
     setTimeout(() => {
       onboardingOverlay.start();
     }, 500);


### PR DESCRIPTION
## Summary

- **Root cause:** `bootstrap()` in `src/app.ts` unconditionally scheduled `onboardingOverlay.start()` on a 500 ms `setTimeout` whenever the onboarding-dismissed flag wasn't set. On first visit to `?plan=<slug>` (no localStorage flag), both the plan-reader modal and the tour mounted — the tour's transparent click-shield sat above the modal, so tapping the modal's "x" close button no-op'd until the tour finished.
- **Fix:** skip the bootstrap-time `overlay.start()` call when `state.activePlanSlug !== null`. The URL slug is a clear signal the user wants to read a plan, not sit through the tour. The dismissed flag is **not** persisted on this path, so the tour still fires on a later open without a slug.
- **Test:** new unit test in `src/app.test.ts` boots with `?plan=2026-04` and no dismissed flag, advances fake timers past the 500 ms window, and asserts `overlay.start()` was not called and the localStorage flag stayed unset.

Closes #353.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm format:check`
- [x] `pnpm test:cov` (1316 tests pass; all coverage thresholds met)
- [x] `pnpm build`

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKmj4YQnxN8sydc7X6v2ra

---
_Generated by [Claude Code](https://claude.ai/code/session_01VKmj4YQnxN8sydc7X6v2ra)_