### PR TITLE
feat(a11y): describe-this-sky modal (Alt+D) for screen-reader users (closes #381)

### DIFF
--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -417,6 +417,16 @@ vi.mock("./ui", () => ({
       isOpen: vi.fn().mockReturnValue(false),
     };
   }),
+  createDescribeSkyModal: vi.fn().mockImplementation(() => {
+    const element = document.createElement("div");
+    element.dataset.testid = "describe-sky-modal";
+    return {
+      element,
+      open: vi.fn(),
+      close: vi.fn(),
+      isOpen: vi.fn().mockReturnValue(false),
+    };
+  }),
   createSettingsDrawer: vi.fn().mockImplementation(() => {
     const element = document.createElement("div");
     element.dataset.testid = "settings-drawer-root";

--- a/src/app.ts
+++ b/src/app.ts
@@ -79,6 +79,7 @@ import {
   createFovControls,
   createEventsDrawer,
   createHelpModal,
+  createDescribeSkyModal,
   createBottomHud,
   createCommandPalette,
   createSettingsDrawer,
@@ -119,6 +120,7 @@ import type {
   PaletteObjectType,
 } from "./ui";
 import { computeUpcomingEvents } from "./astro/events";
+import { describeSky } from "./astro/describe-sky";
 import type { CelestialEvent } from "./astro/events";
 import type { UIIntent } from "./ui";
 import { buildSearchIndex, searchObjects } from "./astro/search";
@@ -1583,6 +1585,39 @@ export async function bootstrap(
     },
   });
   document.body.appendChild(helpModal.element);
+
+  // Describe-sky modal (#381) — Alt+D turns the WebGL canvas into English
+  // prose for screen-reader users. Uses body positions + camera heading.
+  // Constellations are omitted from the summary in this first pass; that
+  // list lives inside the render pipeline and hoisting it here would
+  // require plumbing that isn't warranted for a still-useful summary.
+  function currentSkySummary(): string {
+    const observer = { lat: state.observer.lat, lon: state.observer.lon };
+    const bodies = computeBodyPositions(observer.lat, observer.lon, state.timeUtc, false).map(
+      (b) => ({ id: b.id, alt: b.alt, az: b.az, mag: b.mag }),
+    );
+    const heading = getCameraHeadingDeg(viewer.camera);
+    const base = {
+      observer,
+      timeUtc: state.timeUtc,
+      bodies,
+      constellations: [] as [],
+    };
+    return Number.isFinite(heading)
+      ? describeSky({ ...base, cameraHeadingDeg: heading })
+      : describeSky(base);
+  }
+  const describeSkyModal = createDescribeSkyModal({
+    getSummary: currentSkySummary,
+  });
+  document.body.appendChild(describeSkyModal.element);
+  // Alt+D — describe the sky.
+  document.addEventListener("keydown", (e) => {
+    if (e.key === "d" && e.altKey && !e.metaKey && !e.ctrlKey) {
+      e.preventDefault();
+      describeSkyModal.open(currentSkySummary());
+    }
+  });
 
   // Events drawer — slide-in surface holding the upcoming-events list (replaces
   // the always-on side-panel section). Created here (after handleIntent is in

--- a/src/astro/describe-sky.test.ts
+++ b/src/astro/describe-sky.test.ts
@@ -1,0 +1,180 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { describe, expect, it } from "vitest";
+import {
+  azimuthToCompass,
+  describeSky,
+  type DescribableBody,
+  type DescribableConstellation,
+} from "./describe-sky";
+
+function body(id: string, alt: number, az: number, mag: number): DescribableBody {
+  return { id, alt, az, mag };
+}
+
+function constellation(
+  id: string,
+  name: string,
+  alt: number,
+  az: number,
+): DescribableConstellation {
+  return { id, name, centroid: { alt, az } };
+}
+
+const ANCHORAGE = { lat: 61.2, lon: -149.9 };
+const MIDNIGHT_UTC = new Date("2026-04-25T08:00:00Z");
+
+describe("azimuthToCompass", () => {
+  it("maps the four cardinals", () => {
+    expect(azimuthToCompass(0)).toBe("north");
+    expect(azimuthToCompass(90)).toBe("east");
+    expect(azimuthToCompass(180)).toBe("south");
+    expect(azimuthToCompass(270)).toBe("west");
+  });
+
+  it("normalizes out-of-range and negative azimuths", () => {
+    expect(azimuthToCompass(360)).toBe("north");
+    expect(azimuthToCompass(720)).toBe("north");
+    expect(azimuthToCompass(-90)).toBe("west");
+  });
+
+  it("uses 16-point resolution", () => {
+    expect(azimuthToCompass(45)).toBe("northeast");
+    expect(azimuthToCompass(112.5)).toBe("east-southeast");
+    expect(azimuthToCompass(292.5)).toBe("west-northwest");
+  });
+});
+
+describe("describeSky", () => {
+  it("names the observer's location and heading in the first sentence", () => {
+    const out = describeSky({
+      observer: ANCHORAGE,
+      timeUtc: MIDNIGHT_UTC,
+      bodies: [],
+      constellations: [],
+      cameraHeadingDeg: 112,
+    });
+    expect(out).toMatch(/^Facing east-southeast/);
+    expect(out).toMatch(/61\.2° N, 149\.9° W/);
+  });
+
+  it("omits the heading clause when no camera heading is provided", () => {
+    const out = describeSky({
+      observer: ANCHORAGE,
+      timeUtc: MIDNIGHT_UTC,
+      bodies: [],
+      constellations: [],
+    });
+    expect(out).toMatch(/^Viewing the sky/);
+  });
+
+  it("reports fully-dark astronomical twilight based on the Sun's altitude", () => {
+    const out = describeSky({
+      observer: ANCHORAGE,
+      timeUtc: MIDNIGHT_UTC,
+      bodies: [body("Sun", -35, 0, -26.7)],
+      constellations: [],
+    });
+    expect(out).toMatch(/fully dark/);
+  });
+
+  it("labels civil / nautical / astronomical twilight bands", () => {
+    const civil = describeSky({
+      observer: ANCHORAGE,
+      timeUtc: MIDNIGHT_UTC,
+      bodies: [body("Sun", -3, 0, -26.7)],
+      constellations: [],
+    });
+    expect(civil).toMatch(/civil twilight/);
+
+    const nautical = describeSky({
+      observer: ANCHORAGE,
+      timeUtc: MIDNIGHT_UTC,
+      bodies: [body("Sun", -10, 0, -26.7)],
+      constellations: [],
+    });
+    expect(nautical).toMatch(/nautical twilight/);
+
+    const astronomical = describeSky({
+      observer: ANCHORAGE,
+      timeUtc: MIDNIGHT_UTC,
+      bodies: [body("Sun", -15, 0, -26.7)],
+      constellations: [],
+    });
+    expect(astronomical).toMatch(/astronomical twilight/);
+  });
+
+  it("lists up to three named naked-eye planets above the horizon, brightest first", () => {
+    const out = describeSky({
+      observer: ANCHORAGE,
+      timeUtc: MIDNIGHT_UTC,
+      bodies: [
+        body("Sun", -20, 90, -26.7),
+        body("Jupiter", 45, 180, -2),
+        body("Mars", 15, 90, 1),
+        body("Saturn", 30, 270, 0.5),
+        body("Venus", 5, 270, -4),
+        body("Mercury", 3, 90, 0),
+      ],
+      constellations: [],
+    });
+    // Magnitude sort (ascending = brightest first) puts Venus (−4),
+    // Jupiter (−2), Mercury (0) in the top three. Saturn (0.5) and
+    // Mars (1) drop out.
+    expect(out).toMatch(/Venus.*Jupiter.*Mercury/);
+    expect(out).not.toContain("Mars is");
+    expect(out).not.toContain("Saturn is");
+  });
+
+  it("skips below-horizon bodies and doesn't invent bright ones", () => {
+    // With one below-horizon body and no visible constellations we fall
+    // through to the single "nothing bright" fallback rather than
+    // stringing two negatives together.
+    const out = describeSky({
+      observer: ANCHORAGE,
+      timeUtc: MIDNIGHT_UTC,
+      bodies: [body("Mars", -20, 90, 1)],
+      constellations: [],
+    });
+    expect(out).toContain("Nothing bright is above the horizon");
+    expect(out).not.toContain("Mars");
+  });
+
+  it("says 'None of the naked-eye planets' when constellations ARE visible but no bright body is", () => {
+    const out = describeSky({
+      observer: ANCHORAGE,
+      timeUtc: MIDNIGHT_UTC,
+      bodies: [],
+      constellations: [constellation("UMa", "Ursa Major", 70, 0)],
+    });
+    expect(out).toContain("None of the naked-eye planets are above the horizon");
+    expect(out).toContain("Ursa Major");
+  });
+
+  it("lists the highest three constellations by name", () => {
+    const out = describeSky({
+      observer: ANCHORAGE,
+      timeUtc: MIDNIGHT_UTC,
+      bodies: [],
+      constellations: [
+        constellation("UMa", "Ursa Major", 70, 0),
+        constellation("Ori", "Orion", 40, 180),
+        constellation("Sco", "Scorpius", 25, 200),
+        constellation("Cyg", "Cygnus", 22, 90),
+        constellation("Lyr", "Lyra", 10, 60), // below altitude threshold, excluded
+      ],
+    });
+    expect(out).toContain("Well-placed constellations: Ursa Major, Orion, Scorpius");
+    expect(out).not.toContain("Lyra");
+    expect(out).not.toContain("Cygnus");
+  });
+
+  it("degrades gracefully to a 'nothing bright' sentence when everything is below the horizon", () => {
+    const out = describeSky({
+      observer: ANCHORAGE,
+      timeUtc: MIDNIGHT_UTC,
+      bodies: [],
+      constellations: [],
+    });
+    expect(out).toContain("Nothing bright is above the horizon right now.");
+  });
+});

--- a/src/astro/describe-sky.ts
+++ b/src/astro/describe-sky.ts
@@ -1,0 +1,177 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/**
+ * "Describe this sky" — prose summary for screen-reader users (#381).
+ *
+ * A WebGL canvas is opaque to assistive tech. This module turns the
+ * scene's current visible-object list into a short block of natural-
+ * language sentences: where you're facing, which bright bodies are up,
+ * which constellations sit well, and the twilight state.
+ *
+ * Pure. No DOM, no Cesium, no fetch — data in, string out.
+ */
+
+export type DescribableBody = {
+  readonly id: string;
+  /** Altitude in degrees; positive = above the horizon. */
+  readonly alt: number;
+  /** Azimuth in degrees, 0 = North, 90 = East. */
+  readonly az: number;
+  /** Apparent magnitude. Lower = brighter. */
+  readonly mag: number;
+};
+
+export type DescribableConstellation = {
+  readonly id: string;
+  readonly name: string;
+  readonly centroid: { readonly alt: number; readonly az: number };
+};
+
+export type DescribeSkyInput = {
+  readonly observer: { readonly lat: number; readonly lon: number };
+  readonly timeUtc: Date;
+  readonly bodies: readonly DescribableBody[];
+  readonly constellations: readonly DescribableConstellation[];
+  /** Camera heading in degrees from North (0..360). Undefined if unknown. */
+  readonly cameraHeadingDeg?: number;
+};
+
+/** Named body list for the "bright things up" sentence — Sun / Moon / naked-eye planets. */
+const NAMED_BRIGHT_BODIES = new Set([
+  "Sun",
+  "Moon",
+  "Mercury",
+  "Venus",
+  "Mars",
+  "Jupiter",
+  "Saturn",
+]);
+
+const CARDINAL_LOOKUP: readonly { readonly maxAz: number; readonly name: string }[] = [
+  { maxAz: 11.25, name: "north" },
+  { maxAz: 33.75, name: "north-northeast" },
+  { maxAz: 56.25, name: "northeast" },
+  { maxAz: 78.75, name: "east-northeast" },
+  { maxAz: 101.25, name: "east" },
+  { maxAz: 123.75, name: "east-southeast" },
+  { maxAz: 146.25, name: "southeast" },
+  { maxAz: 168.75, name: "south-southeast" },
+  { maxAz: 191.25, name: "south" },
+  { maxAz: 213.75, name: "south-southwest" },
+  { maxAz: 236.25, name: "southwest" },
+  { maxAz: 258.75, name: "west-southwest" },
+  { maxAz: 281.25, name: "west" },
+  { maxAz: 303.75, name: "west-northwest" },
+  { maxAz: 326.25, name: "northwest" },
+  { maxAz: 348.75, name: "north-northwest" },
+];
+
+/** Convert azimuth degrees (0..360) to a compass label. */
+export function azimuthToCompass(azDeg: number): string {
+  const norm = ((azDeg % 360) + 360) % 360;
+  for (const entry of CARDINAL_LOOKUP) {
+    if (norm < entry.maxAz) return entry.name;
+  }
+  return "north";
+}
+
+function altToBand(altDeg: number): string {
+  if (altDeg < 10) return "low";
+  if (altDeg < 30) return "medium-low";
+  if (altDeg < 60) return "medium-high";
+  return "high";
+}
+
+function altToPhrase(altDeg: number): string {
+  const rounded = Math.round(altDeg);
+  return `${String(rounded)}° up`;
+}
+
+function formatBodyClause(body: DescribableBody): string {
+  const compass = azimuthToCompass(body.az);
+  return `${body.id} is ${altToBand(body.alt)} in the ${compass}, ${altToPhrase(body.alt)}`;
+}
+
+function formatTwilightSentence(sunAlt: number | null): string | null {
+  if (sunAlt === null) return null;
+  if (sunAlt > 6) return null; // just plain daytime — the summary would be dominated by the Sun anyway
+  if (sunAlt > -0.83) return "The Sun is near the horizon (civil twilight edge).";
+  if (sunAlt > -6) return "The Sun is below the horizon — civil twilight.";
+  if (sunAlt > -12) return "The Sun is below the horizon — nautical twilight.";
+  if (sunAlt > -18) return "The Sun is below the horizon — astronomical twilight.";
+  return "The sky is fully dark (Sun more than 18° below the horizon).";
+}
+
+function pickBrightBodies(bodies: readonly DescribableBody[]): DescribableBody[] {
+  const named = bodies.filter((b) => NAMED_BRIGHT_BODIES.has(b.id) && b.alt > 0 && b.id !== "Sun");
+  // Sort by magnitude (bright first), keep top three so the sentence
+  // stays short. Ties broken by altitude so the highest gets top billing.
+  named.sort((a, b) => a.mag - b.mag || b.alt - a.alt);
+  return named.slice(0, 3);
+}
+
+function pickConstellations(
+  constellations: readonly DescribableConstellation[],
+): DescribableConstellation[] {
+  const above = constellations.filter((c) => c.centroid.alt > 20);
+  above.sort((a, b) => b.centroid.alt - a.centroid.alt);
+  return above.slice(0, 3);
+}
+
+function formatLatLonPhrase(lat: number, lon: number): string {
+  const latAbs = Math.abs(lat).toFixed(1);
+  const lonAbs = Math.abs(lon).toFixed(1);
+  const latHemi = lat >= 0 ? "N" : "S";
+  const lonHemi = lon >= 0 ? "E" : "W";
+  return `${latAbs}° ${latHemi}, ${lonAbs}° ${lonHemi}`;
+}
+
+/**
+ * Render an English prose summary of the given sky snapshot. Returns
+ * between two and five sentences; never throws — an empty visible list
+ * yields "Nothing bright is above the horizon right now."
+ */
+export function describeSky(input: DescribeSkyInput): string {
+  const sentences: string[] = [];
+
+  // Facing sentence.
+  if (input.cameraHeadingDeg !== undefined) {
+    const compass = azimuthToCompass(input.cameraHeadingDeg);
+    sentences.push(
+      `Facing ${compass} (heading ${String(Math.round(input.cameraHeadingDeg))}°) from ${formatLatLonPhrase(input.observer.lat, input.observer.lon)}.`,
+    );
+  } else {
+    sentences.push(
+      `Viewing the sky from ${formatLatLonPhrase(input.observer.lat, input.observer.lon)}.`,
+    );
+  }
+
+  // Twilight state.
+  const sun = input.bodies.find((b) => b.id === "Sun");
+  const twilight = formatTwilightSentence(sun !== undefined ? sun.alt : null);
+  if (twilight !== null) sentences.push(twilight);
+
+  // Bright bodies + constellations. If neither has anything to say, fall
+  // through to a single "nothing above the horizon" sentence rather than
+  // stringing two negatives together.
+  const brights = pickBrightBodies(input.bodies);
+  const cons = pickConstellations(input.constellations);
+
+  if (brights.length === 0 && cons.length === 0) {
+    sentences.push("Nothing bright is above the horizon right now.");
+    return sentences.join(" ");
+  }
+
+  if (brights.length > 0) {
+    sentences.push(`${brights.map(formatBodyClause).join("; ")}.`);
+  } else {
+    sentences.push("None of the naked-eye planets are above the horizon.");
+  }
+
+  if (cons.length > 0) {
+    const names = cons.map((c) => c.name).join(", ");
+    sentences.push(`Well-placed constellations: ${names}.`);
+  }
+
+  return sentences.join(" ");
+}

--- a/src/ui/describe-sky-modal.test.ts
+++ b/src/ui/describe-sky-modal.test.ts
@@ -1,0 +1,89 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDescribeSkyModal } from "./describe-sky-modal";
+
+const SAMPLE_SUMMARY =
+  "Facing east-southeast (heading 112°) from 61.2° N, 149.9° W. Jupiter is medium-high in the south, 45° up.";
+
+describe("createDescribeSkyModal", () => {
+  afterEach(() => {
+    document.body.style.overflow = "";
+    document.body.innerHTML = "";
+  });
+
+  it("mounts hidden and opens with the given summary text", () => {
+    const modal = createDescribeSkyModal({ getSummary: () => "static" });
+    document.body.appendChild(modal.element);
+    expect(modal.element.style.display).toBe("none");
+    expect(modal.isOpen()).toBe(false);
+
+    modal.open(SAMPLE_SUMMARY);
+    expect(modal.isOpen()).toBe(true);
+    expect(modal.element.style.display).toBe("block");
+    const summary = document.querySelector('[data-testid="describe-sky-summary"]');
+    expect(summary?.textContent).toBe(SAMPLE_SUMMARY);
+  });
+
+  it("closes on the × button and on the backdrop click", () => {
+    const modal = createDescribeSkyModal({ getSummary: () => "static" });
+    document.body.appendChild(modal.element);
+    modal.open(SAMPLE_SUMMARY);
+    (document.querySelector("[data-testid='describe-sky-close']") as HTMLElement).click();
+    expect(modal.isOpen()).toBe(false);
+
+    modal.open(SAMPLE_SUMMARY);
+    (document.querySelector("[data-testid='describe-sky-backdrop']") as HTMLElement).click();
+    expect(modal.isOpen()).toBe(false);
+  });
+
+  it("Refresh button re-invokes the getSummary callback", () => {
+    let calls = 0;
+    const modal = createDescribeSkyModal({
+      getSummary: () => {
+        calls += 1;
+        return `refreshed ${String(calls)}`;
+      },
+    });
+    document.body.appendChild(modal.element);
+    modal.open("initial");
+    expect(calls).toBe(0);
+    (document.querySelector("[data-testid='describe-sky-refresh']") as HTMLElement).click();
+    expect(calls).toBe(1);
+    const summary = document.querySelector('[data-testid="describe-sky-summary"]');
+    expect(summary?.textContent).toBe("refreshed 1");
+  });
+
+  it("Copy button forwards the current summary to navigator.clipboard.writeText", () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+    });
+    const modal = createDescribeSkyModal({ getSummary: () => "static" });
+    document.body.appendChild(modal.element);
+    modal.open(SAMPLE_SUMMARY);
+    (document.querySelector("[data-testid='describe-sky-copy']") as HTMLElement).click();
+    expect(writeText).toHaveBeenCalledWith(SAMPLE_SUMMARY);
+    Object.defineProperty(navigator, "clipboard", { value: undefined, configurable: true });
+  });
+
+  it("Copy button is a no-op when navigator.clipboard is unavailable", () => {
+    Object.defineProperty(navigator, "clipboard", { value: undefined, configurable: true });
+    const modal = createDescribeSkyModal({ getSummary: () => "static" });
+    document.body.appendChild(modal.element);
+    modal.open(SAMPLE_SUMMARY);
+    expect(() => {
+      (document.querySelector("[data-testid='describe-sky-copy']") as HTMLElement).click();
+    }).not.toThrow();
+  });
+
+  it("marks the summary block as an ARIA live region (role=status, aria-live=polite)", () => {
+    const modal = createDescribeSkyModal({ getSummary: () => "static" });
+    document.body.appendChild(modal.element);
+    modal.open(SAMPLE_SUMMARY);
+    const summary = document.querySelector('[data-testid="describe-sky-summary"]');
+    expect(summary?.getAttribute("role")).toBe("status");
+    expect(summary?.getAttribute("aria-live")).toBe("polite");
+    expect(summary?.getAttribute("aria-atomic")).toBe("true");
+  });
+});

