### PR TITLE
test(workers): cover astro-worker.ts by extracting dispatch into a testable helper (closes #376)

### DIFF
--- a/src/workers/astro-worker-dispatch.test.ts
+++ b/src/workers/astro-worker-dispatch.test.ts
@@ -1,0 +1,81 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { describe, expect, it } from "vitest";
+import { handleAstroWorkerMessage, type AstroWorkerRequest } from "./astro-worker-dispatch";
+
+// Anchorage at midnight UTC on 2026-04-25 — matches the fixture used in
+// e2e/hover-pick-sweep.spec.ts so any regression in the alt/az math shows
+// up in both suites.
+const ANCHORAGE_LAT = 61.2;
+const ANCHORAGE_LON = -149.9;
+const T_2026_04_25_MIDNIGHT_UTC_MS = Date.UTC(2026, 3, 25, 8, 0, 0);
+
+function makeRequest(overrides: Partial<AstroWorkerRequest> = {}): AstroWorkerRequest {
+  return {
+    type: "compute-altaz",
+    id: 1,
+    raDecs: new Float64Array([0, 0]),
+    lat: ANCHORAGE_LAT,
+    lon: ANCHORAGE_LON,
+    timeMs: T_2026_04_25_MIDNIGHT_UTC_MS,
+    ...overrides,
+  };
+}
+
+describe("handleAstroWorkerMessage", () => {
+  it("returns null for a message whose type is not compute-altaz", () => {
+    // A future protocol change can add new message kinds; the entry file
+    // relies on the null-return to drop unknown types silently.
+    const req = { ...makeRequest(), type: "some-other-op" } as unknown as AstroWorkerRequest;
+    expect(handleAstroWorkerMessage(req)).toBeNull();
+  });
+
+  it("preserves the request id in the response so async callers can correlate", () => {
+    const out = handleAstroWorkerMessage(makeRequest({ id: 42 }));
+    expect(out).not.toBeNull();
+    expect(out!.response.id).toBe(42);
+    expect(out!.response.type).toBe("compute-altaz-result");
+  });
+
+  it("returns an empty altAzs and visibleIndices when the input is empty", () => {
+    const out = handleAstroWorkerMessage(makeRequest({ raDecs: new Float64Array(0) }));
+    expect(out).not.toBeNull();
+    expect(out!.response.altAzs.length).toBe(0);
+    expect(out!.response.visibleIndices.length).toBe(0);
+    // Transferables list is still populated — the two buffers exist even
+    // when they're zero-length. This matters because a bare-return path
+    // would break the caller's postMessage([...]) shape contract.
+    expect(out!.transferables).toHaveLength(2);
+  });
+
+  it("computes alt/az for each ra/dec pair and lists only the above-horizon indices", () => {
+    // Two probe points: north celestial pole (dec ≈ +90°) and south celestial
+    // pole (dec ≈ -90°). From Anchorage (lat +61°), NCP is high above the
+    // horizon and SCP is far below it, regardless of the time / RA — this
+    // makes the assertion time-independent. RA/Dec inputs to
+    // `altAzFromRaDec` are in *degrees* (see `worker-math.ts`), and the
+    // `alt > 0` visibility check reads altitude in degrees.
+    const NCP_DEC_DEG = 89.9; // just under +90° to avoid singular altAz math
+    const SCP_DEC_DEG = -89.9;
+    const raDecs = new Float64Array([0, NCP_DEC_DEG, 0, SCP_DEC_DEG]);
+    const out = handleAstroWorkerMessage(makeRequest({ raDecs }));
+    expect(out).not.toBeNull();
+    const { altAzs, visibleIndices } = out!.response;
+    // Two ra/dec pairs → four alt/az entries.
+    expect(altAzs.length).toBe(4);
+    // Index 0 (NCP) should be visible; index 1 (SCP) should not be.
+    expect(Array.from(visibleIndices)).toEqual([0]);
+    // Sanity-check the NCP altitude — it should sit within a few degrees
+    // of the observer's latitude (61.2°). Loose bound so drift in the
+    // upstream math library doesn't spuriously fail.
+    const ncpAltDeg = altAzs[0]!;
+    expect(ncpAltDeg).toBeGreaterThan(55);
+    expect(ncpAltDeg).toBeLessThan(90);
+  });
+
+  it("returns the altAzs and visibleIndices buffers in the transferables list", () => {
+    const out = handleAstroWorkerMessage(makeRequest());
+    expect(out).not.toBeNull();
+    expect(out!.transferables).toContain(out!.response.altAzs.buffer);
+    expect(out!.transferables).toContain(out!.response.visibleIndices.buffer);
+  });
+});

--- a/src/workers/astro-worker-dispatch.ts
+++ b/src/workers/astro-worker-dispatch.ts
@@ -1,0 +1,88 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/**
+ * Pure dispatch function for the astro Web Worker (issue #376).
+ *
+ * The Worker entry (`astro-worker.ts`) can't be exercised under jsdom — a
+ * Web Worker runs in its own realm and jsdom doesn't spin one up — so the
+ * message-handler body used to sit as an anonymous callback and go untested,
+ * dragging `astro-worker.ts` coverage to 0%.
+ *
+ * Extracting the handler into this pure function lets vitest hit every
+ * branch: unknown message type, empty inputs, mixed above/below-horizon
+ * results, and the postMessage transferables list the caller must forward
+ * to keep the zero-copy contract.
+ *
+ * `astro-worker.ts` is now a ~5-line file that wires `self.onmessage` to
+ * this function and forwards the result to `self.postMessage`.
+ */
+
+import { lstFromMs, altAzFromRaDec } from "./worker-math";
+
+export type AstroWorkerRequest = {
+  type: "compute-altaz";
+  /** Sequence id to correlate response with request */
+  id: number;
+  /** Flat Float64Array of [ra0, dec0, ra1, dec1, ...] */
+  raDecs: Float64Array;
+  lat: number;
+  lon: number;
+  timeMs: number;
+};
+
+export type AstroWorkerResponse = {
+  type: "compute-altaz-result";
+  id: number;
+  /** Flat Float64Array of [alt0, az0, alt1, az1, ...] — same length as raDecs */
+  altAzs: Float64Array;
+  /** Indices of entries where alt > 0 */
+  visibleIndices: Uint16Array;
+};
+
+/**
+ * Dispatch outcome. When the message type isn't recognised we return
+ * `null` — the worker entry drops it silently, matching the pre-refactor
+ * `if (type !== "compute-altaz") return;` early-out.
+ */
+export type AstroWorkerDispatch = {
+  response: AstroWorkerResponse;
+  /**
+   * Transferable buffers the caller must pass as the second argument to
+   * `self.postMessage`. Keeps the zero-copy contract in one place so the
+   * entry file doesn't have to know which fields are transferable.
+   */
+  transferables: Transferable[];
+};
+
+export function handleAstroWorkerMessage(req: AstroWorkerRequest): AstroWorkerDispatch | null {
+  if (req.type !== "compute-altaz") return null;
+
+  const { id, raDecs, lat, lon, timeMs } = req;
+  const count = raDecs.length / 2;
+  const altAzs = new Float64Array(count * 2);
+  const visible: number[] = [];
+
+  const latRad = (lat * Math.PI) / 180;
+  const localST = lstFromMs(timeMs, lon);
+
+  for (let i = 0; i < count; i++) {
+    const ra = raDecs[i * 2]!;
+    const dec = raDecs[i * 2 + 1]!;
+    const { alt, az } = altAzFromRaDec(ra, dec, latRad, localST);
+    altAzs[i * 2] = alt;
+    altAzs[i * 2 + 1] = az;
+    if (alt > 0) visible.push(i);
+  }
+
+  const visibleIndices = new Uint16Array(visible);
+
+  return {
+    response: {
+      type: "compute-altaz-result",
+      id,
+      altAzs,
+      visibleIndices,
+    },
+    transferables: [altAzs.buffer, visibleIndices.buffer],
+  };
+}

--- a/src/workers/astro-worker.ts
+++ b/src/workers/astro-worker.ts
@@ -1,70 +1,27 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 /**
- * Astro computation Web Worker.
+ * Astro computation Web Worker (entry).
  *
- * Uses the simplified typed-array approach for zero-copy message passing:
- * - Receives flat Float64Array of [ra, dec, ra, dec, ...] pairs plus observer params
- * - Returns flat Float64Array of [alt, az, alt, az, ...] pairs and visible index array
- *
- * No astronomy-engine import: pure GMST math is faster and sufficient for visual rendering.
+ * All logic lives in the pure `handleAstroWorkerMessage` in
+ * `astro-worker-dispatch.ts` so it can be tested under jsdom (issue #376).
+ * This entry is just the Worker-global glue: dispatch the message, forward
+ * the response with the transferables list to keep the zero-copy contract.
  */
 
-import { lstFromMs, altAzFromRaDec } from "./worker-math";
+import { handleAstroWorkerMessage, type AstroWorkerRequest } from "./astro-worker-dispatch";
 
-// ---- Message protocol ----
+// Re-export the message-protocol types so existing importers of this file
+// keep compiling — the Worker entry has historically been the type source
+// of truth for the client wrapper (`astro-worker-client.ts`).
+export type { AstroWorkerRequest, AstroWorkerResponse } from "./astro-worker-dispatch";
 
-export type AstroWorkerRequest = {
-  type: "compute-altaz";
-  /** Sequence id to correlate response with request */
-  id: number;
-  /** Flat Float64Array of [ra0, dec0, ra1, dec1, ...] */
-  raDecs: Float64Array;
-  lat: number;
-  lon: number;
-  timeMs: number;
-};
-
-export type AstroWorkerResponse = {
-  type: "compute-altaz-result";
-  id: number;
-  /** Flat Float64Array of [alt0, az0, alt1, az1, ...] — same length as raDecs */
-  altAzs: Float64Array;
-  /** Indices of entries where alt > 0 */
-  visibleIndices: Uint16Array;
-};
-
-// ---- Worker message handler ----
-
+/* c8 ignore start — Worker-global bridge, not reachable under jsdom. All
+ * behavior is exercised via handleAstroWorkerMessage in
+ * astro-worker-dispatch.test.ts. */
 self.onmessage = (event: MessageEvent<AstroWorkerRequest>) => {
-  const { type, id, raDecs, lat, lon, timeMs } = event.data;
-  if (type !== "compute-altaz") return;
-
-  const count = raDecs.length / 2;
-  const altAzs = new Float64Array(count * 2);
-  const visible: number[] = [];
-
-  const latRad = (lat * Math.PI) / 180;
-  const localST = lstFromMs(timeMs, lon);
-
-  for (let i = 0; i < count; i++) {
-    const ra = raDecs[i * 2]!;
-    const dec = raDecs[i * 2 + 1]!;
-    const { alt, az } = altAzFromRaDec(ra, dec, latRad, localST);
-    altAzs[i * 2] = alt;
-    altAzs[i * 2 + 1] = az;
-    if (alt > 0) visible.push(i);
-  }
-
-  const visibleIndices = new Uint16Array(visible);
-
-  const response: AstroWorkerResponse = {
-    type: "compute-altaz-result",
-    id,
-    altAzs,
-    visibleIndices,
-  };
-
-  // Transfer ownership of typed arrays for zero-copy messaging
-  self.postMessage(response, [altAzs.buffer, visibleIndices.buffer]);
+  const out = handleAstroWorkerMessage(event.data);
+  if (out === null) return;
+  self.postMessage(out.response, out.transferables);
 };
+/* c8 ignore stop */


### PR DESCRIPTION
## Summary

Mikado refactor for #376. `src/workers/astro-worker.ts` sat at 0% line coverage because its message-handler body was an anonymous callback attached to `self.onmessage` — jsdom can't spin up a Web Worker, so vitest never reached the code.

## What this PR does

- **New `src/workers/astro-worker-dispatch.ts`** — pure function `handleAstroWorkerMessage(req): { response, transferables } | null`. Captures every branch of the old handler: unknown message-type early-out, the alt/az compute loop, the visible-index accumulation, the zero-copy transferables list.
- **New `src/workers/astro-worker-dispatch.test.ts`** — 5 unit tests: type-guard early-out, id correlation, empty input, mixed above/below-horizon indices, transferables identity.
- **`astro-worker.ts`** shrinks to ~5 lines of Worker-global glue, wrapped in `/* c8 ignore start/stop */`. The bridge is genuinely unreachable under jsdom; the behaviour it wraps is fully exercised by the dispatch tests.

`astro-worker-client.ts` continues to import `AstroWorkerRequest` / `AstroWorkerResponse` from `./astro-worker` — the entry re-exports both types so no client-side change was needed.

## Results

| | before | after |
|---|---|---|
| `src/workers/` line coverage | ~82% | **97.56%** |
| Tests | 1398 | 1403 |

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm format:check` — clean
- [x] `pnpm test:cov` — 1403/1403 pass, thresholds hold, workers dir up from ~82% to 97.56%
- [x] `pnpm build` — clean

Closes #376.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VKmj4YQnxN8sydc7X6v2ra)_