### PR TITLE
perf(sw): properly bypass /api/* + tighten routing + unit-test the classifier (closes #379)

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,10 +1,24 @@
 /* SPDX-License-Identifier: Apache-2.0 */
-/* Service worker for Planisphere — cache-first with network-first for TLE data */
+/* Service worker for Planisphere (#379).
+ *
+ * Routing (see `classifyRequest`):
+ *
+ *   - Non-GET                  → passthrough (no respondWith)
+ *   - /api/*                   → passthrough — API responses may carry
+ *                                per-user auth state; never cache them
+ *   - TLE origin (celestrak)   → network-first with cache fallback
+ *   - /cesium/*  /assets/*     → cache-first (content-hashed, safe forever)
+ *   - Everything else          → network-first with cache fallback
+ *                                so a redeploy reaches users on their
+ *                                next navigation
+ *
+ * Behavior is exercised by a Node vm-based test (scripts/sw-routing.test.mjs)
+ * that loads this file's `classifyRequest` and asserts each branch.
+ */
 
-const CACHE_VERSION = "planisphere-v1";
+const CACHE_VERSION = "planisphere-v2";
 const TLE_ORIGIN = "https://celestrak.org";
 
-// App shell resources to pre-cache on install
 const APP_SHELL = ["/", "/index.html", "/favicon.svg", "/manifest.json"];
 
 self.addEventListener("install", (event) => {
@@ -21,40 +35,49 @@ self.addEventListener("activate", (event) => {
     caches
       .keys()
       .then((keys) =>
-        Promise.all(
-          keys
-            .filter((key) => key !== CACHE_VERSION)
-            .map((key) => caches.delete(key)),
-        ),
+        Promise.all(keys.filter((key) => key !== CACHE_VERSION).map((key) => caches.delete(key))),
       )
       .then(() => self.clients.claim()),
   );
 });
 
+/**
+ * Pure routing classifier — exported via `self.__testExports` in test
+ * builds. Returns one of:
+ *   - "passthrough"
+ *   - "cache-first"
+ *   - "network-first"
+ */
+function classifyRequest(url, method) {
+  if (method !== "GET") return "passthrough";
+  // API responses may carry per-user auth state (notebooks, plans list,
+  // /me). Never cache them — sharing them across sessions would be a
+  // real correctness / privacy bug.
+  if (url.pathname.startsWith("/api/")) return "passthrough";
+  // Short-URL redirects have no useful cache; the redirect is fast and
+  // the target is often the current origin. Skip caching.
+  if (url.pathname.startsWith("/s/")) return "passthrough";
+  if (url.origin === TLE_ORIGIN) return "network-first";
+  if (url.pathname.startsWith("/assets/")) return "cache-first";
+  if (url.pathname.startsWith("/cesium/")) return "cache-first";
+  return "network-first";
+}
+
 self.addEventListener("fetch", (event) => {
   const { request } = event;
   const url = new URL(request.url);
-
-  // Network-first for TLE requests (external data that changes frequently)
-  if (url.origin === TLE_ORIGIN) {
-    event.respondWith(networkFirstWithCacheFallback(request));
+  const strategy = classifyRequest(url, request.method);
+  if (strategy === "passthrough") return;
+  if (strategy === "cache-first") {
+    event.respondWith(cacheFirstWithNetworkFallback(request));
     return;
   }
-
-  // Skip non-GET requests
-  if (request.method !== "GET") {
-    return;
-  }
-
-  // Cache-first for everything else (app shell, Cesium assets, static files)
-  event.respondWith(cacheFirstWithNetworkFallback(request));
+  event.respondWith(networkFirstWithCacheFallback(request));
 });
 
 async function cacheFirstWithNetworkFallback(request) {
   const cached = await caches.match(request);
-  if (cached) {
-    return cached;
-  }
+  if (cached) return cached;
   try {
     const response = await fetch(request);
     if (response.ok) {
@@ -77,9 +100,11 @@ async function networkFirstWithCacheFallback(request) {
     return response;
   } catch {
     const cached = await caches.match(request);
-    if (cached) {
-      return cached;
-    }
-    return new Response("Offline — TLE data unavailable", { status: 503 });
+    if (cached) return cached;
+    return new Response("Offline", { status: 503 });
   }
 }
+
+// Exported for the Node vm-based unit test. Guarded behind a `self`
+// property that's never referenced by production callers.
+self.__swExports = { classifyRequest };

--- a/scripts/sw-routing.test.mjs
+++ b/scripts/sw-routing.test.mjs
@@ -1,0 +1,100 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { readFileSync } from "node:fs";
+import vm from "node:vm";
+import { describe, it, expect } from "vitest";
+
+/**
+ * Load `public/sw.js` into a sandboxed vm with a stub `self`, then pull
+ * `self.__swExports.classifyRequest` out to exercise every branch (#379).
+ *
+ * The classifier is the correctness surface — a regression that starts
+ * caching `/api/*` responses is a real auth-leak risk.
+ */
+
+const SW_SOURCE = readFileSync("public/sw.js", "utf8");
+
+function loadClassifier() {
+  const stubSelf = {
+    addEventListener: () => {},
+    skipWaiting: () => {},
+    clients: { claim: () => {} },
+  };
+  const context = {
+    self: stubSelf,
+    caches: {
+      open: () => Promise.resolve({ addAll: () => Promise.resolve(), put: () => {} }),
+      keys: () => Promise.resolve([]),
+      delete: () => Promise.resolve(),
+      match: () => Promise.resolve(undefined),
+    },
+    fetch: () => Promise.reject(new Error("no net in test")),
+    URL,
+    Response,
+    console,
+  };
+  vm.createContext(context);
+  vm.runInContext(SW_SOURCE, context);
+  return stubSelf.__swExports.classifyRequest;
+}
+
+const classifyRequest = loadClassifier();
+
+const TLE_ORIGIN = "https://celestrak.org";
+
+describe("sw.js — classifyRequest", () => {
+  it("passthrough for non-GET methods", () => {
+    expect(classifyRequest(new URL("http://localhost/"), "POST")).toBe("passthrough");
+    expect(classifyRequest(new URL("http://localhost/assets/x.js"), "PUT")).toBe("passthrough");
+    expect(classifyRequest(new URL("http://localhost/assets/x.js"), "DELETE")).toBe("passthrough");
+  });
+
+  it("passthrough for /api/* — API responses can carry per-user auth state", () => {
+    expect(classifyRequest(new URL("http://localhost/api/notebooks"), "GET")).toBe("passthrough");
+    expect(classifyRequest(new URL("http://localhost/api/notebooks/42"), "GET")).toBe(
+      "passthrough",
+    );
+    expect(classifyRequest(new URL("http://localhost/api/auth/me"), "GET")).toBe("passthrough");
+    expect(classifyRequest(new URL("http://localhost/api/plans/2026-04"), "GET")).toBe(
+      "passthrough",
+    );
+    expect(classifyRequest(new URL("http://localhost/api/share"), "GET")).toBe("passthrough");
+  });
+
+  it("passthrough for /s/<code> shortlinks — the target may change and the redirect is fast", () => {
+    expect(classifyRequest(new URL("http://localhost/s/abc123"), "GET")).toBe("passthrough");
+  });
+
+  it("network-first for TLE origin — data changes, offline fallback is fine", () => {
+    expect(classifyRequest(new URL(`${TLE_ORIGIN}/NORAD/elements/visual.txt`), "GET")).toBe(
+      "network-first",
+    );
+  });
+
+  it("cache-first for content-hashed /assets/*", () => {
+    expect(classifyRequest(new URL("http://localhost/assets/index-abc.js"), "GET")).toBe(
+      "cache-first",
+    );
+    expect(classifyRequest(new URL("http://localhost/assets/notebook-xyz.js"), "GET")).toBe(
+      "cache-first",
+    );
+  });
+
+  it("cache-first for /cesium/* — Cesium's own build hashes each file", () => {
+    expect(classifyRequest(new URL("http://localhost/cesium/Cesium.js"), "GET")).toBe(
+      "cache-first",
+    );
+    expect(classifyRequest(new URL("http://localhost/cesium/Workers/main.js"), "GET")).toBe(
+      "cache-first",
+    );
+    expect(classifyRequest(new URL("http://localhost/cesium/Assets/starMap.jpg"), "GET")).toBe(
+      "cache-first",
+    );
+  });
+
+  it("network-first for /index.html and root — redeploys must reach visitors", () => {
+    expect(classifyRequest(new URL("http://localhost/"), "GET")).toBe("network-first");
+    expect(classifyRequest(new URL("http://localhost/index.html"), "GET")).toBe("network-first");
+    expect(classifyRequest(new URL("http://localhost/favicon.svg"), "GET")).toBe("network-first");
+    expect(classifyRequest(new URL("http://localhost/manifest.json"), "GET")).toBe("network-first");
+  });
+});


### PR DESCRIPTION
## Summary

The service worker on main was cache-first for everything except TLE. That's a real auth-leak: a user's `/api/notebooks` response gets cached in the shared app cache and served to any subsequent session — the same origin is enough because the SW cache doesn't respect cookies. `/api/auth/me`, `/api/plans/*`, `/api/notebooks/:id` all had the same problem.

## What this PR changes

**`public/sw.js`**:
- Extracts a pure `classifyRequest(url, method)` returning `"passthrough" | "cache-first" | "network-first"`.
- **Passthrough** for `/api/*` (never cache — auth state) and `/s/*` (shortlink redirects — target may change).
- **Network-first** for TLE origin (unchanged), and for `/`, `/index.html`, `/favicon.svg`, `/manifest.json` — so redeploys reach visitors.
- **Cache-first** for `/assets/*` and `/cesium/*` — both content-hashed.
- `CACHE_VERSION` bumped `v1 → v2` so `activate` drops the stale cache on first post-upgrade load.
- Exports the classifier via `self.__swExports` for the unit test.

**`scripts/sw-routing.test.mjs`** — 7 tests using `node:vm` to load `sw.js` in a stub `self`/`caches`/`fetch` context and exercise every classifier branch. Runs in `pnpm test:cov` — a regression that starts caching `/api/*` fails CI.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm format:check` — clean
- [x] `pnpm test:cov` — 1411 pass (+7 from the SW classifier tests)
- [x] `pnpm build` — clean

## Notes

Kept the current app-shell precache list (`/`, `/index.html`, `/favicon.svg`, `/manifest.json`) rather than growing it to include the hashed vite chunks. Enumerating hashed filenames at build time would need a new build step; the network-first fallback + cache-first for `/assets/*` gives near-identical return-visit behavior with much less complexity.

Closes #379.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VKmj4YQnxN8sydc7X6v2ra)_