--- a/src/ui/describe-sky-modal.ts
+++ b/src/ui/describe-sky-modal.ts
@@ -1,0 +1,215 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { el } from "./dom";
+import { PANEL_BG, PANEL_BORDER, TEXT_COLOR } from "./styles";
+
+/**
+ * "Describe this sky" modal (#381). Renders the current sky snapshot as
+ * prose so screen-reader users can hear what's actually visible on the
+ * WebGL canvas.
+ *
+ * The modal owns no astronomy math — the caller supplies a summary
+ * string via `open(summary)` (or refresh-getter) so this UI stays free
+ * of any `astro/` imports.
+ */
+
+export type DescribeSkyModal = {
+  readonly element: HTMLElement;
+  open(summary: string): void;
+  close(): void;
+  isOpen(): boolean;
+};
+
+export type DescribeSkyModalOptions = {
+  /** Getter called when the user hits the "Refresh" button so the
+   *  summary can reflect the current time / camera / visible list. */
+  readonly getSummary: () => string;
+};
+
+export function createDescribeSkyModal(options: DescribeSkyModalOptions): DescribeSkyModal {
+  const summaryEl = el("p", {
+    testid: "describe-sky-summary",
+    attrs: {
+      role: "status",
+      "aria-live": "polite",
+      "aria-atomic": "true",
+    },
+    style: {
+      color: TEXT_COLOR,
+      fontFamily: "-apple-system, BlinkMacSystemFont, sans-serif",
+      fontSize: "16px",
+      lineHeight: "1.55",
+      margin: "0",
+      padding: "0",
+      whiteSpace: "pre-wrap",
+    },
+  });
+
+  const copyBtn = el("button", {
+    testid: "describe-sky-copy",
+    type: "button",
+    text: "Copy",
+    attrs: { title: "Copy the summary text to the clipboard" },
+    style: {
+      background: "rgba(255,255,255,0.08)",
+      border: "1px solid rgba(255,255,255,0.25)",
+      borderRadius: "6px",
+      color: TEXT_COLOR,
+      cursor: "pointer",
+      fontSize: "13px",
+      padding: "4px 12px",
+    },
+  });
+
+  const refreshBtn = el("button", {
+    testid: "describe-sky-refresh",
+    type: "button",
+    text: "Refresh",
+    attrs: { title: "Recompute the summary against the current view" },
+    style: {
+      background: "rgba(255,255,255,0.08)",
+      border: "1px solid rgba(255,255,255,0.25)",
+      borderRadius: "6px",
+      color: TEXT_COLOR,
+      cursor: "pointer",
+      fontSize: "13px",
+      padding: "4px 12px",
+    },
+  });
+
+  const closeBtn = el("button", {
+    testid: "describe-sky-close",
+    type: "button",
+    text: "×",
+    attrs: { title: "Close (Esc)" },
+    style: {
+      background: "rgba(255,255,255,0.1)",
+      border: "1px solid rgba(255,255,255,0.3)",
+      borderRadius: "4px",
+      color: TEXT_COLOR,
+      cursor: "pointer",
+      fontSize: "18px",
+      lineHeight: "1",
+      padding: "2px 10px",
+    },
+  });
+
+  const title = el("h2", {
+    text: "Sky summary",
+    attrs: { id: "describe-sky-title" },
+    style: {
+      color: TEXT_COLOR,
+      fontFamily: "-apple-system, BlinkMacSystemFont, sans-serif",
+      fontSize: "18px",
+      margin: "0",
+    },
+  });
+
+  const header = el("div", {
+    style: {
+      display: "flex",
+      justifyContent: "space-between",
+      alignItems: "center",
+      padding: "12px 16px",
+      borderBottom: "1px solid rgba(255,255,255,0.15)",
+      gap: "8px",
+    },
+    children: [title, closeBtn],
+  });
+
+  const buttonRow = el("div", {
+    style: {
+      display: "flex",
+      gap: "8px",
+      padding: "12px 16px 0",
+    },
+    children: [copyBtn, refreshBtn],
+  });
+
+  const body = el("div", {
+    style: { padding: "16px" },
+    children: [summaryEl],
+  });
+
+  const panel = el("div", {
+    testid: "describe-sky-panel",
+    attrs: {
+      role: "dialog",
+      "aria-modal": "true",
+      "aria-labelledby": "describe-sky-title",
+    },
+    style: {
+      position: "absolute",
+      top: "50%",
+      left: "50%",
+      transform: "translate(-50%, -50%)",
+      width: "min(80vw, 600px)",
+      maxWidth: "calc(100vw - 24px)",
+      background: PANEL_BG,
+      border: PANEL_BORDER,
+      borderRadius: "8px",
+      display: "flex",
+      flexDirection: "column",
+      boxSizing: "border-box",
+    },
+    children: [header, body, buttonRow],
+  });
+
+  const backdrop = el("div", {
+    testid: "describe-sky-backdrop",
+    style: { position: "absolute", inset: "0", background: "rgba(0,0,0,0.6)" },
+  });
+
+  const root = el("div", {
+    testid: "describe-sky-modal",
+    style: { display: "none", position: "fixed", inset: "0", zIndex: "2000" },
+    children: [backdrop, panel],
+  });
+
+  let open = false;
+
+  function setOpen(value: boolean): void {
+    open = value;
+    root.style.display = value ? "block" : "none";
+    document.body.style.overflow = value ? "hidden" : "";
+  }
+
+  function doOpen(summary: string): void {
+    summaryEl.textContent = summary;
+    setOpen(true);
+    // Move focus to the summary itself so screen readers announce it.
+    summaryEl.setAttribute("tabindex", "-1");
+    summaryEl.focus();
+  }
+
+  function doClose(): void {
+    setOpen(false);
+  }
+
+  backdrop.addEventListener("click", doClose);
+  closeBtn.addEventListener("click", doClose);
+  refreshBtn.addEventListener("click", () => {
+    summaryEl.textContent = options.getSummary();
+  });
+  copyBtn.addEventListener("click", () => {
+    const clipboard = navigator.clipboard as
+      { writeText?: (s: string) => Promise<void> } | undefined;
+    if (clipboard === undefined || typeof clipboard.writeText !== "function") return;
+    const text = summaryEl.textContent ?? "";
+    void clipboard.writeText(text).catch(() => {
+      // Clipboard denied — silent per app convention.
+    });
+  });
+
+  document.addEventListener("keydown", (e) => {
+    if (e.key === "Escape" && open) {
+      doClose();
+    }
+  });
+
+  return {
+    element: root,
+    open: doOpen,
+    close: doClose,
+    isOpen: () => open,
+  };
+}

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -27,6 +27,8 @@ export { createTonightDrawer } from "./tonight-drawer";
 export type { TonightDrawer, TonightDrawerOptions } from "./tonight-drawer";
 export type { HelpModal, HelpModalOptions } from "./help-modal";
 export { createHelpModal } from "./help-modal";
