### PR TITLE
feat(ui): surface upcoming events in the empty-sky popover (closes #351)

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -988,6 +988,11 @@ export async function bootstrap(
         handleIntent(intent);
       },
       initialFov: state.fov,
+      // Read straight from the mutable caches — `cachedEvents` is refreshed on every
+      // observer/time change (see refreshEvents), so on-open() the popover always
+      // renders the freshest upcoming-events list against the current viewing time.
+      getEvents: () => cachedEvents,
+      getNow: () => state.timeUtc,
     });
     cesiumContainer.appendChild(emptySkyPopover.element);
 

--- a/src/ui/empty-sky-popover.test.ts
+++ b/src/ui/empty-sky-popover.test.ts
@@ -2,6 +2,34 @@
 import { describe, expect, it, vi } from "vitest";
 import { createEmptySkyPopover } from "./empty-sky-popover";
 import type { UIIntent } from "./index";
+import type { CelestialEvent, IssPassEvent, MeteorShowerEvent } from "../astro/events";
+
+function issPass(when: Date, peakAlt = 45, peakAz = 120): IssPassEvent {
+  return {
+    kind: "iss-pass",
+    when,
+    title: `ISS pass at ${peakAlt}°`,
+    description: "ISS pass description",
+    peakAltDeg: peakAlt,
+    peakAzDeg: peakAz,
+    durationSec: 360,
+    eclipsed: false,
+    magnitudeAtPeak: -2,
+  };
+}
+
+function shower(when: Date, name: string, view?: { az: number; alt: number }): MeteorShowerEvent {
+  return {
+    kind: "meteor-shower-peak",
+    when,
+    title: `${name} meteor shower peak`,
+    description: `Expect meteors from ${name}.`,
+    showerId: name.toLowerCase(),
+    showerName: name,
+    zhr: 100,
+    ...(view ? { viewAz: view.az, viewAlt: view.alt } : {}),
+  };
+}
 
 describe("createEmptySkyPopover", () => {
   it("returns a detached element and starts closed", () => {
@@ -144,6 +172,202 @@ describe("createEmptySkyPopover", () => {
     // The card should be anchored via `left` and `top` near (but not at) the click point.
     expect(card!.style.left).not.toBe("");
     expect(card!.style.top).not.toBe("");
+  });
+
+  it("renders no upcoming-events section when getEvents is not supplied", () => {
+    const popover = createEmptySkyPopover({ dispatch: vi.fn(), initialFov: "off" });
+    popover.open(30, 180, 100, 200);
+    expect(
+      popover.element.querySelector<HTMLElement>("[data-testid='empty-sky-popover-events']"),
+    ).toBeNull();
+    expect(
+      popover.element.querySelectorAll<HTMLElement>("[data-testid='empty-sky-popover-event-row']")
+        .length,
+    ).toBe(0);
+  });
+
+  it("renders no events section when getEvents returns an empty list", () => {
+    const popover = createEmptySkyPopover({
+      dispatch: vi.fn(),
+      initialFov: "off",
+      getEvents: () => [],
+      getNow: () => new Date("2026-07-06T00:00:00Z"),
+    });
+    popover.open(30, 180, 100, 200);
+    expect(
+      popover.element.querySelector<HTMLElement>("[data-testid='empty-sky-popover-events']"),
+    ).toBeNull();
+  });
+
+  it("renders exactly 3 upcoming-events rows sorted by time when 4+ events are supplied", () => {
+    const now = new Date("2026-07-06T00:00:00Z");
+    const events: CelestialEvent[] = [
+      shower(new Date("2026-07-08T03:00:00Z"), "Perseids"), // +2d 3h
+      issPass(new Date("2026-07-06T00:42:00Z")), // +42 min
+      shower(new Date("2026-07-06T05:00:00Z"), "Delta Aquariids"), // +5h
+      shower(new Date("2026-07-10T00:00:00Z"), "Alpha Capricornids"), // +4d
+    ];
+    const popover = createEmptySkyPopover({
+      dispatch: vi.fn(),
+      initialFov: "off",
+      getEvents: () => events,
+      getNow: () => now,
+    });
+    popover.open(30, 180, 100, 200);
+
+    const rows = popover.element.querySelectorAll<HTMLElement>(
+      "[data-testid='empty-sky-popover-event-row']",
+    );
+    expect(rows.length).toBe(3);
+
+    // Sorted by time — the ISS (42min) first, then Delta Aquariids (5h), then Perseids (2d).
+    expect(rows[0]!.textContent).toContain("ISS");
+    expect(rows[1]!.textContent).toContain("Delta Aquariids");
+    expect(rows[2]!.textContent).toContain("Perseids");
+    // Alpha Capricornids (further out) is dropped by the 3-cap.
+    const allText = popover.element.textContent ?? "";
+    expect(allText).not.toContain("Alpha Capricornids");
+  });
+
+  it("relative-time chip shows minutes for events under an hour out", () => {
+    const now = new Date("2026-07-06T00:00:00Z");
+    const events: CelestialEvent[] = [issPass(new Date("2026-07-06T00:42:00Z"))];
+    const popover = createEmptySkyPopover({
+      dispatch: vi.fn(),
+      initialFov: "off",
+      getEvents: () => events,
+      getNow: () => now,
+    });
+    popover.open(30, 180, 100, 200);
+    const chip = popover.element.querySelector<HTMLElement>(
+      "[data-testid='empty-sky-popover-event-chip']",
+    );
+    expect(chip).not.toBeNull();
+    expect(chip!.textContent).toContain("42 min");
+    expect(chip!.textContent).toContain("in");
+  });
+
+  it("relative-time chip shows Xd Yh for multi-day events", () => {
+    const now = new Date("2026-07-06T00:00:00Z");
+    const events: CelestialEvent[] = [
+      shower(new Date("2026-07-09T14:00:00Z"), "Perseids"), // 3d 14h
+    ];
+    const popover = createEmptySkyPopover({
+      dispatch: vi.fn(),
+      initialFov: "off",
+      getEvents: () => events,
+      getNow: () => now,
+    });
+    popover.open(30, 180, 100, 200);
+    const chip = popover.element.querySelector<HTMLElement>(
+      "[data-testid='empty-sky-popover-event-chip']",
+    );
+    expect(chip).not.toBeNull();
+    expect(chip!.textContent).toContain("3d");
+    expect(chip!.textContent).toContain("14h");
+  });
+
+  it("clicking an events row with a view direction dispatches set-time AND set-view", () => {
+    const now = new Date("2026-07-06T00:00:00Z");
+    const events: CelestialEvent[] = [issPass(new Date("2026-07-06T00:42:00Z"), 45, 120)];
+    const dispatch = vi.fn();
+    const popover = createEmptySkyPopover({
+      dispatch,
+      initialFov: "off",
+      getEvents: () => events,
+      getNow: () => now,
+    });
+    popover.open(30, 180, 100, 200);
+
+    const row = popover.element.querySelector<HTMLElement>(
+      "[data-testid='empty-sky-popover-event-row']",
+    );
+    expect(row).not.toBeNull();
+    row!.click();
+
+    expect(dispatch).toHaveBeenCalledWith({
+      type: "set-time",
+      time: events[0]!.when,
+    } satisfies UIIntent);
+    expect(dispatch).toHaveBeenCalledWith({
+      type: "set-view",
+      az: 120,
+      alt: 45,
+    } satisfies UIIntent);
+  });
+
+  it("clicking an events row without a view direction only dispatches set-time", () => {
+    const now = new Date("2026-07-06T00:00:00Z");
+    // Meteor shower without viewAz/viewAlt supplied.
+    const events: CelestialEvent[] = [shower(new Date("2026-07-06T05:00:00Z"), "Perseids")];
+    const dispatch = vi.fn();
+    const popover = createEmptySkyPopover({
+      dispatch,
+      initialFov: "off",
+      getEvents: () => events,
+      getNow: () => now,
+    });
+    popover.open(30, 180, 100, 200);
+    const row = popover.element.querySelector<HTMLElement>(
+      "[data-testid='empty-sky-popover-event-row']",
+    );
+    row!.click();
+
+    expect(dispatch).toHaveBeenCalledWith({
+      type: "set-time",
+      time: events[0]!.when,
+    } satisfies UIIntent);
+    // No set-view intent should have been dispatched.
+    expect(
+      dispatch.mock.calls.some(
+        (call: unknown[]) =>
+          typeof call[0] === "object" &&
+          call[0] !== null &&
+          (call[0] as { type: string }).type === "set-view",
+      ),
+    ).toBe(false);
+  });
+
+  it("clicking an events row closes the popover", () => {
+    const now = new Date("2026-07-06T00:00:00Z");
+    const events: CelestialEvent[] = [issPass(new Date("2026-07-06T00:42:00Z"))];
+    const popover = createEmptySkyPopover({
+      dispatch: vi.fn(),
+      initialFov: "off",
+      getEvents: () => events,
+      getNow: () => now,
+    });
+    popover.open(30, 180, 100, 200);
+    const row = popover.element.querySelector<HTMLElement>(
+      "[data-testid='empty-sky-popover-event-row']",
+    );
+    row!.click();
+    expect(popover.isOpen()).toBe(false);
+  });
+
+  it("re-opening after events change picks up the fresh list", () => {
+    const now = new Date("2026-07-06T00:00:00Z");
+    let events: CelestialEvent[] = [];
+    const popover = createEmptySkyPopover({
+      dispatch: vi.fn(),
+      initialFov: "off",
+      getEvents: () => events,
+      getNow: () => now,
+    });
+    popover.open(30, 180, 100, 200);
+    expect(
+      popover.element.querySelectorAll<HTMLElement>("[data-testid='empty-sky-popover-event-row']")
+        .length,
+    ).toBe(0);
+
+    // Fresh events arrive; next open must reflect them.
+    events = [issPass(new Date("2026-07-06T00:42:00Z"))];
+    popover.close();
+    popover.open(30, 180, 100, 200);
+    expect(
+      popover.element.querySelectorAll<HTMLElement>("[data-testid='empty-sky-popover-event-row']")
+        .length,
+    ).toBe(1);
   });
 
   it("flips the card to the left when the click is near the right viewport edge", () => {

--- a/src/ui/empty-sky-popover.ts
+++ b/src/ui/empty-sky-popover.ts
@@ -1,11 +1,20 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 import { el } from "./dom";
 import { FOV_PRESETS, type FovPresetId, isFovPresetId } from "../astro/fov-presets";
+import type { CelestialEvent } from "../astro/events";
 import type { UIIntent } from "./index";
 
 export type EmptySkyPopoverOptions = {
   readonly dispatch: (intent: UIIntent) => void;
   readonly initialFov: FovPresetId;
+  /** Supplier for the current upcoming-events list. Called on each `open()` so the
+   *  popover always renders the freshest events. Omit (or return []) to hide the
+   *  upcoming-events section entirely and fall back to the standalone empty-sky UI. */
+  readonly getEvents?: () => readonly CelestialEvent[];
+  /** Supplier for the "now" reference used to format relative-time chips ("in 42 min",
+   *  "in 3d 14h"). Should be the app's viewing time (`state.timeUtc`) — the same value
+   *  the events were computed against. Defaults to real wall-clock time when omitted. */
+  readonly getNow?: () => Date;
 };
 
 export type EmptySkyPopover = {
@@ -99,6 +108,88 @@ const FOV_SELECT_STYLE: Partial<CSSStyleDeclaration> = {
   padding: "3px",
   font: "11px sans-serif",
 };
+
+const EVENTS_SECTION_STYLE: Partial<CSSStyleDeclaration> = {
+  marginTop: "8px",
+  paddingTop: "8px",
+  borderTop: "1px solid rgba(255,255,255,0.12)",
+  display: "flex",
+  flexDirection: "column",
+  gap: "4px",
+};
+
+const EVENTS_HEADING_STYLE: Partial<CSSStyleDeclaration> = {
+  color: "rgba(255,255,255,0.6)",
+  font: "11px sans-serif",
+  textTransform: "uppercase",
+  letterSpacing: "0.4px",
+};
+
+const EVENT_ROW_STYLE: Partial<CSSStyleDeclaration> = {
+  display: "flex",
+  justifyContent: "space-between",
+  alignItems: "center",
+  gap: "6px",
+  padding: "4px 6px",
+  background: "rgba(255,255,255,0.06)",
+  border: "1px solid rgba(255,255,255,0.1)",
+  borderRadius: "4px",
+  cursor: "pointer",
+  textAlign: "left",
+  color: "#fff",
+  font: "11px sans-serif",
+};
+
+const EVENT_TITLE_STYLE: Partial<CSSStyleDeclaration> = {
+  flex: "1",
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+  whiteSpace: "nowrap",
+};
+
+const EVENT_CHIP_STYLE: Partial<CSSStyleDeclaration> = {
+  flexShrink: "0",
+  padding: "1px 6px",
+  background: "rgba(100,160,255,0.25)",
+  border: "1px solid rgba(100,160,255,0.5)",
+  borderRadius: "8px",
+  color: "rgba(255,255,255,0.9)",
+  font: "10px sans-serif",
+};
+
+const MAX_EVENT_ROWS = 3;
+
+/** Format a millisecond delta as a short relative-time chip. Examples:
+ *  - "in 42 min" (< 1 hour)
+ *  - "in 5h 12m" (< 1 day)
+ *  - "in 3d 14h" (>= 1 day)
+ *  Negative deltas (past events) collapse to "now". */
+export function formatRelative(fromMs: number, toMs: number): string {
+  const deltaMs = toMs - fromMs;
+  if (deltaMs <= 0) return "now";
+  const totalMinutes = Math.round(deltaMs / 60000);
+  if (totalMinutes < 60) return `in ${String(totalMinutes)} min`;
+  const totalHours = Math.floor(totalMinutes / 60);
+  if (totalHours < 24) {
+    const mins = totalMinutes - totalHours * 60;
+    return `in ${String(totalHours)}h ${String(mins)}m`;
+  }
+  const days = Math.floor(totalHours / 24);
+  const hours = totalHours - days * 24;
+  return `in ${String(days)}d ${String(hours)}h`;
+}
+
+/** Extract the aim direction from an event when one is available. ISS pass events
+ *  carry peakAz/peakAlt; the other kinds carry optional viewAz/viewAlt. */
+function viewFromEvent(event: CelestialEvent): { az: number; alt: number } | null {
+  if (event.kind === "iss-pass") {
+    return { az: event.peakAzDeg, alt: event.peakAltDeg };
+  }
+  if (event.viewAz !== undefined && event.viewAlt !== undefined) {
+    return { az: event.viewAz, alt: event.viewAlt };
+  }
+  return null;
+}
 
 /** Smart edge-flip placement matching the object-card idiom. */
 function smartPosition(
@@ -194,11 +285,17 @@ export function createEmptySkyPopover(opts: EmptySkyPopoverOptions): EmptySkyPop
     children: [el("label", { text: "FOV", style: FOV_LABEL_STYLE }), fovSelect],
   });
 
-  // Card — floating panel with readout, "Look here", FOV select, and close button.
+  // Upcoming-events section — rebuilt on every open() from opts.getEvents().
+  // Hidden entirely when no events are supplied or the list is empty, so the
+  // fallback "Empty sky" copy stays the whole story.
+  const eventsHost = el("div", { testid: "empty-sky-popover-events-host" });
+  eventsHost.style.display = "none";
+
+  // Card — floating panel with readout, "Look here", upcoming events, FOV select, close.
   const card = el("div", {
     testid: "empty-sky-popover-card",
     style: CARD_STYLE,
-    children: [header, readout, actionRow, fovRow],
+    children: [header, readout, actionRow, eventsHost, fovRow],
   });
 
   const root = el("div", {
@@ -238,10 +335,66 @@ export function createEmptySkyPopover(opts: EmptySkyPopoverOptions): EmptySkyPop
     root.style.display = "none";
   }
 
+  function buildEventRow(event: CelestialEvent, nowMs: number): HTMLElement {
+    const chip = el("span", {
+      testid: "empty-sky-popover-event-chip",
+      text: formatRelative(nowMs, event.when.getTime()),
+      style: EVENT_CHIP_STYLE,
+    });
+    const title = el("span", {
+      testid: "empty-sky-popover-event-title",
+      text: event.title,
+      style: EVENT_TITLE_STYLE,
+    });
+    const row = el("button", {
+      testid: "empty-sky-popover-event-row",
+      type: "button",
+      style: EVENT_ROW_STYLE,
+      children: [title, chip],
+    });
+    row.addEventListener("click", () => {
+      opts.dispatch({ type: "set-time", time: event.when });
+      const view = viewFromEvent(event);
+      if (view !== null) {
+        opts.dispatch({ type: "set-view", az: view.az, alt: view.alt });
+      }
+      closePopover();
+    });
+    return row;
+  }
+
+  function renderEvents(): void {
+    const supplier = opts.getEvents;
+    if (!supplier) {
+      eventsHost.replaceChildren();
+      eventsHost.style.display = "none";
+      return;
+    }
+    const upcoming = [...supplier()].sort((a, b) => a.when.getTime() - b.when.getTime());
+    const shown = upcoming.slice(0, MAX_EVENT_ROWS);
+    if (shown.length === 0) {
+      eventsHost.replaceChildren();
+      eventsHost.style.display = "none";
+      return;
+    }
+    const nowMs = (opts.getNow ? opts.getNow() : new Date()).getTime();
+    const section = el("div", {
+      testid: "empty-sky-popover-events",
+      style: EVENTS_SECTION_STYLE,
+      children: [
+        el("div", { text: "Upcoming", style: EVENTS_HEADING_STYLE }),
+        ...shown.map((event) => buildEventRow(event, nowMs)),
+      ],
+    });
+    eventsHost.replaceChildren(section);
+    eventsHost.style.display = "";
+  }
+
   function openPopover(alt: number, az: number, screenX: number, screenY: number): void {
     currentAlt = alt;
     currentAz = az;
     setReadout(alt, az);
+    renderEvents();
     placeReticle(screenX, screenY);
     placeCard(screenX, screenY);
     show();


### PR DESCRIPTION
## Summary

Clicking an empty patch of sky opened a popover that showed alt/az and a "Look here" button but nothing about *why* the sky is worth watching — even if an ISS pass or meteor peak was 40 minutes away. This wires the existing `computeUpcomingEvents` list (already fed into the events drawer) into the popover so users see the next few things happening overhead without leaving the click.

**New `createEmptySkyPopover` prop signature:**

```ts
export type EmptySkyPopoverOptions = {
  readonly dispatch: (intent: UIIntent) => void;
  readonly initialFov: FovPresetId;
  readonly getEvents?: () => readonly CelestialEvent[]; // NEW
  readonly getNow?: () => Date;                          // NEW
};
```

- `getEvents` is read on every `open()` call so the freshest list is always shown. Omitted or empty → the events section is hidden and the original "Empty sky" popover copy stays the whole story (graceful empty state per the issue).
- `getNow` supplies the reference time for the relative-time chips ("in 42 min", "in 3d 14h"). Defaults to wall-clock when omitted. In `app.ts` it comes from `state.timeUtc` — the same instant events were computed against, so chips read correctly under time-scrubbing.
- Up to **3 rows** rendered, sorted by time. Each row is a button showing the event title + relative-time chip; clicking dispatches `{ type: "set-time", time: event.when }`, plus `{ type: "set-view", az, alt }` when the event carries a peak direction (ISS `peakAzDeg/AltDeg`, or conjunction/eclipse/shower `viewAz/viewAlt`), and closes the popover.

Both props are optional to keep every existing call site (there is only one — `app.ts`) working without ceremony; the app.ts diff is 5 lines to plumb `cachedEvents` and `state.timeUtc`.

## Test plan

- [x] `pnpm typecheck && pnpm lint && pnpm format:check && pnpm test:cov && pnpm build` — full pre-push gate green locally (1324/1324 tests, all coverage thresholds met including `src/ui/`)
- [x] New unit tests in `src/ui/empty-sky-popover.test.ts` cover: fallback when `getEvents` is omitted, empty-list fallback, 3-row cap with sorting from a 4-event input, relative-time chip formatting for both minutes-out and multi-day events, click dispatch of `set-time` alone (event without view direction), click dispatch of `set-time + set-view` (event with view direction), popover auto-closes on row click, and re-opening picks up a freshly mutated events list

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKmj4YQnxN8sydc7X6v2ra

---
_Generated by [Claude Code](https://claude.ai/code/session_01VKmj4YQnxN8sydc7X6v2ra)_