### PR TITLE
test(e2e): stabilize the Xvfb WebGL flake trio via a bootstrap-ready signal (closes #373)

### DIFF
--- a/e2e/bottom-hud-smoke.spec.ts
+++ b/e2e/bottom-hud-smoke.spec.ts
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 import { expect, test } from "@playwright/test";
-import { seedDefaultStorage, waitForCesiumPainted } from "./fixtures";
+import { seedDefaultStorage, waitForCesiumPainted, waitForPlanisphereReady } from "./fixtures";
 
 /**
  * Bottom-HUD / drawer-rail smoke test (issue #303 #4).
@@ -31,6 +31,10 @@ test("bottom-hud is present and each drawer trigger opens its drawer", async ({ 
   await page.goto("/?lat=61.2&lon=-149.9&t=2026-04-25T08:00:00Z");
   await expect(page.locator("#cesium-container canvas")).toBeVisible();
   await waitForCesiumPainted(page, 10_000);
+  // Bottom-hud chrome is only appended near the tail of bootstrap; without
+  // this the earlier `waitForCesiumPainted` alone could return before the
+  // HUD lands in the DOM on slow Xvfb runners (#373).
+  await waitForPlanisphereReady(page);
 
   // Bottom HUD chrome is mounted.
   await expect(page.locator("[data-testid='bottom-hud']")).toBeVisible();

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -30,6 +30,30 @@ export async function seedDefaultStorage(page: Page): Promise<void> {
 }
 
 /**
+ * Wait for the SPA's bootstrap to fully complete (#373). Cesium's first paint
+ * — what `waitForCesiumPainted` observes — happens very early in `bootstrap`,
+ * before the bottom-HUD, tooltip, drawers, and empty-sky popover are wired
+ * into the DOM. Tests that then poked those elements were racing the tail
+ * of bootstrap on slow Xvfb runners, producing the intermittent
+ * `bottom-hud-smoke` / `hover-pick-sweep` / `plan-modal` flake trio.
+ *
+ * `app.ts` sets `window.__PLANISPHERE_READY__ = true` (and dispatches a
+ * `planisphere:ready` CustomEvent) as the final line of `bootstrap`.
+ * `page.waitForFunction` polls the flag until it flips.
+ *
+ * Use this INSTEAD of / AFTER `waitForCesiumPainted` for anything that
+ * asserts on DOM chrome; only paint-only tests (like `cesium-initialises`)
+ * can rely on the pixel poll alone.
+ */
+export async function waitForPlanisphereReady(page: Page, timeoutMs = 15_000): Promise<void> {
+  await page.waitForFunction(
+    () => (window as unknown as { __PLANISPHERE_READY__?: boolean }).__PLANISPHERE_READY__ === true,
+    undefined,
+    { timeout: timeoutMs },
+  );
+}
+
+/**
  * Wait until Cesium has painted a non-black centre crop. Why screenshots
  * rather than `canvas.toDataURL()` / `drawImage(canvas)` / `gl.readPixels`?
  *

--- a/e2e/hover-pick-sweep.spec.ts
+++ b/e2e/hover-pick-sweep.spec.ts
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 import { expect, test } from "@playwright/test";
-import { seedDefaultStorage, waitForCesiumPainted } from "./fixtures";
+import { seedDefaultStorage, waitForCesiumPainted, waitForPlanisphereReady } from "./fixtures";
 
 /**
  * Hover-pick sweep regression test (issue #303, motivated by #302).
@@ -33,6 +33,11 @@ test("hover-pick sweep yields ≥ 25 hover popups across a 7×37 grid", async ({
   const canvas = page.locator("#cesium-container canvas");
   await expect(canvas).toBeVisible();
   await waitForCesiumPainted(page, 10_000);
+  // Tooltip element and pick handler are wired mid-bootstrap; `waitForCesiumPainted`
+  // returns as soon as the first star field paints, which can happen before those
+  // are attached on slow Xvfb runners. Wait for the bootstrap-complete flag so
+  // the sweep doesn't start with 0 hits (#373).
+  await waitForPlanisphereReady(page);
 
   // Pre-warm: nudge the mouse to register a real DOM event before sweeping.
   // Without this Cesium occasionally drops the first 1-2 picks of a run.

--- a/e2e/plan-modal.spec.ts
+++ b/e2e/plan-modal.spec.ts
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 import { expect, test } from "@playwright/test";
-import { seedDefaultStorage } from "./fixtures";
+import { seedDefaultStorage, waitForPlanisphereReady } from "./fixtures";
 
 /**
  * Deep-link plan modal test (issue #303 #3).
@@ -66,6 +66,12 @@ test("deep-link ?plan=<slug> opens the plan reader modal with the plan title", a
   // its `setPlan` is fired by `openPlanBySlug` immediately after bootstrap
   // (URL hydration → set-active-plan intent → `getPlan` → `plansModal.setPlan`).
   await expect(page.locator("#cesium-container canvas")).toBeVisible();
+  // The plans-modal element is created near the bootstrap tail (after all
+  // other drawers), and `openPlanBySlug` fires only once the full DOM is
+  // wired. Waiting on the bootstrap-complete flag before hunting for the
+  // modal card eliminates the "waited 10s for modal that hadn't been
+  // created yet" flake on slow Xvfb (#373).
+  await waitForPlanisphereReady(page);
 
   // The modal renders into a fixed `data-plans-modal-card` container. Title
   // text is set by `setPlan(plan)` in `src/ui/plans-modal.ts`.

--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -645,6 +645,30 @@ describe("bootstrap", () => {
     await expect(bootstrap(null)).resolves.toBeUndefined();
   });
 
+  it("sets window.__PLANISPHERE_READY__ and dispatches planisphere:ready when bootstrap completes (#373)", async () => {
+    const readyWindow = globalThis as { __PLANISPHERE_READY__?: boolean };
+    readyWindow.__PLANISPHERE_READY__ = false;
+    let eventFired = false;
+    const listener = (): void => {
+      eventFired = true;
+    };
+    globalThis.addEventListener("planisphere:ready", listener);
+    const root = document.createElement("main");
+    root.id = "app";
+    const cesiumDiv = document.createElement("div");
+    cesiumDiv.id = "cesium-container";
+    root.appendChild(cesiumDiv);
+    const errorDiv = document.createElement("div");
+    errorDiv.id = "error";
+    root.appendChild(errorDiv);
+    document.body.appendChild(root);
+    await bootstrap(root);
+    expect(readyWindow.__PLANISPHERE_READY__).toBe(true);
+    expect(eventFired).toBe(true);
+    globalThis.removeEventListener("planisphere:ready", listener);
+    document.body.removeChild(root);
+  });
+
   it("shows error text when state parsing fails", async () => {
     const root = document.createElement("main");
     root.id = "app";

--- a/src/app.ts
+++ b/src/app.ts
@@ -1772,6 +1772,22 @@ export async function bootstrap(
   if (state.activePlanSlug !== null) {
     void openPlanBySlug(state.activePlanSlug);
   }
+
+  // Ready signal for e2e (#373). Fires only after `bootstrap` has finished
+  // wiring the full DOM — bottom-HUD, tooltip, drawers, empty-sky popover.
+  // Cesium's first paint is much earlier (see the synchronous `doRerender`
+  // above), so tests relying on `waitForCesiumPainted` alone were racing the
+  // rest of bootstrap on slow CI runners. This is the stable signal to gate
+  // any e2e assertion that touches DOM chrome or hover-pick / tooltip state.
+  //
+  // Set as a global flag *and* dispatched as a CustomEvent so tests can wait
+  // either way (waitForFunction on the flag is the simplest; the event lets
+  // any early listener catch it too).
+  const readyWindow = globalThis as { __PLANISPHERE_READY__?: boolean };
+  readyWindow.__PLANISPHERE_READY__ = true;
+  if (typeof globalThis.dispatchEvent === "function") {
+    globalThis.dispatchEvent(new CustomEvent("planisphere:ready"));
+  }
 }
 
 function showError(el: HTMLElement | null, message: string): void {


### PR DESCRIPTION
## Summary

Three e2e specs — `bottom-hud-smoke`, `hover-pick-sweep`, `plan-modal` — have intermittently failed on Xvfb runners for months with the same fingerprint (4 pass, these 3 fail, empty-commit retry passes). Documented on #340 and earlier PR trees but never root-caused. This PR fixes the underlying race.

## Root cause

`waitForCesiumPainted` polls a viewport screenshot for non-black pixels. That proves Cesium's initial star field painted — which happens **very early** in `bootstrap` (`doRerender` at line 906 of `src/app.ts`). But the DOM chrome the failing specs then poke — bottom-HUD (~line 1586), tooltip element (~line 1026), plans-modal (~line 1635), empty-sky popover (~line 1024) — is appended **later**. On slow Xvfb runners, "canvas painted" happens before "everything is wired," and the specs sample empty DOM.

The old `hover-pick-sweep` already had a load-bearing 500 ms `waitForTimeout` after `waitForCesiumPainted` — a lucky timeout, not a signal.

## Fix

- **`src/app.ts`** — final line of `bootstrap` now sets `window.__PLANISPHERE_READY__ = true` and dispatches a `planisphere:ready` CustomEvent.
- **`e2e/fixtures.ts`** — new `waitForPlanisphereReady(page)` helper via `page.waitForFunction`.
- **`bottom-hud-smoke`, `hover-pick-sweep`, `plan-modal`** — each awaits `waitForPlanisphereReady()` before touching DOM chrome. The 500 ms sleep in `hover-pick-sweep` is kept — it's still useful for Cesium's post-bootstrap texture-upload settle, just no longer papering over the fundamental race.
- **`src/app.test.ts`** — new unit test verifies the flag is set and the event fires after bootstrap returns.

## Non-changes

- No functional change to production behaviour. Signal is additive; nothing branches on it.
- No spec-level `test.retry(...)`. That would hide, not fix.
- Not touching Xvfb / Playwright config.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm format:check` — clean
- [x] `pnpm test:cov` — 1400/1400 pass (1 new unit test for the signal)
- [x] `pnpm build` — clean
- [ ] `pnpm e2e` on CI — the trio passes on this branch's first run. **This is the real acceptance test:** if the CI e2e job goes green without needing a retry, the fix is validated.

Closes #373.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VKmj4YQnxN8sydc7X6v2ra)_