+export type { DescribeSkyModal, DescribeSkyModalOptions } from "./describe-sky-modal";
+export { createDescribeSkyModal } from "./describe-sky-modal";
 export type { LoginModal, LoginModalOptions } from "./login-modal";
 export { createLoginModal } from "./login-modal";
 export { createOnboardingOverlay, ONBOARDING_STORAGE_KEY } from "./onboarding-overlay";


### PR DESCRIPTION
## Summary

A WebGL canvas is opaque to assistive tech — a Planisphere page today reads as "canvas" and nothing else. This PR ships a text summary of the current view, wired to **Alt+D**, that turns the same data the scene draws from into English prose. Doubles as a shareable snippet for sighted users (Copy button).

## What this PR adds

- **`src/astro/describe-sky.ts`** — pure function that takes observer / time / bodies / constellations / heading and returns 2–4 English sentences:
  > Facing east-southeast (heading 112°) from 61.2° N, 149.9° W. The sky is fully dark (Sun more than 18° below the horizon). Venus is low in the west, 5° up; Jupiter is medium-high in the south, 45° up; Mercury is low in the east, 3° up. Well-placed constellations: Ursa Major, Orion, Scorpius.
  Also exports `azimuthToCompass` for the 16-point cardinal names.

- **`src/ui/describe-sky-modal.ts`** — modal shell with `role="dialog"` + `aria-labelledby` + the summary block as `role="status"` `aria-live="polite"`. Copy / Refresh / × buttons; Escape to close. No astronomy imports — takes a `getSummary` callback so this UI stays free of `astro/`.

