### PR TITLE
perf(cache): immutable Cache-Control for Cesium + Vite chunks (closes #378)

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: Apache-2.0
+# Cloudflare Workers Static Assets honors a `_headers` file at the root of
+# the assets directory (`dist/` after vite copies `public/` → `dist/`).
+#
+# All paths listed here are either:
+#  (a) content-hashed by the tool that built them (Vite for /assets/*,
+#      Cesium's own build for /cesium/**), OR
+#  (b) versioned via the immediate parent directory (Cesium's Assets /
+#      ThirdParty / Widgets / Workers).
+#
+# Both are safe for `immutable, max-age=31536000` — a new build changes the
+# hashed filename or the directory, so cached files never become wrong.
+# HTML and the manifest keep default caching so redeploys propagate to
+# visitors on their next navigation.
+
+/assets/*
+  Cache-Control: public, max-age=31536000, immutable
+
+/cesium/Cesium.js
+  Cache-Control: public, max-age=31536000, immutable
+
+/cesium/Assets/*
+  Cache-Control: public, max-age=31536000, immutable
+
+/cesium/ThirdParty/*
+  Cache-Control: public, max-age=31536000, immutable
+
+/cesium/Widgets/*
+  Cache-Control: public, max-age=31536000, immutable
+
+/cesium/Workers/*
+  Cache-Control: public, max-age=31536000, immutable

--- a/scripts/check-headers.test.mjs
+++ b/scripts/check-headers.test.mjs
@@ -1,0 +1,55 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { readFileSync } from "node:fs";
+import { describe, it, expect } from "vitest";
+
+/**
+ * Guard the Cloudflare Workers `_headers` rules that give Cesium + Vite
+ * chunks their long-lived immutable cache (#378). Every rule listed here
+ * must survive future edits to `public/_headers`; a regression drops
+ * return-visit cost by dozens of megabytes.
+ */
+
+const HEADERS = readFileSync("public/_headers", "utf8");
+
+const REQUIRED_RULES = [
+  "/assets/*",
+  "/cesium/Cesium.js",
+  "/cesium/Assets/*",
+  "/cesium/ThirdParty/*",
+  "/cesium/Widgets/*",
+  "/cesium/Workers/*",
+];
+
+describe("public/_headers", () => {
+  it("has the SPDX marker", () => {
+    expect(HEADERS).toContain("SPDX-License-Identifier: Apache-2.0");
+  });
+
+  for (const rule of REQUIRED_RULES) {
+    it(`caches ${rule} as public, max-age=31536000, immutable`, () => {
+      // Find the block for this rule (the line matching `rule` verbatim
+      // at the start of a line) and confirm the very next Cache-Control
+      // header is the immutable one-year rule.
+      const lines = HEADERS.split("\n");
+      const ruleIdx = lines.findIndex((l) => l.trim() === rule);
+      expect(ruleIdx, `no block for ${rule}`).toBeGreaterThan(-1);
+      const cacheHeader = lines
+        .slice(ruleIdx + 1)
+        .find((l) => l.trim().startsWith("Cache-Control:"));
+      expect(cacheHeader).toBeDefined();
+      expect(cacheHeader.trim()).toBe("Cache-Control: public, max-age=31536000, immutable");
+    });
+  }
+
+  it("does NOT set immutable caching on /index.html (redeploys must reach users)", () => {
+    const lines = HEADERS.split("\n");
+    const idx = lines.findIndex((l) => l.trim() === "/index.html");
+    // Either the block doesn't exist at all, or if it does, it must not
+    // set the year-long immutable cache — HTML has to be able to change
+    // between deploys.
+    if (idx === -1) return;
+    const cacheHeader = lines.slice(idx + 1).find((l) => l.trim().startsWith("Cache-Control:"));
+    if (cacheHeader === undefined) return;
+    expect(cacheHeader).not.toContain("immutable");
+  });
+});


### PR DESCRIPTION
## Summary

Every visit to Planisphere was refetching multi-MB of content-hashed Cesium assets and Vite chunks even when nothing had changed — Cloudflare Workers Static Assets serves them with a default posture that browsers don't treat as long-lived.

## What this PR adds

- **`public/_headers`** — Workers Static Assets honors a `_headers` file at the root of the assets directory (which is `dist/` after vite copies `public/` → `dist/`). Rules for `/assets/*` (vite-hashed), `/cesium/Cesium.js` (Cesium-hashed), and the four content-versioned Cesium dirs (`Assets`, `ThirdParty`, `Widgets`, `Workers`). All six get `Cache-Control: public, max-age=31536000, immutable`. HTML keeps default caching so redeploys reach visitors.

- **`scripts/check-headers.test.mjs`** — 8 unit tests: SPDX marker, one per required rule verifying `Cache-Control: public, max-age=31536000, immutable`, and a guard that `/index.html` (if ever added) doesn't get immutable caching. Runs in the normal `pnpm test:cov` sweep — a future edit that drops any rule fails CI.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm format:check` — clean
- [x] `pnpm test:cov` — 1411 pass (+8 from the header tests)
- [x] `pnpm build` — clean; verified `dist/_headers` copied by vite
- [ ] Post-deploy: `curl -I` against the branch-preview URL should show `cache-control: public, max-age=31536000, immutable` on the assets

Closes #378.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VKmj4YQnxN8sydc7X6v2ra)_