### PR TITLE
feat(state): deep-link animation state and speed in share URL (closes #348)

### DIFF
--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -250,6 +250,9 @@ vi.mock("../data/boundaries.json", () => ({
 
 // Captured dispatch function from UI mock — used in intent tests
 let capturedDispatch: ((intent: unknown) => void) | null = null;
+// Captured bottomHud.setAnimation spy — lets tests assert bootstrap hydration
+// of ?anim / ?speed reaches the HUD (#348).
+let capturedBottomHudSetAnimation: ReturnType<typeof vi.fn> | null = null;
 let capturedPanelOptions: {
   onOpenEvents?: () => void;
   onOpenSettings?: () => void;
@@ -409,12 +412,14 @@ vi.mock("./ui", () => ({
     capturedDispatch = dispatch as (intent: unknown) => void;
     const element = document.createElement("div");
     element.dataset.testid = "bottom-hud";
+    const setAnimation = vi.fn();
+    capturedBottomHudSetAnimation = setAnimation;
     return {
       element,
       setTime: vi.fn(),
       setObserver: vi.fn(),
       setCompass: vi.fn(),
-      setAnimation: vi.fn(),
+      setAnimation,
       destroy: vi.fn(),
     };
   }),
@@ -1185,6 +1190,43 @@ describe("handleIntent routing", () => {
     expect(() => capturedDispatch!({ type: "set-animation-speed", speed: 10 })).not.toThrow();
     expect(() => capturedDispatch!({ type: "set-animation-speed", speed: 100 })).not.toThrow();
     expect(() => capturedDispatch!({ type: "set-animation-speed", speed: 1 })).not.toThrow();
+    document.body.removeChild(root);
+    document.body.removeChild(panelRoot);
+  });
+
+  it("hydrates animation state from ?anim=play&speed=10 and syncs the HUD (#348)", async () => {
+    capturedDispatch = null;
+    capturedBottomHudSetAnimation = null;
+    const { root, panelRoot } = makeRoot();
+    await bootstrap(root, new URLSearchParams({ anim: "play", speed: "10" }));
+    expect(capturedBottomHudSetAnimation).not.toBeNull();
+    // Bootstrap should reflect the hydrated URL params in the HUD.
+    expect(capturedBottomHudSetAnimation).toHaveBeenCalledWith(true, 10);
+    document.body.removeChild(root);
+    document.body.removeChild(panelRoot);
+  });
+
+  it("does not sync animation-playing to HUD when ?anim is absent (default paused)", async () => {
+    capturedDispatch = null;
+    capturedBottomHudSetAnimation = null;
+    const { root, panelRoot } = makeRoot();
+    // Explicit empty params — the default (globalThis.location.search) may
+    // still carry ?anim=play&speed=10 from a prior test's history.replaceState.
+    await bootstrap(root, new URLSearchParams());
+    // Paused default → no setAnimation with playing=true from bootstrap.
+    expect(capturedBottomHudSetAnimation).not.toHaveBeenCalledWith(true, 1);
+    expect(capturedBottomHudSetAnimation).not.toHaveBeenCalledWith(true, 10);
+    expect(capturedBottomHudSetAnimation).not.toHaveBeenCalledWith(true, 100);
+    document.body.removeChild(root);
+    document.body.removeChild(panelRoot);
+  });
+
+  it("hydrates speed only when ?speed=100 and ?anim absent (#348)", async () => {
+    capturedDispatch = null;
+    capturedBottomHudSetAnimation = null;
+    const { root, panelRoot } = makeRoot();
+    await bootstrap(root, new URLSearchParams({ speed: "100" }));
+    expect(capturedBottomHudSetAnimation).toHaveBeenCalledWith(false, 100);
     document.body.removeChild(root);
     document.body.removeChild(panelRoot);
   });

--- a/src/app.ts
+++ b/src/app.ts
@@ -1099,12 +1099,9 @@ export async function bootstrap(
 
   let bottomHud: BottomHud | null = null;
 
-  // #136 — time animation state. Not URL-synced; animation is a transient
-  // client-side thing that shouldn't survive reload.
-  const animation: { playing: boolean; speed: 1 | 10 | 100 } = {
-    playing: false,
-    speed: 1,
-  };
+  // #136 — time animation state. Since #348, URL-synced via ?anim / ?speed so
+  // that "Copy link" while animating captures the play state and speed. The
+  // authoritative store is `state.animation`; RAF bookkeeping stays local.
   let animationRafId: number | null = null;
   let animationLastFrameMs = 0;
   const ANIMATION_BASE_MS_PER_MS = 60_000; // 1× wall-second = 1 minute of sky time
@@ -1118,7 +1115,7 @@ export async function bootstrap(
         : null;
     if (raf === null) return;
     const tick = (): void => {
-      if (!animation.playing) {
+      if (!state.animation.playing) {
         animationRafId = null;
         return;
       }
@@ -1126,7 +1123,7 @@ export async function bootstrap(
         typeof globalThis.performance?.now === "function" ? globalThis.performance.now() : 0;
       const dt = animationLastFrameMs === 0 ? 16 : now - animationLastFrameMs;
       animationLastFrameMs = now;
-      const advanceMs = dt * animation.speed * (ANIMATION_BASE_MS_PER_MS / 1000);
+      const advanceMs = dt * state.animation.speed * (ANIMATION_BASE_MS_PER_MS / 1000);
       const next = new Date(state.timeUtc.getTime() + advanceMs);
       handleIntent({ type: "set-time", time: next });
       animationRafId = raf(tick);
@@ -1305,18 +1302,21 @@ export async function bootstrap(
     intent: UIIntent & { type: "set-mode" | "toggle-animation" | "set-animation-speed" },
   ): void {
     if (intent.type === "toggle-animation") {
-      animation.playing = !animation.playing;
-      bottomHud?.setAnimation(animation.playing, animation.speed);
-      if (animation.playing) {
+      const nextPlaying = !state.animation.playing;
+      state = { ...state, animation: { ...state.animation, playing: nextPlaying } };
+      bottomHud?.setAnimation(nextPlaying, state.animation.speed);
+      if (nextPlaying) {
         startAnimationLoop();
       } else {
         stopAnimationLoop();
       }
+      updateUrl(state);
       return;
     }
     if (intent.type === "set-animation-speed") {
-      animation.speed = intent.speed;
-      bottomHud?.setAnimation(animation.playing, animation.speed);
+      state = { ...state, animation: { ...state.animation, speed: intent.speed } };
+      bottomHud?.setAnimation(state.animation.playing, state.animation.speed);
+      updateUrl(state);
       return;
     }
     // Notebook is a Pro feature (issue #224). Non-Pro users attempting to
@@ -1543,6 +1543,16 @@ export async function bootstrap(
   );
   document.body.appendChild(bottomHud.element);
   bottomHud.setCompass(getCameraHeadingDeg(viewer.camera));
+
+  // #348 — hydrate the animation state that came in from ?anim / ?speed.
+  // Reflects to the HUD immediately so the play button and speed pill match
+  // the URL, and kicks off the RAF loop when the link was captured mid-play.
+  if (state.animation.playing || state.animation.speed !== 1) {
+    bottomHud.setAnimation(state.animation.playing, state.animation.speed);
+  }
+  if (state.animation.playing) {
+    startAnimationLoop();
+  }
 
   // Location picker overlay (milestone 1B of Plan 07, issue #193). Created once at
   // bootstrap and opened via the `open-location-picker` intent fired from the bottom

--- a/src/state/state.test.ts
+++ b/src/state/state.test.ts
@@ -517,3 +517,129 @@ describe("activePlanSlug", () => {
     expect(s.activePlanSlug).toBeNull();
   });
 });
+
+describe("animation — defaults", () => {
+  it("defaults to paused, speed=1", () => {
+    expect(DEFAULT_STATE.animation.playing).toBe(false);
+    expect(DEFAULT_STATE.animation.speed).toBe(1);
+  });
+
+  it("returns default animation when both params absent", () => {
+    const s = expectOk(parseStateFromSearchParams(new URLSearchParams()));
+    expect(s.animation.playing).toBe(false);
+    expect(s.animation.speed).toBe(1);
+  });
+});
+
+describe("animation — parse from URL", () => {
+  it("parses anim=play as playing=true", () => {
+    const s = expectOk(parseStateFromSearchParams(new URLSearchParams({ anim: "play" })));
+    expect(s.animation.playing).toBe(true);
+  });
+
+  it("parses anim=paused as playing=false", () => {
+    const s = expectOk(parseStateFromSearchParams(new URLSearchParams({ anim: "paused" })));
+    expect(s.animation.playing).toBe(false);
+  });
+
+  it("falls back to paused for unknown anim value", () => {
+    const s = expectOk(parseStateFromSearchParams(new URLSearchParams({ anim: "wat" })));
+    expect(s.animation.playing).toBe(false);
+  });
+
+  it("parses speed=1", () => {
+    const s = expectOk(parseStateFromSearchParams(new URLSearchParams({ speed: "1" })));
+    expect(s.animation.speed).toBe(1);
+  });
+
+  it("parses speed=10", () => {
+    const s = expectOk(parseStateFromSearchParams(new URLSearchParams({ speed: "10" })));
+    expect(s.animation.speed).toBe(10);
+  });
+
+  it("parses speed=100", () => {
+    const s = expectOk(parseStateFromSearchParams(new URLSearchParams({ speed: "100" })));
+    expect(s.animation.speed).toBe(100);
+  });
+
+  it("falls back to 1 for out-of-range speed", () => {
+    const s = expectOk(parseStateFromSearchParams(new URLSearchParams({ speed: "42" })));
+    expect(s.animation.speed).toBe(1);
+  });
+
+  it("falls back to 1 for non-numeric speed", () => {
+    const s = expectOk(parseStateFromSearchParams(new URLSearchParams({ speed: "abc" })));
+    expect(s.animation.speed).toBe(1);
+  });
+
+  it("falls back to 1 for empty speed", () => {
+    const s = expectOk(parseStateFromSearchParams(new URLSearchParams({ speed: "" })));
+    expect(s.animation.speed).toBe(1);
+  });
+
+  it("parses both anim and speed together", () => {
+    const s = expectOk(
+      parseStateFromSearchParams(new URLSearchParams({ anim: "play", speed: "10" })),
+    );
+    expect(s.animation.playing).toBe(true);
+    expect(s.animation.speed).toBe(10);
+  });
+});
+
+describe("animation — serialize round-trip", () => {
+  it("omits anim param when paused (default)", () => {
+    const s = expectOk(parseStateFromSearchParams(new URLSearchParams()));
+    const out = serializeStateToSearchParams(s);
+    expect(out.has("anim")).toBe(false);
+  });
+
+  it("omits speed param when speed=1 (default)", () => {
+    const s = expectOk(parseStateFromSearchParams(new URLSearchParams()));
+    const out = serializeStateToSearchParams(s);
+    expect(out.has("speed")).toBe(false);
+  });
+
+  it("writes anim=play when playing", () => {
+    const out = serializeStateToSearchParams({
+      ...DEFAULT_STATE,
+      animation: { playing: true, speed: 1 },
+    });
+    expect(out.get("anim")).toBe("play");
+  });
+
+  it("writes speed=10 when non-default", () => {
+    const out = serializeStateToSearchParams({
+      ...DEFAULT_STATE,
+      animation: { playing: false, speed: 10 },
+    });
+    expect(out.get("speed")).toBe("10");
+  });
+
+  it("writes speed=100 when non-default", () => {
+    const out = serializeStateToSearchParams({
+      ...DEFAULT_STATE,
+      animation: { playing: false, speed: 100 },
+    });
+    expect(out.get("speed")).toBe("100");
+  });
+
+  it("round-trips playing=true, speed=100", () => {
+    const encoded = serializeStateToSearchParams({
+      ...DEFAULT_STATE,
+      animation: { playing: true, speed: 100 },
+    });
+    const decoded = expectOk(parseStateFromSearchParams(encoded));
+    expect(decoded.animation.playing).toBe(true);
+    expect(decoded.animation.speed).toBe(100);
+  });
+
+  it("round-trips playing=false, speed=10", () => {
+    const encoded = serializeStateToSearchParams({
+      ...DEFAULT_STATE,
+      animation: { playing: false, speed: 10 },
+    });
+    const decoded = expectOk(parseStateFromSearchParams(encoded));
+    expect(decoded.animation.playing).toBe(false);
+    expect(decoded.animation.speed).toBe(10);
+  });
+});

--- a/src/state/state.ts
+++ b/src/state/state.ts
@@ -30,6 +30,13 @@ export type ViewDirection = {
 
 export type AppMode = "planetarium" | "notebook";
 
+export type AnimationSpeed = 1 | 10 | 100;
+
+export type Animation = {
+  readonly playing: boolean;
+  readonly speed: AnimationSpeed;
+};
+
 export type AppState = {
   readonly observer: Observer;
   readonly timeUtc: Date;
@@ -43,6 +50,7 @@ export type AppState = {
   readonly skyculture: SkycultureId; // asterism set, default "western"
   readonly mode: AppMode; // app-surface mode, default "planetarium"
   readonly activePlanSlug: string | null; // URL-synced via ?plan=<slug>
+  readonly animation: Animation; // #348 — URL-synced via ?anim=play&speed=<1|10|100>
 };
 
 export type StateParseError =
@@ -86,6 +94,7 @@ export const DEFAULT_FOV: FovPresetId = "off";
 export const DEFAULT_SKYCULTURE: SkycultureId = "western";
 export const DEFAULT_MODE: AppMode = "planetarium";
 export const DEFAULT_ACTIVE_PLAN_SLUG: string | null = null;
+export const DEFAULT_ANIMATION: Animation = { playing: false, speed: 1 };
 
 export const DEFAULT_STATE: AppState = {
   observer: { lat: 0, lon: 0 },
@@ -100,6 +109,7 @@ export const DEFAULT_STATE: AppState = {
   skyculture: DEFAULT_SKYCULTURE,
   mode: DEFAULT_MODE,
   activePlanSlug: DEFAULT_ACTIVE_PLAN_SLUG,
+  animation: DEFAULT_ANIMATION,
 };
 
 const PLAN_SLUG_PATTERN = /^[a-z0-9-]{1,64}$/;
@@ -166,6 +176,13 @@ function parseMode(raw: string | null): AppMode {
   return DEFAULT_MODE;
 }
 
+function parseAnimation(rawAnim: string | null, rawSpeed: string | null): Animation {
+  const playing = rawAnim === "play";
+  const speed: AnimationSpeed =
+    rawSpeed === "10" ? 10 : rawSpeed === "100" ? 100 : DEFAULT_ANIMATION.speed;
+  return { playing, speed };
+}
+
 export function parseStateFromSearchParams(
   params: URLSearchParams,
 ): Result<AppState, StateParseError> {
@@ -225,6 +242,7 @@ export function parseStateFromSearchParams(
   const skyculture = parseSkyculture(params.get("sky"));
   const mode = parseMode(params.get("mode"));
   const activePlanSlug = parseActivePlanSlug(params.get("plan"));
+  const animation = parseAnimation(params.get("anim"), params.get("speed"));
 
   return ok({
     observer: { lat, lon },
@@ -239,6 +257,7 @@ export function parseStateFromSearchParams(
     skyculture,
     mode,
     activePlanSlug,
+    animation,
   });
 }
 
@@ -308,6 +327,14 @@ export function serializeStateToSearchParams(state: AppState): URLSearchParams {
 
   if (state.activePlanSlug !== null) {
     params.set("plan", state.activePlanSlug);
+  }
+
+  if (state.animation.playing) {
+    params.set("anim", "play");
+  }
+
+  if (state.animation.speed !== DEFAULT_ANIMATION.speed) {
+    params.set("speed", String(state.animation.speed));
   }
 
   return params;


### PR DESCRIPTION
## Summary

Copy-link while the sky is animating at 10x/100x now round-trips through the URL. The recipient sees the same play state and speed instead of a still frame.

- **New URL params** on `AppState.animation`:
  - `anim=play|paused` — default `paused`, so old links keep working.
  - `speed=1|10|100` — default `1`; anything else falls back to `1`.
- **Serialise/parse** in `src/state/state.ts` — parser stays a `Result`; malformed and out-of-range values fall back to defaults without throwing.
- **Bootstrap** reflects the hydrated animation state to the HUD and starts the RAF loop when `state.animation.playing` is true. The `toggle-animation` / `set-animation-speed` intents now update `state` and call `updateUrl(state)` so the URL follows subsequent play/pause + speed changes.
- **`state.animation`** replaces the transient closure-local `animation` object that used to live in `bootstrap`; the RAF `tick` reads `state.animation.{playing,speed}` directly.

## Tests

Added to `src/state/state.test.ts`:
- Defaults: `DEFAULT_STATE.animation === { playing: false, speed: 1 }`, and empty search-params returns the same.
- Parse: `anim=play` / `anim=paused` / unknown `anim=wat`; `speed=1/10/100`, plus `speed=42` / `speed=abc` / `speed=""` all fall back to `1`.
- Serialise: `anim` and `speed` are omitted at defaults, written when non-default, and round-trip both `playing=true, speed=100` and `playing=false, speed=10`.

Added to `src/app.test.ts`:
- Bootstrap with `?anim=play&speed=10` calls `bottomHud.setAnimation(true, 10)`.
- Bootstrap with no params does not call `setAnimation` with `playing=true` (using an explicit empty `URLSearchParams` to sidestep leaking `location.search` from earlier tests).
- Bootstrap with `?speed=100` alone calls `setAnimation(false, 100)`.

## Test plan
- [x] `pnpm typecheck && pnpm lint && pnpm format:check && pnpm test:cov && pnpm build` (1337/1337 tests passing, state 97.85% lines / 96.93% branches, app.ts 92.91% lines / 67.68% branches — both above thresholds)

Closes #348

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKmj4YQnxN8sydc7X6v2ra

---
_Generated by [Claude Code](https://claude.ai/code/session_01VKmj4YQnxN8sydc7X6v2ra)_