- **Wire-up in `src/app.ts`** — `Alt+D` opens the modal via a document-level `keydown` listener. `currentSkySummary` uses `computeBodyPositions` + `getCameraHeadingDeg`. Constellations passed as `[]` in this first pass — the visible-constellation list lives inside the render pipeline and hoisting it would need plumbing that isn't warranted for a still-useful summary.

## Tests

- **`describe-sky.test.ts`** — 12 tests (compass helper, twilight bands, brightest-first sort, below-horizon skip, "none of the naked-eye planets" vs "nothing bright" fallbacks, top-3 constellations).
- **`describe-sky-modal.test.ts`** — 6 tests (hidden→open transition, Copy forwarding to clipboard, Copy no-op when unavailable, Refresh re-invokes getSummary, close via × / backdrop, ARIA live-region attributes).

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm format:check` — clean
- [x] `pnpm test:cov` — 1422 pass (+18 from these tests)
- [x] `pnpm build` — clean
- [ ] Manual with VoiceOver / NVDA: press `Alt+D`, expect the modal to announce the summary text.

## Notes

- No localization. English only for v1 — the palette handles other languages via the language module, but describe-sky prose is a separate scope.
- Uses the empty-constellations path for now; when someone wants richer output the next PR can plumb the visible-constellation snapshot from the render pipeline into this modal.

Closes #381.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VKmj4YQnxN8sydc7X6v2ra)_